### PR TITLE
fix: address 5 bugs found in exploratory testing (#017–#021)

### DIFF
--- a/.megapowers/CHANGELOG.md
+++ b/.megapowers/CHANGELOG.md
@@ -106,3 +106,20 @@ All four wrap-up actions complete. Here's what was done:
 ---
 
 The issue is complete. You can now run `/issue close` to mark it done, or pick up the next issue.
+All three wrap-up actions complete:
+
+### ✅ write-changelog
+Changelog entry generated (above) — system will append to `.megapowers/CHANGELOG.md`.
+
+### ✅ capture-learnings
+Saved to `.megapowers/plans/022-exploratory-testing-bug-fixes/learnings.md` — 7 bullets covering:
+- Binary detection must precede `Buffer.toString()`
+- `Array.join("")` false-positive noop pattern and the length-guard fix
+- `splitDst()` as the highest-risk internal helper (CRLF normalization)
+- Exit code semantics need documentation at the call site
+- `tsc --noEmit` catches what vitest misses (incomplete fixtures)
+- `@LINE` vs `#index` ergonomics for symbol disambiguation
+- "FAILS:" test title convention debt
+
+### ✅ close-issue
+**Issue #022 is ready to close.** Run `/issue close` to finalize, or select a new issue to continue.

--- a/.megapowers/state.json
+++ b/.megapowers/state.json
@@ -1,171 +1,66 @@
 {
   "version": 1,
-  "activeIssue": null,
-  "workflow": "feature",
-  "phase": null,
+  "activeIssue": "022-exploratory-testing-bug-fixes",
+  "workflow": "bugfix",
+  "phase": "done",
   "phaseHistory": [
     {
-      "from": "brainstorm",
-      "to": "spec",
-      "timestamp": 1772314163697
+      "from": "reproduce",
+      "to": "diagnose",
+      "timestamp": 1772467071250
     },
     {
-      "from": "spec",
+      "from": "diagnose",
       "to": "plan",
-      "timestamp": 1772314347932
+      "timestamp": 1772467397002
     },
     {
       "from": "plan",
-      "to": "review",
-      "timestamp": 1772314582529
-    },
-    {
-      "from": "review",
-      "to": "plan",
-      "timestamp": 1772315408843
-    },
-    {
-      "from": "plan",
-      "to": "review",
-      "timestamp": 1772316100453
-    },
-    {
-      "from": "review",
       "to": "implement",
-      "timestamp": 1772316106922
-    },
-    {
-      "from": "review",
-      "to": "plan",
-      "timestamp": 1772316480577
-    },
-    {
-      "from": "plan",
-      "to": "review",
-      "timestamp": 1772317269317
-    },
-    {
-      "from": "review",
-      "to": "plan",
-      "timestamp": 1772317494102
-    },
-    {
-      "from": "plan",
-      "to": "review",
-      "timestamp": 1772317775073
-    },
-    {
-      "from": "review",
-      "to": "plan",
-      "timestamp": 1772317942934
-    },
-    {
-      "from": "plan",
-      "to": "review",
-      "timestamp": 1772318575565
-    },
-    {
-      "from": "review",
-      "to": "plan",
-      "timestamp": 1772318843157
-    },
-    {
-      "from": "plan",
-      "to": "review",
-      "timestamp": 1772333916148
-    },
-    {
-      "from": "review",
-      "to": "plan",
-      "timestamp": 1772334289443
-    },
-    {
-      "from": "plan",
-      "to": "review",
-      "timestamp": 1772369743698
-    },
-    {
-      "from": "review",
-      "to": "plan",
-      "timestamp": 1772370514604
-    },
-    {
-      "from": "plan",
-      "to": "review",
-      "timestamp": 1772373290936
-    },
-    {
-      "from": "review",
-      "to": "plan",
-      "timestamp": 1772374282338
-    },
-    {
-      "from": "plan",
-      "to": "review",
-      "timestamp": 1772377859092
-    },
-    {
-      "from": "review",
-      "to": "plan",
-      "timestamp": 1772378833073
-    },
-    {
-      "from": "plan",
-      "to": "review",
-      "timestamp": 1772380677498
-    },
-    {
-      "from": "review",
-      "to": "implement",
-      "timestamp": 1772380684545
+      "timestamp": 1772468506972
     },
     {
       "from": "implement",
       "to": "verify",
-      "timestamp": 1772383730128
+      "timestamp": 1772480661211
     },
     {
       "from": "verify",
-      "to": "code-review",
-      "timestamp": 1772384225460
+      "to": "implement",
+      "timestamp": 1772480872583
     },
     {
-      "from": "code-review",
+      "from": "implement",
+      "to": "verify",
+      "timestamp": 1772480892593
+    },
+    {
+      "from": "verify",
       "to": "done",
-      "timestamp": 1772384913773
+      "timestamp": 1772480961715
     }
   ],
-  "reviewApproved": true,
-  "currentTaskIndex": 9,
+  "reviewApproved": false,
+  "planMode": null,
+  "planIteration": 2,
+  "currentTaskIndex": 0,
   "completedTasks": [
     1,
     2,
     3,
     4,
     5,
-    6,
-    7,
-    8,
-    9,
-    10
+    6
   ],
   "tddTaskState": {
-    "taskIndex": 10,
+    "taskIndex": 1,
     "state": "test-written",
     "skipped": false
   },
-  "taskJJChanges": {
-    "2": "lprnkmzw",
-    "3": "mxnpmktu",
-    "4": "qnkksqvk",
-    "5": "vyyummlk",
-    "6": "yxnzrtpm",
-    "7": "yztlyvwo",
-    "8": "ruzpyrty",
-    "9": "xusqnwon",
-    "10": "oklsrmtm"
-  },
-  "jjChangeId": "mtswkqpx",
-  "doneActions": [],
-  "megaEnabled": true
+  "taskJJChanges": {},
+  "jjChangeId": "omwnrwnw",
+  "doneActions": [
+    "close-issue"
+  ],
+  "megaEnabled": false
 }

--- a/docs/exploratory-functional-testing.md
+++ b/docs/exploratory-functional-testing.md
@@ -1,0 +1,194 @@
+# Exploratory / Adversarial Functional Testing Report
+
+This document records a **manual, exploratory (non-unit) functional test** of the `pi-hashline-readmap` extension tools.
+
+- Repo: `pi-hashline-readmap`
+- Date: 2026-03-02
+- Focus: try normal usage + try to break tools via edge cases
+- Tools exercised: `read`, `edit`, `grep`, `sg`, plus the bash output filter
+
+## Test setup
+
+A sandbox was created under:
+
+- `tmp/exploratory/`
+
+with the following files (representative edge cases):
+
+- `sample.ts` — TypeScript with two same-named exported functions + a class
+- `large.txt` — ~500KB text file (forces truncation in `read`)
+- `large.ts` — ~110KB TS file with thousands of exported functions (forces truncation + structural map)
+- `crlf.txt` — CRLF line endings
+- `regex.txt` — regex metacharacters, anchors like `^` and `$`
+- `binary.bin` — random bytes (non-image binary)
+- `bad.ts` — intentionally invalid/unparseable TypeScript
+
+## What worked (basic functionality)
+
+### `read`
+
+- Hashlines appear correct on normal text/TS files.
+- Truncation works and suggests using `offset=...` to continue.
+- `symbol=...` reads work for unambiguous symbols.
+- Structural map appears for large TS files.
+
+### `grep`
+
+- Regex and literal modes behave as expected.
+- `ignoreCase`, `context`, and `limit` work.
+- Returned matches include `LINE:HASH` anchors usable by `edit`.
+
+### `edit`
+
+- Hash mismatch detection works (stale anchors are detected and the tool prints updated `>>>` anchors).
+
+### bash filter
+
+- `npm test` output was summarized/condensed, indicating the bash compression filter is active.
+
+## Breaks / bugs found (with repro)
+
+### 1) `sg` reports “Command failed” when there are **no matches**
+
+This is the biggest functional issue observed.
+
+**Repro**:
+
+```ts
+sg({ pattern: "console.log($$$ARGS)", lang: "typescript", path: "tmp/exploratory/sample.ts" })
+```
+
+**Actual**:
+
+- Returns an error like:
+  - `Command failed: sg run --json ...`
+
+**Expected**:
+
+- Should return the normal no-results response, e.g.
+  - `No matches found for pattern: ...`
+
+**Likely cause**:
+
+- `ast-grep` appears to exit with code `1` for “no matches”.
+- `src/sg.ts` uses `execFileText()` which rejects on any non-zero exit code, so `stdout` is never parsed.
+
+---
+
+### 2) `edit` cannot truly “delete a line” (docs say it can)
+
+Tool docs state `set_line` can “Replace or delete a single line”, but:
+
+- `set_line(..., new_text: "")` leaves an empty line (does not remove it)
+- `replace_lines(..., new_text: "")` also leaves a blank line behind
+
+**Repro**:
+
+1) `read(tmp/exploratory/regex.txt)` to obtain anchors
+2) then:
+
+```ts
+edit({
+  path: "tmp/exploratory/regex.txt",
+  edits: [{ set_line: { anchor: "3:HASH", new_text: "" } }]
+})
+```
+
+**Actual**:
+
+- Line becomes blank but remains present.
+
+**Expected (per docs)**:
+
+- The line should be removed entirely.
+
+---
+
+### 3) `edit` corrupts CRLF files (mixed CR/CRLF + extra blank lines)
+
+This can subtly dirty files and introduce inconsistent line endings.
+
+**Repro**:
+
+Start with `tmp/exploratory/crlf.txt` (CRLF line endings), then:
+
+```ts
+edit({
+  path: "tmp/exploratory/crlf.txt",
+  edits: [{ insert_after: { anchor: "1:02", text: "inserted\r\n" } }]
+})
+```
+
+**Actual**:
+
+- File ends up with mixed line endings.
+- `file` reported: `ASCII text, with CRLF, CR line terminators`.
+- Extra blank lines appeared.
+- Hex dump showed doubled `0d` sequences (bare `\r` introduced).
+
+**Expected**:
+
+- Preserve file’s EOL convention consistently.
+- Inserted text should be normalized to match file EOL style.
+- No stray `\r` characters.
+
+---
+
+### 4) `read(symbol=...)` ambiguity message is misleading for top-level symbol collisions
+
+If a file has two top-level functions with the same name, the tool reports:
+
+> “Use dot notation to disambiguate.”
+
+…but dot notation cannot disambiguate two top-level `add()` overloads.
+
+**Repro**:
+
+```ts
+read({ path: "tmp/exploratory/sample.ts", symbol: "add" })
+```
+
+**Actual**:
+
+- Ambiguity list is shown
+- Suggests dot notation
+
+**Expected**:
+
+- Provide an addressing scheme that can disambiguate top-level collisions, e.g.
+  - `add#1` / `add#2`
+  - `add@line:3`
+  - signature-based selection (`add(a: number, b: number)`) if available
+
+---
+
+### 5) `read`/`grep` operate on arbitrary binary as UTF-8 text (no warning)
+
+Not necessarily a strict bug, but it’s easy to get misleading output.
+
+**Repro**:
+
+```ts
+read({ path: "tmp/exploratory/binary.bin" })
+```
+
+```ts
+grep({ pattern: "p", path: "tmp/exploratory/binary.bin" })
+```
+
+**Actual**:
+
+- Binary content is rendered with replacement characters / garbage text.
+- `grep` can match inside that rendered output.
+
+**Suggestion**:
+
+- Detect likely-binary files (NUL bytes or low UTF-8 validity) and warn or refuse by default.
+
+## Suggested fixes (high level)
+
+1) **`sg`:** treat exit code `1` as “no matches”, parse stdout anyway, and only error on other exit codes.
+2) **`edit`:** implement true line deletion semantics or update docs to match behavior.
+3) **`edit`:** preserve CRLF files correctly (normalize insertions to file EOL, avoid mixed terminators).
+4) **`read(symbol=...)`:** improve ambiguity resolution UX for top-level symbol collisions.
+5) **binary handling:** warn/refuse by default (optional configurable behavior).

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -88,18 +88,23 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 				searchPathIsDirectory = false;
 			}
 
