### PR TITLE
feat(#039): read map param, grep summary + truncation, prompt expansions

### DIFF
--- a/prompts/read.md
+++ b/prompts/read.md
@@ -9,6 +9,17 @@ Use the appended map for targeted reads with `offset` and `limit` — e.g., `rea
 
 Maps support 17 languages (including TypeScript, Python, Rust, Go, C/C++, Java, and more) and are cached in memory by file modification time for fast repeated access.
 
+## Map Parameter
+
+Use the `map` parameter to request a structural map alongside the file content:
+
+- `read(path, { map: true })` — appends the structural map after hashlined content, even for small files
+- `read(path, { map: true, offset: 50, limit: 20 })` — scoped hashlines with full-file map
+
+**Mutual exclusivity:** `map` cannot be combined with `symbol`. Use one or the other.
+
+When `map` is not specified, structural maps are only appended automatically when a file exceeds the truncation threshold.
+
 ## Symbol Parameter
 
 Use the `symbol` parameter to read a specific symbol by name — no line numbers needed:
@@ -16,9 +27,22 @@ Use the `symbol` parameter to read a specific symbol by name — no line numbers
 - `read(path, { symbol: "functionName" })` — reads just that function
 - `read(path, { symbol: "ClassName.methodName" })` — reads a method inside a class (dot notation)
 
+**Examples by symbol type:**
+
+| Type | Example | What it reads |
+|------|---------|---------------|
+| Function | `{ symbol: "processEvent" }` | The full function body |
+| Class | `{ symbol: "EventEmitter" }` | The entire class declaration |
+| Method | `{ symbol: "EventEmitter.emit" }` | A single method within a class |
+| Interface | `{ symbol: "RequestOptions" }` | The full interface declaration |
+| Type alias | `{ symbol: "EventHandler" }` | The type alias definition |
+| Const/variable | `{ symbol: "DEFAULT_TIMEOUT" }` | The const/let/var declaration |
+| Enum | `{ symbol: "LogLevel" }` | The full enum declaration |
+
 **Mutual exclusivity:** `symbol` cannot be combined with `offset` or `limit`. Use one addressing mode or the other.
 
 **Behavior by result:**
+
 - **Found:** Returns hashlined content for the symbol's line range only, prepended with `[Symbol: name (kind), lines X-Y of Z]`.
 - **Ambiguous (multiple matches):** Returns a disambiguation list with each candidate's name, kind, and line range. Use dot notation (e.g., `ClassName.methodName`) to narrow the match.
 - **Not found:** Falls back to a normal read with a warning listing up to 20 available symbol names.

--- a/prompts/sg.md
+++ b/prompts/sg.md
@@ -12,9 +12,26 @@ Structural code search using **ast-grep** (`sg`). This tool finds code by **AST 
 - `export function $NAME($$$PARAMS) { $$$BODY }` — exported function declarations
 - `$OBJ.$METHOD($$$ARGS)` — method calls
 - `import $NAME from '$SOURCE'` — default imports
+- `class $NAME { $$$BODY }` — class declarations
+- `if ($COND) { $$$BODY }` — if statements (no else)
+- `try { $$$BODY } catch ($ERR) { $$$HANDLER }` — try-catch blocks
+- `const $NAME = ($$$PARAMS) => $BODY` — arrow function assignments
+- `const $NAME = ($$$PARAMS) => { $$$BODY }` — arrow functions with block body
+- `<$TAG $$$ATTRS>$$$CHILDREN</$TAG>` — JSX elements (React/TSX)
+- `async function $NAME($$$PARAMS) { $$$BODY }` — async function declarations
 
 ## Workflow: search → edit
 
 1. Run `sg({ pattern: "console.log($$$ARGS)" })`
 2. Review output grouped by file (`--- path ---`) with anchors (`>>LINE:HASH|...`)
 3. Use anchors directly with `edit({ path: "file.ts", edits: [{ set_line: { anchor: "42:ab", new_text: "..." } }] })`
+
+## Tips & Common Pitfalls
+
+1. **Whitespace is mostly ignored** — `function $NAME ($$$P)` and `function $NAME($$$P)` match the same AST nodes. Don't try to match exact formatting.
+2. **Semicolons matter for statements** — In languages that use semicolons (TypeScript, JavaScript, Java, C), patterns like `const x = 1` won't match `const x = 1;`. Include the semicolon: `const $NAME = $VALUE;`.
+3. **Use `$$$` for optional/variable-length parts** — `$$$ARGS` matches zero or more arguments. Use it when you don't know how many children a node has (function args, array elements, object properties).
+4. **Language-specific syntax** — Patterns are parsed as the target language's AST. A TypeScript pattern with type annotations (e.g., `function $NAME($P: $T)`) won't match JavaScript files. Use the `lang` parameter to be explicit.
+5. **Blocks vs expressions** — `($$$PARAMS) => $BODY` matches single-expression arrow functions, while `($$$PARAMS) => { $$$BODY }` matches block-body arrows. They're different AST node types.
+6. **Decorators and attributes** — Decorators (`@decorator`) are separate AST nodes. To match a decorated class, use `@$DEC class $NAME { $$$BODY }`. Without it, plain `class $NAME { $$$BODY }` still matches decorated classes in some parsers.
+7. **JSX requires TSX/JSX language** — When searching for JSX patterns like `<Component $$$PROPS />`, use `lang: "tsx"` or `lang: "jsx"`. Plain `typescript` or `javascript` parsers won't recognize JSX syntax.

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -19,6 +19,7 @@ const grepSchema = Type.Object({
 	literal: Type.Optional(Type.Boolean({ description: "Treat pattern as literal string instead of regex (default: false)" })),
 	context: Type.Optional(Type.Number({ description: "Number of lines to show before and after each match (default: 0)" })),
 	limit: Type.Optional(Type.Number({ description: "Maximum number of matches to return (default: 100)" })),
+	summary: Type.Optional(Type.Boolean({ description: "Return per-file match counts only (no hashline anchors)" })),
 });
 
 interface GrepParams {
@@ -29,6 +30,7 @@ interface GrepParams {
 	literal?: boolean;
 	context?: number;
 	limit?: number;
+	summary?: boolean;
 }
 
 const MATCH_LINE_RE = /^(.*):(\d+): (.*)$/;
@@ -116,19 +118,31 @@ export function parseGrepIR(lines: string[]): GrepIR {
 	return { totalMatches, files: [...fileMap.values()] };
 }
 
-export function formatGrepOutput(ir: GrepIR): string {
+export function formatGrepOutput(ir: GrepIR, options?: { summary?: boolean; limit?: number }): string {
 	const header = `[${ir.totalMatches} matches in ${ir.files.length} files]`;
 	if (ir.files.length === 0) return header;
-
-	const blocks: string[] = [header];
-	for (const file of ir.files) {
-		blocks.push(`--- ${file.path} (${file.matchCount} matches) ---`);
-		for (const line of file.lines) {
-			blocks.push(line.raw);
+	let output: string;
+	if (options?.summary) {
+		const fileLines = [...ir.files]
+			.sort((a, b) => b.matchCount - a.matchCount)
+			.map((f) => `${f.path}: ${f.matchCount} matches`);
+		output = [header, ...fileLines].join("\n");
+	} else {
+		const blocks: string[] = [header];
+		for (const file of ir.files) {
+			blocks.push(`--- ${file.path} (${file.matchCount} matches) ---`);
+			for (const line of file.lines) {
+				blocks.push(line.raw);
+			}
 		}
+		output = blocks.join("\n");
 	}
 
-	return blocks.join("\n");
+	if (options?.limit !== undefined && ir.totalMatches === options.limit) {
+		output += `\n\n[Results truncated at ${options.limit} matches — refine pattern or increase limit]`;
+	}
+
+	return output;
 }
 
 const GREP_TRUNCATION_THRESHOLD = 50;
@@ -320,7 +334,15 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 				file.lines = deduplicateContext(file.lines);
 			}
 			const truncatedIR = truncateGrepIR(grepIR);
-			const formattedOutput = formatGrepOutput(truncatedIR);
+			const { summary, limit } = params as GrepParams;
+			const effectiveLimit = limit ?? 100;
+			const outputIR = summary
+				? {
+					...truncatedIR,
+					files: truncatedIR.files.map((file) => ({ ...file, path: toAbsolutePath(file.path) })),
+				}
+				: truncatedIR;
+			const formattedOutput = formatGrepOutput(outputIR, { summary, limit: effectiveLimit });
 			return {
 				...result,
 				content: result.content.map((item) =>

--- a/src/read.ts
+++ b/src/read.ts
@@ -32,6 +32,7 @@ export function registerReadTool(pi: ExtensionAPI): void {
 			offset: Type.Optional(Type.Number({ description: "Line number to start reading from (1-indexed)" })),
 			limit: Type.Optional(Type.Number({ description: "Maximum number of lines to read" })),
 			symbol: Type.Optional(Type.String({ description: "Symbol to read (e.g., functionName or ClassName.methodName)" })),
+			map: Type.Optional(Type.Boolean({ description: "Append structural map to output (cannot combine with symbol)" })),
 		}),
 
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
@@ -44,6 +45,14 @@ export function registerReadTool(pi: ExtensionAPI): void {
 			if (params.symbol && (params.offset !== undefined || params.limit !== undefined)) {
 				return {
 					content: [{ type: "text", text: "Cannot combine symbol with offset/limit. Use one or the other." }],
+					isError: true,
+					details: {},
+				};
+			}
+
+			if (params.map && params.symbol) {
+				return {
+					content: [{ type: "text", text: "Cannot combine map with symbol. Use one or the other." }],
 					isError: true,
 					details: {},
 				};
@@ -171,7 +180,11 @@ export function registerReadTool(pi: ExtensionAPI): void {
 				text += `\n\n[Showing lines ${startLine}-${endIdx} of ${total}. Use offset=${endIdx + 1} to continue.]`;
 			}
 
-			if (truncation.truncated && !params.offset && !params.limit && !symbolMatch) {
+			// Append structural map: on-demand (params.map) or auto on truncated full-file reads
+			const shouldAppendMap =
+				!!params.map ||
+				(!!truncation.truncated && !params.offset && !params.limit && !symbolMatch);
+			if (shouldAppendMap) {
 				try {
 					const fileMap = await getOrGenerateMap(absolutePath);
 					if (fileMap) {
@@ -179,7 +192,7 @@ export function registerReadTool(pi: ExtensionAPI): void {
 						text += "\n\n" + mapText;
 					}
 				} catch {
-					// Map generation failed — still return hashlined content without map
+					// Map formatting failed — still return hashlined content without map
 				}
 			}
 

--- a/tests/grep-summary.test.ts
+++ b/tests/grep-summary.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+	parseGrepIR,
+	formatGrepOutput,
+	type GrepIR,
+} from "../src/grep";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { registerGrepTool } from "../src/grep.js";
+
+describe("grep summary mode", () => {
+	it("formatGrepOutput with summary: true returns header + per-file counts sorted descending", () => {
+		const ir: GrepIR = {
+			totalMatches: 7,
+			files: [
+				{
+					path: "src/bar.ts",
+					matchCount: 2,
+					lines: [
+						{ kind: "match", raw: "src/bar.ts:>>1:ab|hello" },
+						{ kind: "match", raw: "src/bar.ts:>>3:cd|world" },
+					],
+				},
+				{
+					path: "src/foo.ts",
+					matchCount: 5,
+					lines: [
+						{ kind: "match", raw: "src/foo.ts:>>1:ab|a" },
+						{ kind: "match", raw: "src/foo.ts:>>2:ab|b" },
+						{ kind: "match", raw: "src/foo.ts:>>3:ab|c" },
+						{ kind: "match", raw: "src/foo.ts:>>4:ab|d" },
+						{ kind: "match", raw: "src/foo.ts:>>5:ab|e" },
+					],
+				},
+			],
+		};
+		const output = formatGrepOutput(ir, { summary: true });
+		const lines = output.split("\n");
+		// Header
+		expect(lines[0]).toBe("[7 matches in 2 files]");
+		// Sorted by match count descending
+		expect(lines[1]).toBe("src/foo.ts: 5 matches");
+		expect(lines[2]).toBe("src/bar.ts: 2 matches");
+		// No hashline anchors anywhere
+		expect(output).not.toContain(">>");
+		expect(output).not.toMatch(/\d+:[0-9a-f]{2}\|/);
+	});
+});
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function callGrepToolSummary(params: {
+	pattern: string;
+	path?: string;
+	glob?: string;
+	ignoreCase?: boolean;
+	literal?: boolean;
+	limit?: number;
+	summary?: boolean;
+}) {
+	let capturedTool: any = null;
+	const mockPi = {
+		registerTool(def: any) {
+			capturedTool = def;
+		},
+	};
+	registerGrepTool(mockPi as any);
+	return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, {
+		cwd: process.cwd(),
+	});
+}
+
+function getTextContent(result: any): string {
+	return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("grep summary schema and integration", () => {
+	it("registers a schema that includes the optional summary parameter", () => {
+		let capturedTool: any = null;
+		const mockPi = {
+			registerTool(def: any) {
+				capturedTool = def;
+			},
+		};
+		registerGrepTool(mockPi as any);
+		expect(capturedTool.parameters?.properties?.summary).toBeDefined();
+	});
+
+	it("summary: true via tool returns per-file counts, no hashlines", async () => {
+		const filePath = resolve(fixturesDir, "small.ts");
+		const result = await callGrepToolSummary({
+			pattern: "export",
+			path: filePath,
+			summary: true,
+		});
+		const text = getTextContent(result);
+		expect(text).toMatch(/^\[\d+ matches in \d+ files\]/);
+		expect(text).toContain(`${filePath}: `);
+		expect(text).not.toMatch(/\d+:[0-9a-f]{2}\|/);
+	});
+});

--- a/tests/grep-truncation-indicator.test.ts
+++ b/tests/grep-truncation-indicator.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { registerGrepTool } from "../src/grep.js";
+import {
+	formatGrepOutput,
+	type GrepIR,
+	type GrepIRLine,
+} from "../src/grep";
+
+describe("grep truncation indicator", () => {
+	it("appends truncation message when result count equals limit", () => {
+		const lines: GrepIRLine[] = Array.from({ length: 5 }, (_, i) => ({
+			kind: "match" as const,
+			raw: `src/foo.ts:>>${i + 1}:ab|line ${i}`,
+		}));
+		const ir: GrepIR = {
+			totalMatches: 5,
+			files: [{ path: "src/foo.ts", matchCount: 5, lines }],
+		};
+		const output = formatGrepOutput(ir, { limit: 5 });
+		expect(output).toContain("[Results truncated at 5 matches — refine pattern or increase limit]");
+	});
+
+	it("does not append truncation message when results are under limit", () => {
+		const lines: GrepIRLine[] = Array.from({ length: 3 }, (_, i) => ({
+			kind: "match" as const,
+			raw: `src/foo.ts:>>${i + 1}:ab|line ${i}`,
+		}));
+		const ir: GrepIR = {
+			totalMatches: 3,
+			files: [{ path: "src/foo.ts", matchCount: 3, lines }],
+		};
+		const output = formatGrepOutput(ir, { limit: 5 });
+		expect(output).not.toContain("[Results truncated");
+	});
+
+	it("does not append truncation message when no limit is specified and results < 100", () => {
+		const lines: GrepIRLine[] = Array.from({ length: 3 }, (_, i) => ({
+			kind: "match" as const,
+			raw: `src/foo.ts:>>${i + 1}:ab|line ${i}`,
+		}));
+		const ir: GrepIR = {
+			totalMatches: 3,
+			files: [{ path: "src/foo.ts", matchCount: 3, lines }],
+		};
+		const output = formatGrepOutput(ir);
+		expect(output).not.toContain("[Results truncated");
+	});
+
+	it("appends truncation message at default limit of 100", () => {
+		const lines: GrepIRLine[] = Array.from({ length: 100 }, (_, i) => ({
+			kind: "match" as const,
+			raw: `src/foo.ts:>>${i + 1}:ab|line ${i}`,
+		}));
+		const ir: GrepIR = {
+			totalMatches: 100,
+			files: [{ path: "src/foo.ts", matchCount: 100, lines }],
+		};
+		// No limit option passed — should use default of 100
+		const output = formatGrepOutput(ir, { limit: 100 });
+		expect(output).toContain("[Results truncated at 100 matches — refine pattern or increase limit]");
+	});
+
+	it("appends truncation message in summary mode when results hit limit", () => {
+		const lines: GrepIRLine[] = Array.from({ length: 5 }, (_, i) => ({
+			kind: "match" as const,
+			raw: `src/foo.ts:>>${i + 1}:ab|line ${i}`,
+		}));
+		const ir: GrepIR = {
+			totalMatches: 5,
+			files: [{ path: "src/foo.ts", matchCount: 5, lines }],
+		};
+		const output = formatGrepOutput(ir, { summary: true, limit: 5 });
+		// Summary header and per-file count appear
+		expect(output).toContain("[5 matches in 1 files]");
+		expect(output).toContain("src/foo.ts: 5 matches");
+		// Truncation indicator also appears
+		expect(output).toContain("[Results truncated at 5 matches — refine pattern or increase limit]");
+		// No hashline anchors in summary mode
+		expect(output).not.toMatch(/\d+:[0-9a-f]{2}\|/);
+	});
+});
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+async function callGrepToolTruncation(params: {
+	pattern: string;
+	path?: string;
+	glob?: string;
+	ignoreCase?: boolean;
+	literal?: boolean;
+	limit?: number;
+	summary?: boolean;
+}) {
+	let capturedTool: any = null;
+	const mockPi = {
+		registerTool(def: any) {
+			capturedTool = def;
+		},
+	};
+	registerGrepTool(mockPi as any);
+	return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function getTextContentT(result: any): string {
+	return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("grep truncation indicator integration", () => {
+	it("truncation indicator appears when tool results hit limit", async () => {
+		// pattern "e" produces 34 matches in small.ts; limit=2 ensures totalMatches === 2 === limit
+		const result = await callGrepToolTruncation({
+			pattern: "e",
+			path: resolve(fixturesDir, "small.ts"),
+			limit: 2,
+		});
+		const text = getTextContentT(result);
+		expect(text).toContain("[Results truncated at 2 matches — refine pattern or increase limit]");
+	});
+});

--- a/tests/read-map-on-demand.test.ts
+++ b/tests/read-map-on-demand.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { clearMapCache } from "../src/map-cache.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function callReadTool(params: { path: string; offset?: number; limit?: number; symbol?: string; map?: boolean }) {
+	const { registerReadTool } = await import("../src/read.js");
+	let capturedTool: any = null;
+	const mockPi = { registerTool(def: any) { capturedTool = def; } };
+	registerReadTool(mockPi as any);
+	return capturedTool.execute("test", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+async function getReadToolDef() {
+	const { registerReadTool } = await import("../src/read.js");
+	let capturedTool: any = null;
+	const mockPi = { registerTool(def: any) { capturedTool = def; } };
+	registerReadTool(mockPi as any);
+	return capturedTool;
+}
+
+describe("read map on demand", () => {
+	beforeEach(() => clearMapCache());
+
+	it("registers a schema that includes the optional map parameter", async () => {
+		const tool = await getReadToolDef();
+		expect(tool.parameters?.properties?.map).toBeDefined();
+	});
+
+	it("rejects map: true combined with symbol", async () => {
+		const result = await callReadTool({
+			path: resolve(fixturesDir, "small.ts"),
+			map: true,
+			symbol: "UserDirectory",
+		});
+		const text = result.content[0].text;
+		expect(result.isError).toBe(true);
+		expect(text).toBe("Cannot combine map with symbol. Use one or the other.");
+	});
+
+	it("map: true on a small file appends structural map after hashlines", async () => {
+		const result = await callReadTool({
+			path: resolve(fixturesDir, "small.ts"),
+			map: true,
+		});
+		const text = result.content[0].text;
+		// Should have hashlines
+		expect(text).toMatch(/^\d+:[0-9a-f]{2}\|/m);
+		// Should NOT have truncation message (file is small)
+		expect(text).not.toContain("[Output truncated:");
+		// Should have structural map appended
+		expect(text).toContain("File Map:");
+		// Map should contain symbols from small.ts
+		expect(text).toContain("UserDirectory");
+		expect(text).toContain("UserRecord");
+	});
+
+	it("map: true on a truncated file still appends the structural map exactly once", async () => {
+		const result = await callReadTool({
+			path: resolve(fixturesDir, "large.ts"),
+			map: true,
+		});
+		const text = result.content[0].text;
+		// File is large enough to be truncated
+		expect(text).toContain("[Output truncated:");
+		// Map still appended even when truncated
+		expect(text).toContain("File Map:");
+		// Map appears exactly once (no double-append)
+		expect(text.match(/File Map:/g)?.length).toBe(1);
+	});
+
+	it("map: true combined with offset/limit scopes hashlines but still appends full map", async () => {
+		const result = await callReadTool({
+			path: resolve(fixturesDir, "small.ts"),
+			map: true,
+			offset: 1,
+			limit: 5,
+		});
+		const text = result.content[0].text;
+		// Should have hashlines starting at line 1
+		expect(text).toMatch(/^1:[0-9a-f]{2}\|/m);
+		// Should have only 5 hashlined content lines (offset=1, limit=5)
+		const hashlineRows = text.split("\n").filter((l: string) => /^\d+:[0-9a-f]{2}\|/.test(l));
+		expect(hashlineRows.length).toBe(5);
+		// Should still have the structural map appended
+		expect(text).toContain("File Map:");
+		expect(text).toContain("UserDirectory");
+	});
+
+	it("map: true on unmappable file returns hashlines without map and no error", async () => {
+		const result = await callReadTool({
+			path: resolve(fixturesDir, "plain.txt"),
+			map: true,
+		});
+		const text = result.content[0].text;
+		// Should have hashlines
+		expect(text).toMatch(/^\d+:[0-9a-f]{2}\|/m);
+		// Should NOT have a map (plain.txt is unmappable)
+		expect(text).not.toContain("File Map:");
+		// Should NOT be an error
+		expect(result.isError).toBeUndefined();
+	});
+
+	it("map not passed: small file does not include structural map", async () => {
+		const result = await callReadTool({
+			path: resolve(fixturesDir, "small.ts"),
+		});
+		const text = result.content[0].text;
+		// Should have hashlines
+		expect(text).toMatch(/^\d+:[0-9a-f]{2}\|/m);
+		// Should NOT have structural map (file is small, map not requested)
+		expect(text).not.toContain("File Map:");
+	});
+
+	it("map: false explicitly: small file does not include structural map", async () => {
+		const result = await callReadTool({
+			path: resolve(fixturesDir, "small.ts"),
+			map: false,
+		});
+		const text = result.content[0].text;
+		expect(text).toMatch(/^\d+:[0-9a-f]{2}\|/m);
+		expect(text).not.toContain("File Map:");
+	});
+});


### PR DESCRIPTION
## Summary

Five independent agent UX enhancements for the read, grep, and sg tools.

## Changes

### Read: Map on Demand
- New optional `map: boolean` parameter — appends the structural map after hashlined content for any file, even small ones
- Mutually exclusive with `symbol` (returns `isError: true` if both passed)
- Works with `offset`/`limit` — scoped hashlines + full-file map
- Silent fallback for unmappable files (no error)
- Existing auto-map-on-truncation behavior unchanged when `map` is not passed

### Grep: Summary Mode
- New optional `summary: boolean` parameter — returns `[N matches in M files]` header + per-file counts sorted descending
- Plain text output, no hashline anchors
- Respects all existing grep parameters (`path`, `glob`, `ignoreCase`, `literal`, `limit`)

### Grep: Truncation Indicator
- When results hit the limit (user-specified or default 100), appends `[Results truncated at N matches — refine pattern or increase limit]`
- Appears in both normal and summary modes

### Prompts: Sg Expansion (`prompts/sg.md`)
- 7 additional pattern examples: class, if, try-catch, arrow functions (both forms), JSX, async function
- New "Tips & Common Pitfalls" section with 7 entries

### Prompts: Read Symbol Clarity (`prompts/read.md`)
- New "Map Parameter" section documenting the `map` param
- Symbol type table expanded with 4 new types: interface, type alias, const/variable, enum

## Code Review Fixes
- Consolidated duplicate map-append blocks in `src/read.ts` into single `shouldAppendMap` condition
- Fixed misleading catch comment ("Map generation failed" → "Map formatting failed")
- Fixed Markdown blank-line spacing in `prompts/read.md`
- Added summary+truncation combination test

## Tests
**300 tests pass, 0 failures** (3 new test files: `read-map-on-demand.test.ts`, `grep-summary.test.ts`, `grep-truncation-indicator.test.ts`)

Closes #039