### PR TITLE
fix(#051): transfer compressor empty-string and status-word edge cases

### DIFF
--- a/src/rtk/transfer.ts
+++ b/src/rtk/transfer.ts
@@ -8,6 +8,7 @@ const SCP_PROGRESS_RE = /\d+%\s+\d+\s+[\d.]+[KMGkmg]B\/s/;
 const RSYNC_AV_HEADER_RE = /^(sending|receiving) incremental file list$/;
 // rsync -av per-file path lines: no whitespace, only path-safe chars (word chars, dots, slashes, hyphens)
 const RSYNC_AV_FILE_RE = /^[\w./\-]+$/;
+const RSYNC_AV_STATUS_RE = /^(done|transfer-complete)$/i;
 
 const SIGNAL_PATTERNS: RegExp[] = [
   /sent .* bytes/, // rsync summary
@@ -23,7 +24,7 @@ function isNoise(line: string): boolean {
     RSYNC_XFR_RE.test(line) ||
     SCP_PROGRESS_RE.test(line) ||
     RSYNC_AV_HEADER_RE.test(line) ||
-    RSYNC_AV_FILE_RE.test(line)
+    RSYNC_AV_FILE_RE.test(line) && !RSYNC_AV_STATUS_RE.test(line)
   );
 }
 
@@ -49,6 +50,6 @@ export function compressTransferOutput(output: string): string | null {
       kept.push(line);
     }
   }
-  if (kept.length === 0) return null;
+  if (kept.length === 0 || kept.every((line) => line.trim() === "")) return null;
   return kept.join("\n");
 }

--- a/tests/bash-filter.test.ts
+++ b/tests/bash-filter.test.ts
@@ -148,6 +148,33 @@ describe("filterBashOutput routing", () => {
     expect(result.output).toBe("compressed scp output");
     spy.mockRestore();
   });
+  it("keeps rsync completion status words while removing listing noise", () => {
+    const input = [
+      "src/file1.txt",
+      "src/file2.txt",
+      "src/file3.txt",
+      "src/file4.txt",
+      "src/file5.txt",
+      "src/file6.txt",
+      "src/file7.txt",
+      "src/file8.txt",
+      "src/file9.txt",
+      "src/file10.txt",
+      "src/file11.txt",
+      "done",
+      "transfer-complete",
+      "sent 12000 bytes  received 34 bytes  100.00 bytes/sec",
+    ].join("\n");
+
+    const result = filterBashOutput("rsync -av src/ dst/", input);
+
+    expect(result.output).toContain("done");
+    expect(result.output).toContain("transfer-complete");
+    expect(result.output).toContain("sent 12000 bytes");
+    expect(result.output).not.toContain("src/file1.txt");
+    expect(result.output).not.toContain("src/file11.txt");
+  });
+
 
   it("test command bypass wins over build when both match (AC14: cargo test)", () => {
     const cmd = "cargo test";

--- a/tests/rtk-transfer.test.ts
+++ b/tests/rtk-transfer.test.ts
@@ -35,6 +35,13 @@ describe("compressTransferOutput", () => {
     expect(result).not.toContain("1.2KB/s");
   });
 
+  it("returns null for scp progress-only output with a trailing newline", () => {
+    const progress = "file.txt                    100%  1234   1.2KB/s   00:00";
+    const input = Array.from({ length: 10 }, () => progress).join("\n") + "\n";
+
+    expect(compressTransferOutput(input)).toBeNull();
+  });
+
   it("preserves final summary line with 'sent ... bytes'", () => {
     const lines = Array(14).fill("noise progress\n").join("") + "sent 1,234 bytes  received 85 bytes  876.00 bytes/sec\n";
     const result = compressTransferOutput(lines)!;


### PR DESCRIPTION
## Summary

Fixes two coupled edge cases in the transfer output compressor:

1. **Empty string instead of null for progress-only output with trailing newline** — `compressTransferOutput` now returns `null` when all kept lines are empty/whitespace, matching the pattern in `build-tools.ts`. This prevents `filterBashOutput` from emitting blank output.

2. **Rsync status words dropped as filename noise** — `done` and `transfer-complete` are no longer misclassified by `RSYNC_AV_FILE_RE` thanks to an explicit `RSYNC_AV_STATUS_RE` exception in `isNoise()`.

## Files Changed
- `src/rtk/transfer.ts` — blank-only null guard + status-word exception regex
- `tests/rtk-transfer.test.ts` — regression test for trailing-newline null return
- `tests/bash-filter.test.ts` — regression test for status word preservation

## Tests
377 tests pass across 65 test files. Existing regression tests (repro-049-bugs) remain green.