-			const fileCache = new Map<string, string[]>();
+			const fileCache = new Map<string, string[] | undefined>();
 			const getFileLines = async (absolutePath: string): Promise<string[] | undefined> => {
 				throwIfAborted(signal);
 				if (fileCache.has(absolutePath)) return fileCache.get(absolutePath);
 				try {
-					const raw = (await fsReadFile(absolutePath)).toString("utf-8");
+					const rawBuffer = await fsReadFile(absolutePath);
+					if (rawBuffer.includes(0)) {
+						fileCache.set(absolutePath, undefined);
+						return undefined;
+					}
+					const raw = rawBuffer.toString("utf-8");
 					const lines = normalizeToLF(stripBom(raw).text).split("\n");
 					fileCache.set(absolutePath, lines);
 					return lines;
 				} catch {
 					fileCache.set(absolutePath, []);
-					return undefined;
+					return [];
 				}
 			};
 
@@ -127,6 +132,7 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 				parsedCount++;
 				const absolute = toAbsolutePath(parsed.displayPath);
 				const fileLines = await getFileLines(absolute);
+				if (fileLines === undefined) continue;
 				const sourceLine = fileLines?.[parsed.lineNumber - 1] ?? parsed.text;
 				const ref = `${parsed.lineNumber}:${computeLineHash(parsed.lineNumber, sourceLine)}`;
 				const marker = parsed.kind === "match" ? ">>" : "  ";

