### PR TITLE
fix: wave 2 — edit pipeline bugs + resilience (#023, #024, #030)

### DIFF
--- a/.megapowers/state.json
+++ b/.megapowers/state.json
@@ -1,64 +1,37 @@
 {
   "version": 1,
-  "activeIssue": "022-exploratory-testing-bug-fixes",
+  "activeIssue": "037-wave-2-edit-pipeline-bugs-resilience",
   "workflow": "bugfix",
-  "phase": "done",
+  "phase": "implement",
   "phaseHistory": [
     {
       "from": "reproduce",
       "to": "diagnose",
-      "timestamp": 1772467071250
+      "timestamp": 1772497008003
     },
     {
       "from": "diagnose",
       "to": "plan",
-      "timestamp": 1772467397002
+      "timestamp": 1772497130738
     },
     {
       "from": "plan",
       "to": "implement",
-      "timestamp": 1772468506972
-    },
-    {
-      "from": "implement",
-      "to": "verify",
-      "timestamp": 1772480661211
-    },
-    {
-      "from": "verify",
-      "to": "implement",
-      "timestamp": 1772480872583
-    },
-    {
-      "from": "implement",
-      "to": "verify",
-      "timestamp": 1772480892593
-    },
-    {
-      "from": "verify",
-      "to": "done",
-      "timestamp": 1772480961715
+      "timestamp": 1772500613227
     }
   ],
   "reviewApproved": false,
   "planMode": null,
-  "planIteration": 2,
-  "currentTaskIndex": 0,
+  "planIteration": 4,
+  "currentTaskIndex": 5,
   "completedTasks": [
     1,
     2,
     3,
     4,
-    5,
-    6
+    5
   ],
-  "tddTaskState": {
-    "taskIndex": 1,
-    "state": "test-written",
-    "skipped": false
-  },
-  "taskJJChanges": {},
-  "jjChangeId": "omwnrwnw",
+  "tddTaskState": null,
   "doneActions": [],
-  "megaEnabled": false
+  "megaEnabled": true
 }

--- a/src/edit-diff.ts
+++ b/src/edit-diff.ts
@@ -22,6 +22,15 @@ export function stripBom(content: string): { bom: string; text: string } {
 	return content.startsWith("\uFEFF") ? { bom: "\uFEFF", text: content.slice(1) } : { bom: "", text: content };
 }
 
+/**
+ * Detect bare \r characters that are NOT part of \r\n sequences.
+ * These cause line-count mismatches between normalizeToLF and external tools (ripgrep, wc).
+ */
+export function hasBareCarriageReturn(content: string): boolean {
+	// Remove all \r\n first, then check if any \r remains
+	return content.replace(/\r\n/g, "").includes("\r");
+}
+
 // ─── Fuzzy text matching ────────────────────────────────────────────────
 
 const SINGLE_QUOTES_RE = /[\u2018\u2019\u201A\u201B]/g;

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -8,6 +8,18 @@ import { applyHashlineEdits, computeLineHash, ensureHashInit, parseLineRef, type
 import { resolveToCwd } from "./path-utils";
 import { throwIfAborted } from "./runtime";
 
+export function wrapWriteError(err: any, path: string): Error {
+	const code = err?.code;
+	if (code === "EACCES" || code === "EPERM") {
+		return new Error(`Permission denied: ${path}`);
+	}
+	return new Error(`Failed to write file: ${path}`);
+}
+
+export function isBinaryBuffer(buf: Buffer): boolean {
+	return buf.includes(0);
+}
+
 // ─── Schema ─────────────────────────────────────────────────────────────
 
 const hashlineEditItemSchema = Type.Union([
@@ -130,9 +142,9 @@ export function registerEditTool(pi: ExtensionAPI): void {
 				(e): e is { replace: { old_text: string; new_text: string; all?: boolean } } => "replace" in e,
 			);
 
-			let raw: string;
+			let rawBuffer: Buffer;
 			try {
-				raw = (await fsReadFile(absolutePath)).toString("utf-8");
+				rawBuffer = await fsReadFile(absolutePath);
 			} catch (err: any) {
 				const code = err?.code;
 				if (code === "EISDIR") {
@@ -143,8 +155,11 @@ export function registerEditTool(pi: ExtensionAPI): void {
 				}
 				throw new Error(`File not readable: ${path}`);
 			}
+			if (isBinaryBuffer(rawBuffer)) {
+				throw new Error(`Cannot edit binary file: ${path}`);
+			}
 			throwIfAborted(signal);
-
+			const raw = rawBuffer.toString("utf-8");
 			const { bom, text: content } = stripBom(raw);
 			const originalEnding = detectLineEnding(content);
 			const originalNormalized = normalizeToLF(content);
@@ -205,7 +220,11 @@ export function registerEditTool(pi: ExtensionAPI): void {
 			}
 
 			throwIfAborted(signal);
-			await fsWriteFile(absolutePath, bom + restoreLineEndings(result, originalEnding), "utf-8");
+			try {
+				await fsWriteFile(absolutePath, bom + restoreLineEndings(result, originalEnding), "utf-8");
+			} catch (err: any) {
+				throw wrapWriteError(err, path);
+			}
 
 			const diffResult = generateCompactOrFullDiff(originalNormalized, result);
 			const warnings: string[] = [];

--- a/src/hashline.ts
+++ b/src/hashline.ts
@@ -20,9 +20,10 @@ interface HashMismatch {
 	line: number;
 	expected: string;
 	actual: string;
+	expectedContent?: string;
 }
 
-type ParsedRef = { line: number; hash: string };
+type ParsedRef = { line: number; hash: string; content?: string };
 
 type ParsedSpec =
 	| { kind: "single"; ref: ParsedRef }
@@ -89,18 +90,59 @@ export function hashLines(content: string): string {
 
 // ─── Parsing ────────────────────────────────────────────────────────────
 
-export function parseLineRef(ref: string): { line: number; hash: string } {
+export function parseLineRef(ref: string): { line: number; hash: string; content?: string } {
+	const contentMatch = ref.match(/^[^|]*\|(.*)$/);
+	const contentAfterPipe = contentMatch ? contentMatch[1] : undefined;
 	const cleaned = ref.replace(/\|.*$/, "").replace(/ {2}.*$/, "").trim();
 	const normalized = cleaned.replace(/\s*:\s*/, ":");
 	const match = normalized.match(new RegExp(`^(\\d+):([0-9a-fA-F]{${HASH_LEN}})$`));
 	if (!match) throw new Error(`Invalid line reference "${ref}". Expected "LINE:HASH" (e.g. "5:ab").`);
 	const line = Number.parseInt(match[1], 10);
 	if (line < 1) throw new Error(`Line number must be >= 1, got ${line} in "${ref}".`);
-	return { line, hash: match[2] };
+	return { line, hash: match[2], content: contentAfterPipe };
 }
 
 // ─── Mismatch formatting ────────────────────────────────────────────────
 
+function tokenSimilarity(a: string, b: string): number {
+	const tokA = new Set(a.trim().split(/\s+/));
+	const tokB = new Set(b.trim().split(/\s+/));
+	if (tokA.size === 0 && tokB.size === 0) return 1;
+	if (tokA.size === 0 || tokB.size === 0) return 0;
+	let overlap = 0;
+	for (const t of tokA) {
+		if (tokB.has(t)) overlap++;
+	}
+	return overlap / Math.max(tokA.size, tokB.size);
+}
+
+function findSimilarLines(
+	expectedContent: string,
+	fileLines: string[],
+	hintLine: number,
+	maxSuggestions: number = 3,
+): string[] {
+	const SCAN_WINDOW = 50;
+	const MIN_SIMILARITY = 0.3;
+	const start = Math.max(0, hintLine - 1 - SCAN_WINDOW);
+	const end = Math.min(fileLines.length, hintLine - 1 + SCAN_WINDOW + 1);
+	const candidates: { line: number; score: number; content: string }[] = [];
+
+	for (let i = start; i < end; i++) {
+		const content = fileLines[i];
+		if (!content.trim()) continue;
+		const score = tokenSimilarity(expectedContent, content);
+		if (score >= MIN_SIMILARITY) {
+			candidates.push({ line: i + 1, score, content });
+		}
+	}
+
+	candidates.sort((a, b) => b.score - a.score);
+	return candidates.slice(0, maxSuggestions).map((c) => {
+		const hash = computeLineHash(c.line, c.content);
+		return `  ${c.line}:${hash}|${c.content}`;
+	});
+}
 function formatMismatchError(mismatches: HashMismatch[], fileLines: string[]): string {
 	const mismatchSet = new Map<number, HashMismatch>();
 	for (const m of mismatches) mismatchSet.set(m.line, m);
@@ -126,6 +168,18 @@ function formatMismatchError(mismatches: HashMismatch[], fileLines: string[]): s
 		const hash = computeLineHash(num, content);
 		const prefix = `${num}:${hash}`;
 		out.push(mismatchSet.has(num) ? `>>> ${prefix}|${content}` : `    ${prefix}|${content}`);
+	}
+
+	const withContent = mismatches.filter((m) => m.expectedContent !== undefined);
+	if (withContent.length > 0) {
+		for (const m of withContent) {
+			const suggestions = findSimilarLines(m.expectedContent!, fileLines, m.line);
+			if (suggestions.length > 0) {
+				out.push("");
+				out.push("Did you mean one of these nearby lines?");
+				out.push(...suggestions);
+			}
+		}
 	}
 
 	return out.join("\n");
@@ -368,7 +422,7 @@ export function applyHashlineEdits(
 			);
 			return true;
 		}
-		mismatches.push({ line: originalLine, expected: ref.hash, actual });
+		mismatches.push({ line: originalLine, expected: ref.hash, actual, expectedContent: ref.content });
 		return false;
 	}
 

--- a/src/read.ts
+++ b/src/read.ts
@@ -9,7 +9,7 @@ import {
 import { Type } from "@sinclair/typebox";
 import { readFileSync } from "fs";
 import { readFile as fsReadFile } from "fs/promises";
-import { normalizeToLF, stripBom } from "./edit-diff";
+import { normalizeToLF, stripBom, hasBareCarriageReturn } from "./edit-diff";
 import { computeLineHash, ensureHashInit } from "./hashline";
 import { resolveToCwd } from "./path-utils";
 import { throwIfAborted } from "./runtime";
@@ -186,6 +186,12 @@ export function registerReadTool(pi: ExtensionAPI): void {
 
 			if (hasBinaryContent) {
 				text = "[Warning: file appears to be binary — output may be garbled]\n\n" + text;
+			}
+
+			if (hasBareCarriageReturn(rawBuffer.toString("utf-8"))) {
+				text =
+					"[Warning: file contains bare CR (\\r) line endings — line numbering may be inconsistent with grep and other tools]\n\n" +
+					text;
 			}
 
 			return {

--- a/src/rtk/git.ts
+++ b/src/rtk/git.ts
@@ -9,22 +9,26 @@ export function isGitCommand(command: string | undefined | null): boolean {
 	return GIT_COMMANDS.some((gc) => cmdLower.startsWith(gc));
 }
 
-export function compactDiff(output: string, maxLines: number = 50): string {
+export function compactDiff(output: string, maxLines: number = 100): string {
 	const lines = output.split("\n");
 	const result: string[] = [];
 	let currentFile = "";
 	let added = 0;
 	let removed = 0;
 	let inHunk = false;
-	let hunkLines = 0;
-	const maxHunkLines = 10;
+	// Maximum context lines (` `) to emit per hunk
+	const maxContextPerHunk = 3;
+	let hunkContextLines = 0;
+
+	// Collect all change lines separately to handle the case where change lines
+	// themselves exceed the overall cap
+	const changeLines: string[] = [];
+	let totalChangeLinesCount = 0;
+
+	// Two-pass approach: first pass collects everything, respecting context budget
+	// but NOT the overall cap for change lines. Second pass applies overall cap.
 
 	for (const line of lines) {
-		if (result.length >= maxLines) {
-			result.push("\n... (more changes truncated)");
-			break;
-		}
-
 		// New file
 		if (line.startsWith("diff --git")) {
 			// Flush previous file stats
@@ -35,7 +39,8 @@ export function compactDiff(output: string, maxLines: number = 50): string {
 			// Extract filename
 			const match = line.match(/diff --git a\/(.+) b\/(.+)/);
 			currentFile = match ? match[2] : "unknown";
-			result.push(`\n📄 ${currentFile}`);
+			result.push("");
+			result.push(`📄 ${currentFile}`);
 			added = 0;
 			removed = 0;
 			inHunk = false;
@@ -45,7 +50,7 @@ export function compactDiff(output: string, maxLines: number = 50): string {
 		// Hunk header
 		if (line.startsWith("@@")) {
 			inHunk = true;
-			hunkLines = 0;
+			hunkContextLines = 0;
 			const hunkInfo = line.match(/@@ .+ @@/)?.[0] || "@@";
 			result.push(`  ${hunkInfo}`);
 			continue;
@@ -55,26 +60,19 @@ export function compactDiff(output: string, maxLines: number = 50): string {
 		if (inHunk) {
 			if (line.startsWith("+") && !line.startsWith("+++")) {
 				added++;
-				if (hunkLines < maxHunkLines) {
-					result.push(`  ${line}`);
-					hunkLines++;
-				}
+				totalChangeLinesCount++;
+				result.push(`  ${line}`);
 			} else if (line.startsWith("-") && !line.startsWith("---")) {
 				removed++;
-				if (hunkLines < maxHunkLines) {
+				totalChangeLinesCount++;
+				result.push(`  ${line}`);
+			} else if (!line.startsWith("\\")) {
+				// Context line — only emit up to budget
+				if (hunkContextLines < maxContextPerHunk) {
 					result.push(`  ${line}`);
-					hunkLines++;
+					hunkContextLines++;
 				}
-			} else if (hunkLines < maxHunkLines && !line.startsWith("\\")) {
-				if (hunkLines > 0) {
-					result.push(`  ${line}`);
-					hunkLines++;
-				}
-			}
-
-			if (hunkLines === maxHunkLines) {
-				result.push("  ... (truncated)");
-				hunkLines++;
+				// Silently skip context lines beyond budget
 			}
 		}
 	}
@@ -84,7 +82,34 @@ export function compactDiff(output: string, maxLines: number = 50): string {
 		result.push(`  +${added} -${removed}`);
 	}
 
-	return result.join("\n");
+	// Apply overall line cap
+	if (result.length <= maxLines) {
+		return result.join("\n");
+	}
+
+	// Too many lines: keep first portion and append indicator
+	// If there are more change lines than the cap, emit head + tail of change lines
+	if (totalChangeLinesCount > maxLines) {
+		// Find all change lines in result
+		const changeLineResults = result.filter(
+			(l) => l.startsWith("  +") || l.startsWith("  -")
+		);
+		const headCount = Math.floor(maxLines / 2);
+		const tailCount = maxLines - headCount;
+		const head = changeLineResults.slice(0, headCount);
+		const tail = changeLineResults.slice(changeLineResults.length - tailCount);
+		const hiddenCount = changeLineResults.length - headCount - tailCount;
+		return [
+			...head,
+			`  ... +${hiddenCount} more changes`,
+			...tail,
+		].join("\n");
+	}
+
+	// Otherwise just truncate to maxLines and append indicator
+	const truncated = result.slice(0, maxLines);
+	truncated.push("... (more changes truncated)");
+	return truncated.join("\n");
 }
 
 interface StatusStats {

--- a/tests/compact-diff.test.ts
+++ b/tests/compact-diff.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "vitest";
+import { compactDiff } from "../src/rtk/git.js";
+
+// Helper to build a synthetic diff string
+function buildDiff(files: Array<{ name: string; hunks: Array<{ header: string; lines: string[] }> }>): string {
+  const parts: string[] = [];
+  for (const file of files) {
+    parts.push(`diff --git a/${file.name} b/${file.name}`);
+    parts.push(`index abc1234..def5678 100644`);
+    parts.push(`--- a/${file.name}`);
+    parts.push(`+++ b/${file.name}`);
+    for (const hunk of file.hunks) {
+      parts.push(hunk.header);
+      parts.push(...hunk.lines);
+    }
+  }
+  return parts.join("\n");
+}
+
+describe("compactDiff — change line preservation", () => {
+  it("preserves all + lines even when there are 20 of them in a single hunk", () => {
+    const addedLines = Array.from({ length: 20 }, (_, i) => `+  added line ${i + 1}`);
+    const diff = buildDiff([{
+      name: "src/foo.ts",
+      hunks: [{
+        header: "@@ -1,1 +1,20 @@",
+        lines: [" context", ...addedLines],
+      }],
+    }]);
+
+    const result = compactDiff(diff);
+
+    // All 20 + lines must appear in output
+    for (let i = 1; i <= 20; i++) {
+      expect(result).toContain(`added line ${i}`);
+    }
+  });
+
+  it("preserves all - lines even when there are 20 of them in a single hunk", () => {
+    const removedLines = Array.from({ length: 20 }, (_, i) => `-  removed line ${i + 1}`);
+    const diff = buildDiff([{
+      name: "src/foo.ts",
+      hunks: [{
+        header: "@@ -1,20 +1,1 @@",
+        lines: [...removedLines, " context"],
+      }],
+    }]);
+
+    const result = compactDiff(diff);
+
+    for (let i = 1; i <= 20; i++) {
+      expect(result).toContain(`removed line ${i}`);
+    }
+  });
+
+  it("does NOT truncate change lines with the old (truncated) message", () => {
+    const addedLines = Array.from({ length: 15 }, (_, i) => `+  line ${i + 1}`);
+    const diff = buildDiff([{
+      name: "src/bar.ts",
+      hunks: [{
+        header: "@@ -1,1 +1,15 @@",
+        lines: addedLines,
+      }],
+    }]);
+
+    const result = compactDiff(diff);
+    // Old code would emit "... (truncated)" after 10 hunk lines
+    expect(result).not.toContain("(truncated)");
+  });
+});
+
+describe("compactDiff — context compression", () => {
+  it("compresses context lines to at most 3 per hunk", () => {
+    const contextLines = Array.from({ length: 10 }, (_, i) => ` context line ${i + 1}`);
+    const diff = buildDiff([{
+      name: "src/baz.ts",
+      hunks: [{
+        header: "@@ -1,12 +1,13 @@",
+        lines: [...contextLines, "+  new line"],
+      }],
+    }]);
+
+    const result = compactDiff(diff);
+
+    // Count how many context lines appear (lines that start with two spaces — "  context line")
+    const contextMatches = (result.match(/  context line \d+/g) || []).length;
+    expect(contextMatches).toBeLessThanOrEqual(3);
+  });
+
+  it("still shows the change line when context is compressed", () => {
+    const contextLines = Array.from({ length: 10 }, (_, i) => ` context line ${i + 1}`);
+    const diff = buildDiff([{
+      name: "src/baz.ts",
+      hunks: [{
+        header: "@@ -1,12 +1,13 @@",
+        lines: [...contextLines, "+  new line"],
+      }],
+    }]);
+
+    const result = compactDiff(diff);
+    expect(result).toContain("new line");
+  });
+});
+
+describe("compactDiff — overall line cap", () => {
+  it("defaults to a cap of 100 lines", () => {
+    // Build a diff with many files/hunks to exceed 100 output lines
+    const files = Array.from({ length: 20 }, (_, fi) => ({
+      name: `src/file${fi}.ts`,
+      hunks: [{
+        header: "@@ -1,1 +1,5 @@",
+        lines: Array.from({ length: 5 }, (_, li) => `+  line ${li + 1}`),
+      }],
+    }));
+    const diff = buildDiff(files);
+
+    const result = compactDiff(diff);
+    const lineCount = result.split("\n").length;
+    // Should be capped at ~100 lines (allow small overshoot for cap indicator)
+    expect(lineCount).toBeLessThanOrEqual(110);
+  });
+
+  it("accepts a custom maxLines parameter", () => {
+    const files = Array.from({ length: 20 }, (_, fi) => ({
+      name: `src/file${fi}.ts`,
+      hunks: [{
+        header: "@@ -1,1 +1,5 @@",
+        lines: Array.from({ length: 5 }, (_, li) => `+  line ${li + 1}`),
+      }],
+    }));
+    const diff = buildDiff(files);
+
+    const result = compactDiff(diff, 30);
+    const lineCount = result.split("\n").length;
+    expect(lineCount).toBeLessThanOrEqual(40);
+  });
+
+  it("shows a truncation indicator when output is capped", () => {
+    const files = Array.from({ length: 30 }, (_, fi) => ({
+      name: `src/file${fi}.ts`,
+      hunks: [{
+        header: "@@ -1,1 +1,5 @@",
+        lines: Array.from({ length: 5 }, (_, li) => `+  line ${li + 1}`),
+      }],
+    }));
+    const diff = buildDiff(files);
+
+    const result = compactDiff(diff, 30);
+    expect(result).toMatch(/truncated|more changes/i);
+  });
+});
+
+describe("compactDiff — change lines exceeding overall cap", () => {
+  it("emits a '... +K more changes' indicator when change lines themselves exceed the cap", () => {
+    // 200 + lines in one hunk
+    const addedLines = Array.from({ length: 200 }, (_, i) => `+  big line ${i + 1}`);
+    const diff = buildDiff([{
+      name: "src/huge.ts",
+      hunks: [{
+        header: "@@ -1,1 +1,200 @@",
+        lines: addedLines,
+      }],
+    }]);
+
+    const result = compactDiff(diff, 50);
+    // Should have a "more changes" indicator
+    expect(result).toMatch(/\+\d+ more changes/);
+  });
+});
+
+describe("compactDiff — backward compatibility", () => {
+  it("returns a non-empty string for an empty diff", () => {
+    expect(compactDiff("")).toBe("");
+  });
+
+  it("handles git status diff correctly (no change lines)", () => {
+    const diff = buildDiff([{
+      name: "src/clean.ts",
+      hunks: [{
+        header: "@@ -1,3 +1,3 @@",
+        lines: [" line1", " line2", " line3"],
+      }],
+    }]);
+    const result = compactDiff(diff);
+    // No +/- lines so stats summary shows +0 -0 is NOT emitted (only if added>0 or removed>0)
+    expect(result).toContain("src/clean.ts");
+  });
+
+  it("still shows file stat summary (+N -M) after each file", () => {
+    const diff = buildDiff([{
+      name: "src/changed.ts",
+      hunks: [{
+        header: "@@ -1,1 +1,3 @@",
+        lines: ["-  old line", "+  new line 1", "+  new line 2"],
+      }],
+    }]);
+    const result = compactDiff(diff);
+    expect(result).toMatch(/\+2 -1/);
+  });
+});

--- a/tests/repro-023-edit-readonly.test.ts
+++ b/tests/repro-023-edit-readonly.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { writeFileSync, chmodSync, mkdirSync, rmSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { wrapWriteError } from "../src/edit.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("Bug #023: edit readonly file -> permission denied", () => {
+	const tmpDir = join(__dirname, ".tmp-023");
+	const readonlyFile = join(tmpDir, "readonly.txt");
+	beforeAll(() => {
+		mkdirSync(tmpDir, { recursive: true });
+		writeFileSync(readonlyFile, "line1\nline2\nline3\n", "utf-8");
+		chmodSync(readonlyFile, 0o444);
+	});
+	afterAll(() => {
+		try {
+			chmodSync(readonlyFile, 0o644);
+		} catch {}
+		try {
+			rmSync(tmpDir, { recursive: true });
+		} catch {}
+	});
+	it("wrapWriteError maps EACCES to 'Permission denied: <path>'", () => {
+		const eacces = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+		eacces.code = "EACCES";
+		expect(wrapWriteError(eacces, "foo.txt").message).toBe("Permission denied: foo.txt");
+	});
+	it("wrapWriteError maps EPERM to 'Permission denied: <path>'", () => {
+		const eperm = new Error("EPERM: operation not permitted") as NodeJS.ErrnoException;
+		eperm.code = "EPERM";
+		expect(wrapWriteError(eperm, "bar.txt").message).toBe("Permission denied: bar.txt");
+	});
+	it("wrapWriteError re-throws other errors with generic message", () => {
+		const eio = new Error("EIO: i/o error") as NodeJS.ErrnoException;
+		eio.code = "EIO";
+		expect(wrapWriteError(eio, "baz.txt").message).toBe("Failed to write file: baz.txt");
+	});
+
+	it("edit tool execute on chmod 444 file returns 'Permission denied: <path>'", async () => {
+		const { registerEditTool } = await import("../src/edit.js");
+		const { ensureHashInit, computeLineHash } = await import("../src/hashline.js");
+		await ensureHashInit();
+		let capturedTool: any = null;
+		const mockPi = {
+			registerTool(def: any) {
+				capturedTool = def;
+			},
+		};
+		registerEditTool(mockPi as any);
+		if (!capturedTool) throw new Error("edit tool was not registered");
+
+		const hash1 = computeLineHash(1, "line1");
+		await expect(
+			capturedTool.execute(
+				"test-call",
+				{
+					path: readonlyFile,
+					edits: [{ set_line: { anchor: `1:${hash1}`, new_text: "modified" } }],
+				},
+				new AbortController().signal,
+				() => {},
+				{ cwd: process.cwd() },
+			),
+		).rejects.toThrow(/Permission denied/);
+	});
+});

--- a/tests/repro-024-bare-cr-read-integration.test.ts
+++ b/tests/repro-024-bare-cr-read-integration.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+type ReadParams = { path: string; offset?: number; limit?: number };
+
+async function callReadTool(params: ReadParams) {
+  const { registerReadTool } = await import("../src/read.js");
+  let capturedTool: any = null;
+  const mockPi = {
+    registerTool(def: any) {
+      capturedTool = def;
+    },
+  };
+  registerReadTool(mockPi as any);
+  if (!capturedTool) throw new Error("read tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function getTextContent(result: any): string {
+  return result.content.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("Bug #024: bare CR warning in read output", () => {
+  const tmpDir = join(__dirname, ".tmp-024");
+  const bareCRFile = join(tmpDir, "bareCR.txt");
+  const normalFile = join(tmpDir, "normal.txt");
+  const mixedFile = join(tmpDir, "mixed.txt");
+
+  beforeAll(() => {
+    mkdirSync(tmpDir, { recursive: true });
+    // Pure bare-CR file (classic Mac)
+    writeFileSync(bareCRFile, Buffer.from("Line 1\rLine 2\rLine 3\r"));
+    // Normal LF file
+    writeFileSync(normalFile, "Line 1\nLine 2\nLine 3\n");
+    // Mixed: LF + bare CR
+    writeFileSync(mixedFile, Buffer.from("Line 1\nLine 2\rLine 3\n"));
+  });
+
+  afterAll(() => {
+    try {
+      rmSync(tmpDir, { recursive: true });
+    } catch {}
+  });
+
+  it("read output for bare-CR file starts with bare-CR warning", async () => {
+    const result = await callReadTool({ path: bareCRFile });
+    const text = getTextContent(result);
+    expect(text).toContain("[Warning: file contains bare CR");
+    expect(text).toContain("line numbering may be inconsistent");
+  });
+
+  it("read output for normal LF file does NOT contain bare-CR warning", async () => {
+    const result = await callReadTool({ path: normalFile });
+    const text = getTextContent(result);
+    expect(text).not.toContain("bare CR");
+  });
+
+  it("read output for mixed LF+bare-CR file includes bare-CR warning", async () => {
+    const result = await callReadTool({ path: mixedFile });
+    const text = getTextContent(result);
+    expect(text).toContain("[Warning: file contains bare CR");
+  });
+});

--- a/tests/repro-024-bare-cr-warning.test.ts
+++ b/tests/repro-024-bare-cr-warning.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { hasBareCarriageReturn } from "../src/edit-diff.js";
+
+describe("Bug #024: bare CR detection", () => {
+	describe("hasBareCarriageReturn()", () => {
+		it("returns false for LF-only content", () => {
+			expect(hasBareCarriageReturn("line1\nline2\nline3\n")).toBe(false);
+		});
+		it("returns false for CRLF-only content", () => {
+			expect(hasBareCarriageReturn("line1\r\nline2\r\nline3\r\n")).toBe(false);
+		});
+		it("returns false for content with no line endings", () => {
+			expect(hasBareCarriageReturn("single line")).toBe(false);
+		});
+		it("returns true for bare CR content (classic Mac)", () => {
+			expect(hasBareCarriageReturn("Line 1\rLine 2\rLine 3\r")).toBe(true);
+		});
+		it("returns true for mixed LF + bare CR content", () => {
+			expect(hasBareCarriageReturn("Line 1\nLine 2\rLine 3\n")).toBe(true);
+		});
+		it("returns false for mixed CRLF + LF (no bare CR)", () => {
+			expect(hasBareCarriageReturn("Line 1\r\nLine 2\nLine 3\r\n")).toBe(false);
+		});
+	});
+});

--- a/tests/repro-030a-edit-binary-guard.test.ts
+++ b/tests/repro-030a-edit-binary-guard.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { isBinaryBuffer } from "../src/edit.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("Bug #030a: binary file guard in edit", () => {
+  const tmpDir = join(__dirname, ".tmp-030a");
+  const binaryFile = join(tmpDir, "binary.bin");
+  const textFile = join(tmpDir, "text.txt");
+
+  beforeAll(() => {
+    mkdirSync(tmpDir, { recursive: true });
+    // Binary file with NUL bytes
+    const buf = Buffer.from([0x48, 0x65, 0x6c, 0x00, 0x6c, 0x6f, 0x0a]);
+    writeFileSync(binaryFile, buf);
+    // Normal text file
+    writeFileSync(textFile, "hello\nworld\n");
+  });
+
+  afterAll(() => {
+    try {
+      rmSync(tmpDir, { recursive: true });
+    } catch {}
+  });
+
+  it("isBinaryBuffer returns true for buffer with NUL bytes", () => {
+    const binary = Buffer.from([0x48, 0x00, 0x6c]);
+    expect(isBinaryBuffer(binary)).toBe(true);
+  });
+
+  it("isBinaryBuffer returns false for buffer without NUL bytes", () => {
+    const text = Buffer.from([0x48, 0x65, 0x6c]);
+    expect(isBinaryBuffer(text)).toBe(false);
+  });
+
+  it("edit tool rejects binary file with 'Cannot edit binary file' error", async () => {
+    const { registerEditTool } = await import("../src/edit.js");
+    const { ensureHashInit } = await import("../src/hashline.js");
+    await ensureHashInit();
+    let capturedTool: any = null;
+    const mockPi = {
+      registerTool(def: any) {
+        capturedTool = def;
+      },
+    };
+    registerEditTool(mockPi as any);
+    if (!capturedTool) throw new Error("edit tool was not registered");
+
+    await expect(
+      capturedTool.execute(
+        "test-call",
+        {
+          path: binaryFile,
+          edits: [{ set_line: { anchor: "1:00", new_text: "modified" } }],
+        },
+        new AbortController().signal,
+        () => {},
+        { cwd: process.cwd() },
+      ),
+    ).rejects.toThrow(/Cannot edit binary file/);
+  });
+});

--- a/tests/repro-030b-did-you-mean.test.ts
+++ b/tests/repro-030b-did-you-mean.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { applyHashlineEdits, ensureHashInit, computeLineHash } from "../src/hashline.js";
+
+describe("Feature #030b: Did you mean? suggestions on anchor mismatch", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("includes 'Did you mean?' with LINE:HASH|content suggestions when anchor mismatches", () => {
+    // File content where line 3 has been edited since last read
+    const content = [
+      "const a = 1;",
+      "const b = 2;",
+      "const c = 3; // modified",  // was "const c = 3;" when agent last read
+      "const d = 4;",
+      "const e = 5;",
+      "function foo() {",
+      "  return a + b;",
+      "}",
+    ].join("\n");
+
+    // Agent passes anchor with |content suffix (as copied from read output)
+    const staleHash = computeLineHash(3, "const c = 3;");
+
+    try {
+      applyHashlineEdits(content, [
+        { set_line: { anchor: `3:${staleHash}|const c = 3;`, new_text: "const c = 99;" } }
+      ]);
+      expect.unreachable("Should have thrown mismatch error");
+    } catch (err: any) {
+      expect(err.message).toContain("changed since last read");
+      // Must contain "Did you mean?" section
+      expect(err.message).toContain("Did you mean");
+      // Must suggest line(s) with LINE:HASH|content format
+      expect(err.message).toMatch(/\d+:[0-9a-f]{2}\|/);
+      // Should suggest line 3 which has similar content "const c = 3; // modified"
+      expect(err.message).toContain("const c = 3;");
+    }
+  });
+
+  it("does NOT show 'Did you mean?' when auto-relocation succeeds", () => {
+    const content = [
+      "line A",
+      "inserted line",
+      "line B",    // was at line 2, now at line 3
+      "line C",
+    ].join("\n");
+
+    const hashB = computeLineHash(2, "line B");
+
+    // Should auto-relocate from line 2 to line 3 — no error
+    const result = applyHashlineEdits(content, [
+      { set_line: { anchor: `2:${hashB}`, new_text: "line B modified" } }
+    ]);
+
+    expect(result.content).toContain("line B modified");
+  });
+
+  it("does NOT show 'Did you mean?' when no |content in anchor (no expected text to compare)", () => {
+    const content = [
+      "const a = 1;",
+      "const b = 2;",
+      "const c = 3; // modified",
+    ].join("\n");
+
+    const staleHash = computeLineHash(3, "const c = 3;");
+
+    try {
+      applyHashlineEdits(content, [
+        { set_line: { anchor: `3:${staleHash}`, new_text: "const c = 99;" } }
+      ]);
+      expect.unreachable("Should have thrown");
+    } catch (err: any) {
+      expect(err.message).toContain("changed since last read");
+      // Without |content, no basis for similarity — no "Did you mean?"
+      expect(err.message).not.toContain("Did you mean");
+    }
+  });
+
+  it("limits suggestions to at most 3 candidates", () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `const var${i} = ${i};`);
+    const content = lines.join("\n");
+    const staleHash = computeLineHash(5, "const varX = 99;");
+
+    try {
+      applyHashlineEdits(content, [
+        { set_line: { anchor: `5:${staleHash}|const varX = 99;`, new_text: "const varX = 100;" } }
+      ]);
+      expect.unreachable("Should have thrown");
+    } catch (err: any) {
+      expect(err.message).toContain("Did you mean");
+      // Extract suggestion lines (indented, after "Did you mean")
+      const didYouMeanIdx = err.message.indexOf("Did you mean");
+      const afterSection = err.message.slice(didYouMeanIdx);
+      const suggestionLines = afterSection
+        .split("\n")
+        .filter((l: string) => /^\s+\d+:[0-9a-f]{2}\|/.test(l));
+      expect(suggestionLines.length).toBeLessThanOrEqual(3);
+      expect(suggestionLines.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Delivers five targeted fixes and enhancements from the Wave 2 batch (#037).

### Bug #023 — Permission denied on read-only file
Write-path now wraps `EACCES`/`EPERM` as `Permission denied: <path>` instead of propagating a raw Node error.

### Bug #024 — Bare CR line endings silently miscount lines
`read` now prepends a warning header when bare CR (`\r`) is detected, so agents know line numbering may differ from ripgrep/wc.

### Bug #030a — Binary file guard in edit
`edit` reads as `Buffer` first, checks for NUL bytes, and returns `Cannot edit binary file: <path>` instead of silently corrupting.

### Feature #030b — "Did you mean?" suggestions on anchor mismatch
When a hash-mismatch anchor carries `|content` and can't be auto-relocated, `formatMismatchError` now scans ±50 lines, scores by token overlap, and emits the top 1–3 candidates in `LINE:HASH|content` format.

### Feature #030c — compactDiff change-line preservation
- All `+`/`-` lines always emitted (no hunk budget for change lines)
- Context lines compressed to 3 per hunk (pre/post)
- Default overall cap raised 50 → 100 (configurable via `maxLines` param)
- Exceeding cap: first/last change lines kept with `... +K more changes` indicator

## Tests
218 tests pass, 0 failures (46 test files). Six new repro test files added.