--- a/src/hashline.ts
+++ b/src/hashline.ts
@@ -109,7 +109,9 @@ function formatMismatchError(mismatches: HashMismatch[], fileLines: string[]): s
 // ─── DST preprocessing helpers ──────────────────────────────────────────
 
 function splitDst(dst: string): string[] {
-	return dst === "" ? [] : dst.split("\n");
+	if (dst === "") return [];
+	const normalized = dst.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\n$/, "");
+	return normalized.split("\n");
 }
 
 function stripNewLinePrefixes(lines: string[]): string[] {
@@ -493,7 +495,7 @@ export function applyHashlineEdits(
 			if (orig.join("\n") === newL.join("\n") && orig.some((line) => CONFUSABLE_HYPHENS_RE.test(line))) {
 				newL = normalizeConfusableHyphensInLines(newL);
 			}
-			if (orig.join("\n") === newL.join("\n")) {
+			if (orig.length === newL.length && orig.join("\n") === newL.join("\n")) {
 				noopEdits.push({ editIndex: idx, loc: `${spec.ref.line}:${spec.ref.hash}`, currentContent: orig.join("\n") });
 				continue;
 			}
@@ -508,7 +510,7 @@ export function applyHashlineEdits(
 			if (orig.join("\n") === newL.join("\n") && orig.some((line) => CONFUSABLE_HYPHENS_RE.test(line))) {
 				newL = normalizeConfusableHyphensInLines(newL);
 			}
-			if (orig.join("\n") === newL.join("\n")) {
+			if (orig.length === newL.length && orig.join("\n") === newL.join("\n")) {
 				noopEdits.push({ editIndex: idx, loc: `${spec.start.line}:${spec.start.hash}`, currentContent: orig.join("\n") });
 				continue;
 			}

--- a/src/read.ts
+++ b/src/read.ts
@@ -77,10 +77,11 @@ export function registerReadTool(pi: ExtensionAPI): void {
 			}
 
 			throwIfAborted(signal);
-			const raw = (await fsReadFile(absolutePath)).toString("utf-8");
+			const rawBuffer = await fsReadFile(absolutePath);
+			const hasBinaryContent = rawBuffer.includes(0);
 			throwIfAborted(signal);
 
-			const normalized = normalizeToLF(stripBom(raw).text);
+			const normalized = normalizeToLF(stripBom(rawBuffer.toString("utf-8")).text);
 			const allLines = normalized.split("\n");
 			const total = allLines.length;
 
@@ -101,6 +102,7 @@ export function registerReadTool(pi: ExtensionAPI): void {
 						const lines = lookup.candidates.map(
 							(c) => `- ${c.name} (${c.kind}) — lines ${c.startLine}-${c.endLine}`,
 						);
+						const hints = lookup.candidates.map((c) => `${params.symbol}@${c.startLine}`).join(" or ");
 						return {
 							content: [
 								{
@@ -109,7 +111,7 @@ export function registerReadTool(pi: ExtensionAPI): void {
 										`Symbol '${params.symbol}' is ambiguous.`,
 										"Matches:",
 										...lines,
-										"Use dot notation to disambiguate.",
+										`Use ${hints} to select by start line.`,
 									].join("\n"),
 								},
 							],
@@ -168,6 +170,10 @@ export function registerReadTool(pi: ExtensionAPI): void {
 
 			if (symbolWarning) {
 				text = symbolWarning + text;
+			}
+
+			if (hasBinaryContent) {
+				text = "[Warning: file appears to be binary — output may be garbled]\n\n" + text;
 			}
 
 			return {

--- a/src/readmap/symbol-lookup.ts
+++ b/src/readmap/symbol-lookup.ts
@@ -27,6 +27,17 @@ export function findSymbol(map: FileMap, query: string): SymbolLookupResult {
   if (!q) return { type: "not-found" };
   if (map.symbols.length === 0) return { type: "not-found" };
 
+  if (q.includes("@")) {
+    const parts = q.split("@");
+    if (parts.length === 2 && parts[0] && /^\d+$/.test(parts[1])) {
+      const [namePart, linePart] = parts;
+      const lineNum = Number.parseInt(linePart, 10);
+      const byLine = map.symbols.filter((s) => s.name === namePart && s.startLine === lineNum);
+      if (byLine.length === 1) return { type: "found", symbol: toMatch(byLine[0]) };
+      if (byLine.length > 1) return { type: "ambiguous", candidates: byLine.map(toMatch) };
+    }
+  }
+
   const exact = map.symbols.filter((s) => s.name === q);
   if (exact.length === 1) return { type: "found", symbol: toMatch(exact[0]) };
   if (exact.length > 1) return { type: "ambiguous", candidates: exact.map(toMatch) };

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -25,6 +25,10 @@ function execFileText(
   return new Promise((resolve, reject) => {
     cp.execFile(cmd, args, opts, (err, stdout, stderr) => {
       if (err) {
+        if ((err as any)?.code === 1) {
+          resolve({ stdout: String(stdout ?? ""), stderr: String(stderr ?? "") });
+          return;
+        }
         (err as any).stdout = stdout;
         (err as any).stderr = stderr;
         reject(err);

--- a/tests/read-symbol-ambiguity-message.test.ts
+++ b/tests/read-symbol-ambiguity-message.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("fs/promises", async () => {
+	const actual = await vi.importActual<typeof import("fs/promises")>("fs/promises");
+	return {
+		...actual,
+		access: vi.fn().mockResolvedValue(undefined),
+		readFile: vi.fn().mockResolvedValue(Buffer.from("one\ntwo\nthree\nfour\nfive\n")),
+		stat: vi.fn().mockResolvedValue({ isDirectory: () => false }),
+	};
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("read symbol ambiguity message", () => {
+	it("suggests @LINE disambiguation and does not suggest dot notation", async () => {
+		const cacheModule = await import("../src/map-cache.js");
+		vi.spyOn(cacheModule, "getOrGenerateMap").mockResolvedValue({
+			path: "/tmp/sample.ts",
+			totalLines: 5,
+			totalBytes: 24,
+			language: "typescript",
+			symbols: [
+				{ name: "add", kind: "function", startLine: 1, endLine: 2 },
+				{ name: "add", kind: "function", startLine: 5, endLine: 5 },
+			],
+			imports: [],
+			detailLevel: "full",
+		} as any);
+
+		const { registerReadTool } = await import("../src/read.js");
+		let capturedTool: any = null;
+		registerReadTool({ registerTool(def: any) { capturedTool = def; } } as any);
+
+		const result = await capturedTool.execute(
+			"test-call",
+			{ path: "/tmp/sample.ts", symbol: "add" },
+			new AbortController().signal,
+			() => {},
+			{ cwd: process.cwd() },
+		);
+
+		const text = result.content.find((c: any) => c.type === "text")?.text ?? "";
+		expect(text).toContain("add@1");
+		expect(text).toContain("add@5");
+		expect(text.toLowerCase()).not.toContain("dot notation");
+	});
+});

--- a/tests/repro-017-sg-no-match.test.ts
+++ b/tests/repro-017-sg-no-match.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Reproduction test for Bug #017:
+ * `sg` exits with code 1 on no matches; execFileText rejects → "Command failed" error
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as cp from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+async function getSgTool() {
+  const { registerSgTool } = await import("../src/sg.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerSgTool(mockPi as any);
+  if (!captured) throw new Error("sg tool was not registered");
+  return captured;
+}
+
+function text(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("Bug #017: sg exits code 1 on no-match", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("handles sg exit code 1 with empty JSON as a no-match response", async () => {
+    const tool = await getSgTool();
+
+    // This is what the REAL `sg` binary does when no matches are found:
+    // exits with code 1, stdout="[]", stderr=""
+    vi.mocked(cp.execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      const err: any = new Error(
+        "Command failed: sg run --json -p console.log($$$ARGS) -l typescript /tmp/sample.ts"
+      );
+      err.code = 1;
+      // stdout is "[]" (empty JSON array), stderr is empty
+      cb(err, "[]", "");
+      return {} as any;
+    });
+
+    const result = await tool.execute(
+      "tc",
+      { pattern: "console.log($$$ARGS)", lang: "typescript" },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    // The bug: execFileText rejects on exit code 1, so the catch block fires.
+    // The catch block returns err.stderr (empty) || err.message ("Command failed:...")
+    // isError is true, and message is "Command failed: ..." instead of "No matches found"
+    expect(result.isError).toBeFalsy(); // BUG: this fails — isError is true
+    expect(text(result)).toBe("No matches found for pattern: console.log($$$ARGS)"); // BUG: shows "Command failed: sg run..."
+  });
+});

--- a/tests/repro-018-edit-deletion.test.ts
+++ b/tests/repro-018-edit-deletion.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Reproduction test for Bug #018:
+ * set_line with new_text:"" fails to delete BLANK lines due to noop detection.
+ *
+ * Non-empty line deletion works fine (those tests pass).
+ * The bug is specifically when trying to delete an already-empty line:
+ * orig.join("\n") === "" === newL.join("\n") → noop detected → line NOT removed.
+ */
+import { describe, it, expect } from "vitest";
+import { applyHashlineEdits, computeLineHash } from "../src/hashline.js";
+
+describe("Bug #018: set_line with new_text='' line deletion", () => {
+  // This case WORKS (non-empty line)
+  it("set_line new_text='' removes a non-empty line (this works)", () => {
+    const content = "line1\nline2\nline3\nline4\nline5";
+    const hash3 = computeLineHash(3, "line3");
+
+    const result = applyHashlineEdits(content, [
+      { set_line: { anchor: `3:${hash3}`, new_text: "" } }
+    ]);
+
+    const resultLines = result.content.split("\n");
+    expect(resultLines).toHaveLength(4);
+    expect(resultLines).toEqual(["line1", "line2", "line4", "line5"]);
+  });
+
+  // This case FAILS (empty/blank line) — the real bug
+  it("deletes a blank line instead of marking the edit as noop", () => {
+    // File has a blank line 3 — user wants to delete it
+    const content = "line1\nline2\n\nline4\nline5";
+    const hashBlank = computeLineHash(3, ""); // hash of empty line
+
+    const result = applyHashlineEdits(content, [
+      { set_line: { anchor: `3:${hashBlank}`, new_text: "" } }
+    ]);
+
+    // BUG: orig=[""], newL=[] → orig.join("\n")==="" === newL.join("\n")==="" → noop
+    // result.content === original content, blank line is NOT removed
+    // noopEdits is populated — edit.ts would throw "No changes made"
+    expect(result.noopEdits).toBeUndefined(); // FAILS: noopEdits is set
+    expect(result.content).not.toBe(content);  // FAILS: content is unchanged
+    const lines = result.content.split("\n");
+    expect(lines).toHaveLength(4); // FAILS: still has 5 lines
+    expect(lines).toEqual(["line1", "line2", "line4", "line5"]); // FAILS: blank line stays
+  });
+});

--- a/tests/repro-019-crlf-corruption.test.ts
+++ b/tests/repro-019-crlf-corruption.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Reproduction test for Bug #019:
+ * CRLF files get mixed line endings + extra blank lines from insert_after.
+ *
+ * Root cause in splitDst():
+ *   "inserted\r\n".split("\n") → ["inserted\r", ""]
+ *   "inserted\n".split("\n")   → ["inserted", ""]
+ * The trailing "" becomes an unwanted blank line.
+ * The embedded \r (from \r\n) then gets doubled when restoreLineEndings applies.
+ */
+import { describe, it, expect } from "vitest";
+import { applyHashlineEdits, computeLineHash } from "../src/hashline.js";
+import { detectLineEnding, normalizeToLF, restoreLineEndings, stripBom } from "../src/edit-diff.js";
+
+function applyAndRestore(rawCRLF: string, edits: Parameters<typeof applyHashlineEdits>[1]) {
+  const { text: content } = stripBom(rawCRLF);
+  const origEnd = detectLineEnding(content);
+  const normalized = normalizeToLF(content);
+  const result = applyHashlineEdits(normalized, edits);
+  return restoreLineEndings(result.content, origEnd);
+}
+
+describe("Bug #019: CRLF files corrupted by insert_after", () => {
+  const rawCRLF = "line1\r\nline2\r\nline3\r\n";
+  const hash1 = computeLineHash(1, "line1");
+
+  it("normalizes CRLF insert_after text without doubled CR", () => {
+    const restored = applyAndRestore(rawCRLF, [
+      { insert_after: { anchor: `1:${hash1}`, text: "inserted\r\n" } }
+    ]);
+
+    // Bug: splitDst("inserted\r\n") = ["inserted\r", ""]
+    // restoreLineEndings then converts \n → \r\n for ALL \n,
+    // giving "inserted\r\r\n" (doubled CR) + extra blank line "\r\n"
+    const hasDoubleCR = restored.includes("\r\r");
+    expect(hasDoubleCR).toBe(false); // FAILS: contains \r\r
+
+    // Also causes extra blank line
+    expect(restored).toBe("line1\r\ninserted\r\nline2\r\nline3\r\n"); // FAILS
+  });
+
+  it("does not add an extra blank line when insert_after text ends with LF", () => {
+    const restored = applyAndRestore(rawCRLF, [
+      { insert_after: { anchor: `1:${hash1}`, text: "inserted\n" } }
+    ]);
+
+    // Bug: splitDst("inserted\n") = ["inserted", ""] — trailing "" → extra blank
+    // No doubled CR (LF text works through restoreLineEndings cleanly),
+    // but an extra blank line appears
+    expect(restored).toBe("line1\r\ninserted\r\nline2\r\nline3\r\n"); // FAILS: extra blank line
+  });
+
+  it("insert_after without trailing newline inserts correctly", () => {
+    const restored = applyAndRestore(rawCRLF, [
+      { insert_after: { anchor: `1:${hash1}`, text: "inserted" } }
+    ]);
+
+    // This works because splitDst("inserted") = ["inserted"] — no trailing ""
+    expect(restored).toBe("line1\r\ninserted\r\nline2\r\nline3\r\n");
+  });
+});

--- a/tests/repro-020-symbol-ambiguity.test.ts
+++ b/tests/repro-020-symbol-ambiguity.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Reproduction test for Bug #020:
+ * Ambiguity message for top-level symbol collisions suggests "dot notation"
+ * which is a dead end — dot notation only works for ClassName.methodName,
+ * not for two top-level functions with the same name.
+ */
+import { describe, it, expect } from "vitest";
+import { findSymbol } from "../src/readmap/symbol-lookup.js";
+import type { FileMap } from "../src/readmap/types.js";
+
+// Synthetic FileMap with two top-level add() functions (overloads)
+const fileMapWithOverloads: FileMap = {
+  path: "/tmp/sample.ts",
+  language: "typescript",
+  totalLines: 11,
+  totalBytes: 200,
+  imports: [],
+  detailLevel: "full" as any,
+  symbols: [
+    {
+      name: "add",
+      kind: "function" as any,
+      startLine: 1,
+      endLine: 3,
+      children: [],
+    },
+    {
+      name: "add",
+      kind: "function" as any,
+      startLine: 5,
+      endLine: 7,
+      children: [],
+    },
+    {
+      name: "multiply",
+      kind: "function" as any,
+      startLine: 9,
+      endLine: 11,
+      children: [],
+    },
+  ],
+};
+
+describe("Bug #020: symbol ambiguity message misleads with dot notation for top-level collisions", () => {
+  it("returns ambiguous for two top-level add() symbols", () => {
+    const result = findSymbol(fileMapWithOverloads, "add");
+    expect(result.type).toBe("ambiguous");
+    if (result.type === "ambiguous") {
+      expect(result.candidates).toHaveLength(2);
+    }
+  });
+
+  it("FAILS: dot notation suggestion is a dead end — add.0 and add#1 are not-found", () => {
+    // The current message says "Use dot notation (e.g. ClassName.methodName) to narrow"
+    // But for top-level overloads, there is NO dot notation that disambiguates.
+    // This test shows the suggestion is unusable.
+    
+    const dotResult = findSymbol(fileMapWithOverloads, "add.0");
+    const hashResult = findSymbol(fileMapWithOverloads, "add#1");
+    const lineResult = findSymbol(fileMapWithOverloads, "add@1");
+
+    // Current behavior: all return not-found — there is NO supported syntax
+    // to pick one of two top-level overloads
+    // Expected after fix: at least one addressing scheme should work
+    expect(lineResult.type).not.toBe("not-found");  // FAILS until name@LINE syntax is supported
+  });
+
+  it("FAILS: read.ts ambiguity message contains actionable disambiguation for top-level overloads", () => {
+    // The read.ts code currently returns:
+    //   "Use dot notation to disambiguate."
+    // But dot notation can't help here. The message should either:
+    //   (a) Not suggest dot notation when all candidates are top-level
+    //   (b) Suggest a valid scheme like add#1 or add@5
+    const result = findSymbol(fileMapWithOverloads, "add");
+    expect(result.type).toBe("ambiguous");
+    
+    if (result.type === "ambiguous") {
+      // Verify at least one addressing scheme works to resolve the ambiguity
+      // Try line-based: "add" at line 1 vs line 5
+      const byLine1 = findSymbol(fileMapWithOverloads, "add@1");
+      const byLine5 = findSymbol(fileMapWithOverloads, "add@5");
+      const byIndex1 = findSymbol(fileMapWithOverloads, "add#1");
+      const byIndex2 = findSymbol(fileMapWithOverloads, "add#2");
+      
+      const anyWorks =
+        byLine1.type === "found" || byLine5.type === "found" ||
+        byIndex1.type === "found" || byIndex2.type === "found";
+      
+      expect(anyWorks).toBe(true); // FAILS: no disambiguation scheme exists yet
+    }
+  });
+});

--- a/tests/repro-021-binary-warning.test.ts
+++ b/tests/repro-021-binary-warning.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Reproduction test for Bug #021:
+ * read and grep silently treat binary files as UTF-8 with no warning.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { writeFile, unlink } from "node:fs/promises";
+import path from "node:path";
+
+const BINARY_FILE = path.join(process.cwd(), "tests/fixtures/binary-test.bin");
+const PLAIN_TEXT_FILE = path.join(process.cwd(), "tests/fixtures/plain.txt");
+const BINARY_CONTENT = Buffer.concat([
+  Buffer.from("PNG\x00\x00\x00\rIHDR"),
+  Buffer.from("\x00\xff\xfe\xfd".repeat(20)),
+  Buffer.from("text content"),
+  Buffer.from("\x00\x01\x02\x03".repeat(5)),
+]);
+
+async function getReadTool() {
+  const { registerReadTool } = await import("../src/read.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerReadTool(mockPi as any);
+  if (!captured) throw new Error("read tool was not registered");
+  return captured;
+}
+
+async function getGrepTool() {
+  const { registerGrepTool } = await import("../src/grep.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerGrepTool(mockPi as any);
+  if (!captured) throw new Error("grep tool was not registered");
+  return captured;
+}
+
+function text(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+function hasBinaryWarning(output: string): boolean {
+  const lowered = output.toLowerCase();
+  return lowered.includes("binary") || lowered.includes("warning");
+}
+
+describe("Bug #021: binary files read/grepped without warning", () => {
+  beforeAll(async () => {
+    await writeFile(BINARY_FILE, BINARY_CONTENT);
+  });
+
+  afterAll(async () => {
+    await unlink(BINARY_FILE).catch(() => {});
+  });
+
+  it("FAILS: read on binary file shows no warning — garbled output returned silently", async () => {
+    const tool = await getReadTool();
+
+    const result = await tool.execute(
+      "tc",
+      { path: BINARY_FILE },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    const output = text(result);
+
+    expect(hasBinaryWarning(output)).toBe(true); // RED: currently fails, no warning prefix
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("grep on binary file should warn or skip matches", async () => {
+    const tool = await getGrepTool();
+
+    const result = await tool.execute(
+      "tc",
+      { pattern: ".", path: BINARY_FILE },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    const output = text(result);
+    const hasAnchoredMatches = output.includes(":>>");
+
+    expect(hasBinaryWarning(output) || !hasAnchoredMatches).toBe(true);
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("non-binary text files are unaffected", async () => {
+    const readTool = await getReadTool();
+    const readResult = await readTool.execute(
+      "tc",
+      { path: PLAIN_TEXT_FILE },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    const readOutput = text(readResult);
+    expect(hasBinaryWarning(readOutput)).toBe(false);
+    expect(readOutput).toMatch(/^1:[0-9a-f]{2}\|/m);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes 5 bugs surfaced during exploratory/adversarial functional testing of the extension tools.

## Bugs Fixed

| # | Tool | Bug | Root Cause |
|---|------|-----|-----------|
| #017 | `sg` | Exit code 1 (no matches) treated as `Command failed` error | `execFileText()` rejected on any non-zero exit; exit-1 is `sg`'s no-match sentinel |
| #018 | `edit` | `set_line { new_text: "" }` on blank lines left them in place | `[""].join("\n") === [].join("\n")` → false-positive noop |
| #019 | `edit` | CRLF files corrupted with doubled `\r` and extra blank lines after `insert_after` | `splitDst()` split on `\n` without normalizing `\r\n` first |
| #020 | `read` | Ambiguity message suggested dead-end dot notation for top-level symbol collisions | No `name@LINE` syntax existed; message always appended dot-notation hint unconditionally |
| #021 | `read`/`grep` | Binary files silently garbled with no warning | Both tools called `.toString("utf-8")` on raw Buffer with no NUL-byte check |

## Changes

**Production code:**
- `src/sg.ts` — resolve (not reject) on `err.code === 1`
- `src/hashline.ts` — add `orig.length === newL.length &&` guard; fix `splitDst()` CRLF normalization
- `src/readmap/symbol-lookup.ts` — add `name@LINE` branch to `findSymbol()`
- `src/read.ts` — update ambiguity message to suggest `name@LINE`; prepend binary warning when NUL bytes detected
- `src/grep.ts` — skip binary files in `getFileLines()` (return `undefined` on NUL bytes)

**Tests added:**
- `tests/repro-017-sg-no-match.test.ts`
- `tests/repro-018-edit-deletion.test.ts`
- `tests/repro-019-crlf-corruption.test.ts`
- `tests/repro-020-symbol-ambiguity.test.ts`
- `tests/read-symbol-ambiguity-message.test.ts`
- `tests/repro-021-binary-warning.test.ts`

**Docs:**
- `docs/exploratory-functional-testing.md` — full testing report that surfaced these bugs

## Test Results

138/138 tests pass. `npm run typecheck` exits 0.