### PR TITLE
feat: expose ptc-native structured results for read/grep/sg/edit

### DIFF
--- a/.megapowers/CHANGELOG.md
+++ b/.megapowers/CHANGELOG.md
@@ -184,3 +184,13 @@ The original PR/branch history is still valid historical context, but #039 shoul
 ### Tests
 - Added regression coverage for `read`/`grep`, `sg`, `hashLines()`, `hashLine()`, mismatch diagnostics, and edit diagnostics
 - Verified with `npm test` → 71 passing files / 388 passing tests
+
+## Issue #053: Expose PTC-native structured results from read/grep/sg/edit — CLOSED ✅
+**Date**: 2026-03-16
+### Added
+- Added stable additive `details.ptcValue` payloads to `read`, `grep`, `sg`, and `edit` so downstream PTC consumers can use structured results without parsing human-formatted text (#053)
+- Added shared structured line helpers in `src/ptc-value.ts` to preserve consistent `{ line, hash, anchor, raw, display }` semantics across line-oriented tool payloads (#053)
+- Documented the `PTC structured output` schema contract in `README.md` for downstream consumers (#053)
+### Tests
+- Added dedicated regression coverage for `read`, `grep`, `sg`, and `edit` ptcValue payloads, including metadata, truncation alignment, and noop/warning cases
+- Verified with `npm run typecheck` and `npm test` → 76 passing files / 399 passing tests

--- a/.megapowers/CHANGELOG.md
+++ b/.megapowers/CHANGELOG.md
@@ -177,12 +177,10 @@ The original PR/branch history is still valid historical context, but #039 shoul
 
 ## Issue #052: Escape control characters in hashlined tool output — CLOSED ✅
 **Date**: 2026-03-16
-
 ### Fixed
 - Escaped raw ASCII control characters in `read`, `grep`, and `sg` hashlined output so copied tool output no longer breaks downstream JSON tool calls (#052)
 - Preserved anchor stability by keeping hash computation on raw line text and applying escaping only in display formatting (#052)
 - Escaped related control-character previews in hashline mismatch diagnostics and edit no-op diagnostics (#052)
-
 ### Tests
 - Added regression coverage for `read`/`grep`, `sg`, `hashLines()`, `hashLine()`, mismatch diagnostics, and edit diagnostics
 - Verified with `npm test` → 71 passing files / 388 passing tests

--- a/README.md
+++ b/README.md
@@ -215,6 +215,43 @@ brew install shellcheck yq scc
 - overlapping/adjacent match ranges are merged before output
 - output is grouped by file and anchored for editing
 
+### PTC structured output
+
+`read`, `grep`, `sg`, and `edit` keep their current human-facing `content[].text` output, but also expose a machine-facing payload at `details.ptcValue`.
+
+Current structured shapes:
+
+- `read.details.ptcValue`
+  - `tool: "read"`
+  - `path: string`
+  - `range: { startLine, endLine, totalLines }`
+  - `warnings: Array<{ code, message }>`
+  - `truncation: null | { outputLines, totalLines, outputBytes, totalBytes }`
+  - `symbol: null | { query, name, kind, parentName, startLine, endLine }`
+  - `map: { requested, appended }`
+  - `lines: Array<{ line, hash, anchor, raw, display }>`
+
+- `grep.details.ptcValue`
+  - `tool: "grep"`
+  - `summary: boolean`
+  - `totalMatches: number`
+  - `records: Array<{ path, line, hash, anchor, kind, raw, display }>`
+
+- `sg.details.ptcValue`
+  - `tool: "sg"`
+  - `files: Array<{ path, ranges: Array<{ startLine, endLine }>, lines: Array<{ line, hash, anchor, raw, display }> }>`
+
+- `edit.details.ptcValue`
+  - `tool: "edit"`
+  - `ok: boolean`
+  - `path: string`
+  - `summary: string`
+  - `diff: string`
+  - `firstChangedLine?: number`
+  - `warnings: string[]`
+  - `noopEdits: Array<{ editIndex, loc, currentContent }>`
+
+Hashes and anchors remain tied to raw file content semantics. `display` stays escaped for safe rendering, while `raw` preserves the underlying file text for programmatic consumers.
 ## Why this is especially good for agents
 
 This extension is optimized around the actual failure modes of coding agents:

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -237,7 +237,28 @@ export function registerEditTool(pi: ExtensionAPI): void {
 				details: {
 					diff: diffResult.diff,
 					firstChangedLine: anchorResult.firstChangedLine ?? diffResult.firstChangedLine,
-				} as EditToolDetails,
+					ptcValue: {
+						tool: "edit",
+						ok: true,
+						path: absolutePath,
+						summary: `Updated ${path}`,
+						diff: diffResult.diff,
+						firstChangedLine: anchorResult.firstChangedLine ?? diffResult.firstChangedLine,
+						warnings,
+						noopEdits: anchorResult.noopEdits ?? [],
+					},
+				} as EditToolDetails & {
+					ptcValue: {
+						tool: string;
+						ok: boolean;
+						path: string;
+						summary: string;
+						diff: string;
+						firstChangedLine: number | undefined;
+						warnings: string[];
+						noopEdits: unknown[];
+					};
+				},
 			};
 		},
 	});

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -6,6 +6,7 @@ import path from "path";
 import { normalizeToLF, stripBom, hasBareCarriageReturn } from "./edit-diff";
 import { looksLikeBinary } from "./binary-detect";
 import { ensureHashInit, formatHashlineDisplay } from "./hashline";
+import { buildPtcLine } from "./ptc-value.js";
 import { resolveToCwd } from "./path-utils";
 import { throwIfAborted } from "./runtime";
 
@@ -78,6 +79,31 @@ export interface GrepIRFile {
 export interface GrepIR {
 	totalMatches: number;
 	files: GrepIRFile[];
+}
+
+interface GrepPtcRecord {
+	path: string;
+	line: number;
+	hash: string;
+	anchor: string;
+	kind: "match" | "context";
+	raw: string;
+	display: string;
+}
+
+function collectPtcRecordsFromIR(
+	ir: GrepIR,
+	recordByRenderedLine: Map<string, GrepPtcRecord>,
+): GrepPtcRecord[] {
+	const records: GrepPtcRecord[] = [];
+	for (const file of ir.files) {
+		for (const line of file.lines) {
+			if (line.kind === "separator") continue;
+			const record = recordByRenderedLine.get(line.raw);
+			if (record) records.push(record);
+		}
+	}
+	return records;
 }
 
 const IR_MATCH_LINE_RE = /^(.+?):>>/;
@@ -259,6 +285,15 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 							content: result.content.map((item) =>
 								item === textBlock ? ({ ...item, text: warning } as typeof item) : item,
 							),
+							details: {
+								...(typeof result.details === "object" && result.details !== null ? result.details : {}),
+								ptcValue: {
+									tool: "grep",
+									summary: !!params.summary,
+									totalMatches: 0,
+									records: [],
+								},
+							},
 						};
 					}
 				} catch {
@@ -294,6 +329,7 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 			};
 
 			const transformed: string[] = [];
+			const recordByRenderedLine = new Map<string, GrepPtcRecord>();
 			let parsedCount = 0;
 			let candidateUnparsedCount = 0;
 			const candidateLinePattern = /^.+(?::|-)\d+(?::|-)\s/;
@@ -336,7 +372,18 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 							if (!patternRe.test(fileLines[i])) continue;
 							const lineNum = i + 1;
 							const marker = ">>";
-							transformed.push(`${parsed.displayPath}:${marker}${formatHashlineDisplay(lineNum, fileLines[i])}`);
+							const renderedLine = `${parsed.displayPath}:${marker}${formatHashlineDisplay(lineNum, fileLines[i])}`;
+							transformed.push(renderedLine);
+							const built = buildPtcLine(lineNum, fileLines[i]);
+							recordByRenderedLine.set(renderedLine, {
+								path: toAbsolutePath(parsed.displayPath),
+								line: built.line,
+								hash: built.hash,
+								anchor: built.anchor,
+								kind: "match",
+								raw: built.raw,
+								display: built.display,
+							});
 							emitted = true;
 						}
 						if (emitted) continue;
@@ -345,8 +392,19 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 				}
 				// Normal (non-bare-CR) path
 				const sourceLine = fileLines?.[parsed.lineNumber - 1] ?? parsed.text;
+				const built = buildPtcLine(parsed.lineNumber, sourceLine);
 				const marker = parsed.kind === "match" ? ">>" : "  ";
-				transformed.push(`${parsed.displayPath}:${marker}${formatHashlineDisplay(parsed.lineNumber, sourceLine)}`);
+				const renderedLine = `${parsed.displayPath}:${marker}${built.line}:${built.hash}|${built.display}`;
+				transformed.push(renderedLine);
+				recordByRenderedLine.set(renderedLine, {
+					path: toAbsolutePath(parsed.displayPath),
+					line: built.line,
+					hash: built.hash,
+					anchor: built.anchor,
+					kind: parsed.kind,
+					raw: built.raw,
+					display: built.display,
+				});
 			}
 
 			if (parsedCount === 0 && candidateUnparsedCount > 0) {
@@ -365,6 +423,12 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 						...passthroughDetails,
 						hashlinePassthrough: true,
 						hashlineWarning: warning,
+						ptcValue: {
+							tool: "grep",
+							summary: !!params.summary,
+							totalMatches: 0,
+							records: [],
+						},
 					},
 				};
 			}
@@ -383,11 +447,21 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 				}
 				: truncatedIR;
 			const formattedOutput = formatGrepOutput(outputIR, { summary, limit: effectiveLimit });
+			const ptcRecords = collectPtcRecordsFromIR(outputIR, recordByRenderedLine);
 			return {
 				...result,
 				content: result.content.map((item) =>
 					item === textBlock ? ({ ...item, text: formattedOutput } as typeof item) : item,
 				),
+				details: {
+					...(typeof result.details === "object" && result.details !== null ? result.details : {}),
+					ptcValue: {
+						tool: "grep",
+						summary: !!summary,
+						totalMatches: grepIR.totalMatches,
+						records: ptcRecords,
+					},
+				},
 			};
 		},
 	});

--- a/src/ptc-value.ts
+++ b/src/ptc-value.ts
@@ -1,0 +1,29 @@
+import { computeLineHash, escapeControlCharsForDisplay } from "./hashline.js";
+
+export interface PtcLine {
+  line: number;
+  hash: string;
+  anchor: string;
+  raw: string;
+  display: string;
+}
+
+export interface PtcWarning {
+  code: string;
+  message: string;
+}
+
+export function buildPtcLine(line: number, raw: string): PtcLine {
+  const hash = computeLineHash(line, raw);
+  return {
+    line,
+    hash,
+    anchor: `${line}:${hash}`,
+    raw,
+    display: escapeControlCharsForDisplay(raw),
+  };
+}
+
+export function buildPtcLines(startLine: number, rawLines: string[]): PtcLine[] {
+  return rawLines.map((raw, index) => buildPtcLine(startLine + index, raw));
+}

--- a/src/read.ts
+++ b/src/read.ts
@@ -11,6 +11,7 @@ import { readFileSync } from "fs";
 import { readFile as fsReadFile } from "fs/promises";
 import { normalizeToLF, stripBom, hasBareCarriageReturn } from "./edit-diff";
 import { ensureHashInit, formatHashlineDisplay } from "./hashline";
+import { buildPtcLines, type PtcWarning } from "./ptc-value.js";
 import { looksLikeBinary } from "./binary-detect";
 import { resolveToCwd } from "./path-utils";
 import { throwIfAborted } from "./runtime";
@@ -106,6 +107,7 @@ export function registerReadTool(pi: ExtensionAPI): void {
 			const normalized = normalizeToLF(stripBom(rawBuffer.toString("utf-8")).text);
 			const allLines = normalized.split("\n");
 			const total = allLines.length;
+			const structuredWarnings: PtcWarning[] = [];
 
 			let startLine = params.offset ? Math.max(1, params.offset) : 1;
 			let endIdx = params.limit ? Math.min(startLine - 1 + params.limit, total) : total;
@@ -162,6 +164,7 @@ export function registerReadTool(pi: ExtensionAPI): void {
 			}
 
 			const selected = allLines.slice(startLine - 1, endIdx);
+			const ptcLines = buildPtcLines(startLine, selected);
 
 			const formatted = selected
 				.map((line, i) => {
@@ -183,12 +186,14 @@ export function registerReadTool(pi: ExtensionAPI): void {
 			const shouldAppendMap =
 				!!params.map ||
 				(!!truncation.truncated && !params.offset && !params.limit && !symbolMatch);
+			let appendedMap = false;
 			if (shouldAppendMap) {
 				try {
 					const fileMap = await getOrGenerateMap(absolutePath);
 					if (fileMap) {
 						const mapText = formatFileMapWithBudget(fileMap);
 						text += "\n\n" + mapText;
+						appendedMap = true;
 					}
 				} catch {
 					// Map formatting failed — still return hashlined content without map
@@ -201,22 +206,60 @@ export function registerReadTool(pi: ExtensionAPI): void {
 			}
 
 			if (symbolWarning) {
+				structuredWarnings.push({ code: "symbol-warning", message: symbolWarning.trim() });
 				text = symbolWarning + text;
 			}
 
 			if (hasBinaryContent) {
-				text = "[Warning: file appears to be binary — output may be garbled]\n\n" + text;
+				const warning = "[Warning: file appears to be binary — output may be garbled]";
+				structuredWarnings.push({ code: "binary-content", message: warning });
+				text = `${warning}\n\n${text}`;
 			}
 
 			if (hasBareCarriageReturn(rawBuffer.toString("utf-8"))) {
-				text =
-					"[Warning: file contains bare CR (\\r) line endings — line numbering may be inconsistent with grep and other tools]\n\n" +
-					text;
+				const warning = "[Warning: file contains bare CR (\\r) line endings — line numbering may be inconsistent with grep and other tools]";
+				structuredWarnings.push({ code: "bare-cr", message: warning });
+				text = `${warning}\n\n${text}`;
 			}
 
 			return {
 				content: [{ type: "text", text }],
-				details: { truncation: truncation.truncated ? truncation : undefined },
+				details: {
+					truncation: truncation.truncated ? truncation : undefined,
+					ptcValue: {
+						tool: "read",
+						path: absolutePath,
+						range: {
+							startLine,
+							endLine: endIdx,
+							totalLines: total,
+						},
+						warnings: structuredWarnings,
+						truncation: truncation.truncated
+							? {
+								outputLines: truncation.outputLines,
+								totalLines: total,
+								outputBytes: truncation.outputBytes,
+								totalBytes: truncation.totalBytes,
+							}
+							: null,
+						symbol: symbolMatch
+							? {
+								query: params.symbol ?? symbolMatch.name,
+								name: symbolMatch.name,
+								kind: symbolMatch.kind,
+								parentName: symbolMatch.parentName,
+								startLine: symbolMatch.startLine,
+								endLine: symbolMatch.endLine,
+							}
+							: null,
+						map: {
+							requested: !!params.map,
+							appended: appendedMap,
+						},
+						lines: ptcLines,
+					},
+				},
 			};
 		},
 	});

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -5,7 +5,8 @@ import path from "node:path";
 import { readFile as fsReadFile, stat as fsStat } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { normalizeToLF, stripBom } from "./edit-diff.js";
-import { ensureHashInit, formatHashlineDisplay } from "./hashline.js";
+import { ensureHashInit } from "./hashline.js";
+import { buildPtcLine } from "./ptc-value.js";
 import { resolveToCwd } from "./path-utils.js";
 
 type SgParams = { pattern: string; lang?: string; path?: string };
@@ -96,7 +97,12 @@ export function registerSgTool(pi: ExtensionAPI): void {
         if (!Array.isArray(matches) || matches.length === 0) {
           return {
             content: [{ type: "text", text: `No matches found for pattern: ${p.pattern}` }],
-            details: {},
+            details: {
+              ptcValue: {
+                tool: "sg",
+                files: [],
+              },
+            },
           };
         }
 
@@ -131,6 +137,11 @@ export function registerSgTool(pi: ExtensionAPI): void {
           else grouped.set(display, { abs, matches: [m] });
         }
         const blocks: string[] = [];
+        const ptcFiles: Array<{
+          path: string;
+          ranges: SgRange[];
+          lines: ReturnType<typeof buildPtcLine>[];
+        }> = [];
         for (const [display, { abs, matches: fileMatches }] of grouped) {
           const lines = await getFileLines(abs);
           if (!lines) continue;
@@ -140,22 +151,43 @@ export function registerSgTool(pi: ExtensionAPI): void {
             endLine: m.range.end.line + 1,
           }));
           const mergedRanges = mergeRanges(ranges);
+          const ptcFile = {
+            path: abs,
+            ranges: mergedRanges.map((range) => ({ ...range })),
+            lines: [] as ReturnType<typeof buildPtcLine>[],
+          };
           for (const range of mergedRanges) {
             for (let ln = range.startLine; ln <= range.endLine; ln++) {
               const srcLine = lines[ln - 1] ?? "";
-              blocks.push(`>>${formatHashlineDisplay(ln, srcLine)}`);
+              const built = buildPtcLine(ln, srcLine);
+              blocks.push(`>>${built.line}:${built.hash}|${built.display}`);
+              ptcFile.lines.push(built);
             }
           }
+          ptcFiles.push(ptcFile);
         }
 
         if (blocks.length === 0) {
           return {
             content: [{ type: "text", text: `No matches found for pattern: ${p.pattern}` }],
-            details: {},
+            details: {
+              ptcValue: {
+                tool: "sg",
+                files: [],
+              },
+            },
           };
         }
 
-        return { content: [{ type: "text", text: blocks.join("\n") }], details: {} };
+        return {
+          content: [{ type: "text", text: blocks.join("\n") }],
+          details: {
+            ptcValue: {
+              tool: "sg",
+              files: ptcFiles,
+            },
+          },
+        };
       } catch (err: any) {
         if (err?.code === "ENOENT") {
           return {

--- a/tests/edit-ptc-value.test.ts
+++ b/tests/edit-ptc-value.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+
+async function callEditTool(params: Record<string, unknown>) {
+  const { registerEditTool } = await import("../src/edit.js");
+  let capturedTool: any = null;
+  const mockPi = { registerTool(def: any) { capturedTool = def; } };
+  registerEditTool(mockPi as any);
+  if (!capturedTool) throw new Error("edit tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function makeFixtureFile(): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-ptc-"));
+  const filePath = resolve(dir, "sample.ts");
+  writeFileSync(filePath, [
+    "const one = 1;",
+    "const two = 2;",
+    "const three = 3;",
+  ].join("\n"), "utf-8");
+  return filePath;
+}
+
+function getTextContent(result: any): string {
+  return result.content.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("edit ptcValue", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("returns structured status, diff, firstChangedLine, and noop metadata for anchor edits", async () => {
+    const filePath = makeFixtureFile();
+    const originalLines = readFileSync(filePath, "utf-8").split("\n");
+    const anchor1 = `1:${computeLineHash(1, originalLines[0])}`;
+    const anchor2 = `2:${computeLineHash(2, originalLines[1])}`;
+
+    const result = await callEditTool({
+      path: filePath,
+      edits: [
+        { set_line: { anchor: anchor1, new_text: originalLines[0] } },
+        { set_line: { anchor: anchor2, new_text: "const two = 22;" } },
+      ],
+    });
+
+    const text = getTextContent(result);
+    const ptc = result.details?.ptcValue;
+
+    expect(ptc).toBeDefined();
+    expect(ptc.ok).toBe(true);
+    expect(ptc.path).toBe(filePath);
+    expect(ptc.summary).toContain("Updated");
+    expect(ptc.firstChangedLine).toBe(2);
+    expect(ptc.diff).toContain("const two = 2;");
+    expect(ptc.diff).toContain("const two = 22;");
+    expect(ptc.warnings).toEqual([]);
+    expect(ptc.noopEdits).toEqual([
+      {
+        editIndex: 0,
+        loc: anchor1,
+        currentContent: "const one = 1;",
+      },
+    ]);
+    expect(text.startsWith("Updated")).toBe(true);
+  });
+
+  it("returns legacy normalization warning when using top-level oldText/newText", async () => {
+    const filePath = makeFixtureFile();
+
+    const result = await callEditTool({
+      path: filePath,
+      oldText: "const two = 2;",
+      newText: "const two = 22;",
+    });
+
+    const ptc = result.details?.ptcValue;
+
+    expect(ptc).toBeDefined();
+    expect(ptc.ok).toBe(true);
+    expect(ptc.warnings).toContain(
+      "Legacy top-level oldText/newText input was normalized to edits[0].replace. Prefer the edits[] format."
+    );
+  });
+});

--- a/tests/grep-ptc-value.test.ts
+++ b/tests/grep-ptc-value.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { resolve, dirname, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFileSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { computeLineHash, ensureHashInit, escapeControlCharsForDisplay } from "../src/hashline.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function callGrepTool(params: { pattern: string; path: string; literal?: boolean; context?: number; summary?: boolean; limit?: number }) {
+  const { registerGrepTool } = await import("../src/grep.js");
+  let capturedTool: any = null;
+  const mockPi = { registerTool(def: any) { capturedTool = def; } };
+  registerGrepTool(mockPi as any);
+  if (!capturedTool) throw new Error("grep tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function getTextContent(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+function makeManyMatchesFile(): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "pi-grep-ptc-"));
+  const filePath = resolve(dir, "many-matches.txt");
+  writeFileSync(filePath, Array.from({ length: 60 }, (_, index) => `match line ${index + 1}`).join("\n"), "utf-8");
+  return filePath;
+}
+
+function makeBinaryFile(): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "pi-grep-ptc-bin-"));
+  const filePath = resolve(dir, "sample.bin");
+  writeFileSync(filePath, Buffer.from([0x00, 0x61, 0x62, 0x63]));
+  return filePath;
+}
+
+describe("grep ptcValue", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("returns structured match and context records with complete fields while keeping rendered grep text unchanged", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const displayPath = basename(filePath);
+    const sourceLines = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n").split("\n");
+    const result = await callGrepTool({ pattern: "createDemoDirectory", path: filePath, literal: true, context: 1 });
+    const text = getTextContent(result);
+    const ptc = result.details?.ptcValue;
+
+    expect(ptc).toBeDefined();
+    expect(ptc.tool).toBe("grep");
+    expect(ptc.summary).toBe(false);
+    expect(ptc.totalMatches).toBe(1);
+    expect(ptc.records).toEqual([
+      { lineNumber: 44, kind: "context" as const },
+      { lineNumber: 45, kind: "match" as const },
+      { lineNumber: 46, kind: "context" as const },
+    ].map(({ lineNumber, kind }) => {
+      const raw = sourceLines[lineNumber - 1];
+      const hash = computeLineHash(lineNumber, raw);
+      return {
+        path: filePath,
+        line: lineNumber,
+        hash,
+        anchor: `${lineNumber}:${hash}`,
+        kind,
+        raw,
+        display: escapeControlCharsForDisplay(raw),
+      };
+    }));
+
+    const expectedText = [
+      "[1 matches in 1 files]",
+      `--- ${displayPath} (1 matches) ---`,
+      ...[
+        { lineNumber: 44, marker: "  " },
+        { lineNumber: 45, marker: ">>" },
+        { lineNumber: 46, marker: "  " },
+      ].map(({ lineNumber, marker }) => {
+        const raw = sourceLines[lineNumber - 1];
+        const hash = computeLineHash(lineNumber, raw);
+        return `${displayPath}:${marker}${lineNumber}:${hash}|${escapeControlCharsForDisplay(raw)}`;
+      }),
+    ].join("\n");
+
+    expect(text).toBe(expectedText);
+  });
+  it("keeps ptc records aligned with the truncated rendered output", async () => {
+    const filePath = makeManyMatchesFile();
+    const result = await callGrepTool({ pattern: "match", path: filePath, literal: true });
+    const text = getTextContent(result);
+    const ptc = result.details?.ptcValue;
+    expect(text).toContain(`--- ${basename(filePath)} (60 matches) ---`);
+    expect(ptc.totalMatches).toBe(60);
+    expect(ptc.records).toHaveLength(10);
+    expect(text.split("\n").filter((line) => line.startsWith(`${basename(filePath)}:`))).toHaveLength(10);
+  });
+  it("returns a minimal ptc payload for direct binary-file warnings", async () => {
+    const filePath = makeBinaryFile();
+    const result = await callGrepTool({ pattern: "abc", path: filePath, literal: true });
+    const text = getTextContent(result);
+    const ptc = result.details?.ptcValue;
+    expect(text).toContain("appears to be a binary file");
+    expect(ptc).toEqual({
+      tool: "grep",
+      summary: false,
+      totalMatches: 0,
+      records: [],
+    });
+  });
+});

--- a/tests/read-ptc-metadata.test.ts
+++ b/tests/read-ptc-metadata.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function callReadTool(params: { path: string; offset?: number; limit?: number; symbol?: string; map?: boolean }) {
+  const { registerReadTool } = await import("../src/read.js");
+  let capturedTool: any = null;
+  const mockPi = { registerTool(def: any) { capturedTool = def; } };
+  registerReadTool(mockPi as any);
+  if (!capturedTool) throw new Error("read tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function getTextContent(result: any): string {
+  return result.content.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+function makeBareCrFixture(): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "pi-read-ptc-"));
+  const filePath = resolve(dir, "bare-cr.txt");
+  writeFileSync(filePath, "alpha\rbeta\rgamma", "utf-8");
+  return filePath;
+}
+
+describe("read ptcValue — metadata cases", () => {
+  it("captures truncation and auto-appended map metadata for large reads", async () => {
+    const filePath = resolve(fixturesDir, "large.ts");
+    const result = await callReadTool({ path: filePath });
+    const ptc = result.details?.ptcValue;
+    const text = getTextContent(result);
+
+    expect(ptc).toBeDefined();
+    expect(ptc.truncation).not.toBeNull();
+    expect(ptc.map).toEqual({ requested: false, appended: true });
+    expect(text).toContain("[Output truncated:");
+    expect(text).toContain("File Map:");
+  });
+
+  it("captures symbol metadata for symbol reads", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const result = await callReadTool({ path: filePath, symbol: "createDemoDirectory" });
+    const ptc = result.details?.ptcValue;
+    const text = getTextContent(result);
+
+    expect(ptc.symbol).toEqual({
+      query: "createDemoDirectory",
+      name: "createDemoDirectory",
+      kind: "function",
+      parentName: undefined,
+      startLine: 45,
+      endLine: 49,
+    });
+    expect(ptc.range).toEqual({ startLine: 45, endLine: 49, totalLines: 49 });
+    expect(text.startsWith("[Symbol: createDemoDirectory (function), lines 45-49 of 49]")).toBe(true);
+  });
+
+  it("captures explicit map requests on small files", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const result = await callReadTool({ path: filePath, map: true });
+    const ptc = result.details?.ptcValue;
+    const text = getTextContent(result);
+
+    expect(ptc.map).toEqual({ requested: true, appended: true });
+    expect(text).toContain("File Map:");
+  });
+
+  it("captures bare-CR warnings as structured warnings without changing warning text", async () => {
+    const filePath = makeBareCrFixture();
+    const result = await callReadTool({ path: filePath });
+    const ptc = result.details?.ptcValue;
+    const text = getTextContent(result);
+
+    expect(ptc.warnings).toContainEqual({
+      code: "bare-cr",
+      message: "[Warning: file contains bare CR (\\r) line endings — line numbering may be inconsistent with grep and other tools]",
+    });
+    expect(text.startsWith("[Warning: file contains bare CR (\\r) line endings — line numbering may be inconsistent with grep and other tools]")).toBe(true);
+  });
+});

--- a/tests/read-ptc-value.test.ts
+++ b/tests/read-ptc-value.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { computeLineHash, ensureHashInit, escapeControlCharsForDisplay } from "../src/hashline.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function callReadTool(params: { path: string; offset?: number; limit?: number; symbol?: string; map?: boolean }) {
+  const { registerReadTool } = await import("../src/read.js");
+  let capturedTool: any = null;
+  const mockPi = { registerTool(def: any) { capturedTool = def; } };
+  registerReadTool(mockPi as any);
+  if (!capturedTool) throw new Error("read tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function getTextContent(result: any): string {
+  return result.content.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("read ptcValue — basic line payload", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("returns a structured payload with exact line metadata while keeping text output unchanged", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const raw = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n");
+    const sourceLines = raw.split("\n");
+    const result = await callReadTool({ path: filePath });
+    const text = getTextContent(result);
+    const ptc = result.details?.ptcValue;
+
+    expect(ptc).toBeDefined();
+    expect(ptc).toEqual({
+      tool: "read",
+      path: filePath,
+      range: {
+        startLine: 1,
+        endLine: sourceLines.length,
+        totalLines: sourceLines.length,
+      },
+      warnings: [],
+      truncation: null,
+      symbol: null,
+      map: {
+        requested: false,
+        appended: false,
+      },
+      lines: sourceLines.map((rawLine, index) => {
+        const line = index + 1;
+        const hash = computeLineHash(line, rawLine);
+        return {
+          line,
+          hash,
+          anchor: `${line}:${hash}`,
+          raw: rawLine,
+          display: escapeControlCharsForDisplay(rawLine),
+        };
+      }),
+    });
+
+    const expectedText = sourceLines
+      .map((rawLine, index) => {
+        const line = index + 1;
+        const hash = computeLineHash(line, rawLine);
+        return `${line}:${hash}|${escapeControlCharsForDisplay(rawLine)}`;
+      })
+      .join("\n");
+
+    expect(text).toBe(expectedText);
+  });
+});

--- a/tests/sg-ptc-value.test.ts
+++ b/tests/sg-ptc-value.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import * as cp from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import { computeLineHash, ensureHashInit, escapeControlCharsForDisplay } from "../src/hashline.js";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function getSgTool() {
+  const { registerSgTool } = await import("../src/sg.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerSgTool(mockPi as any);
+  if (!captured) throw new Error("sg tool was not registered");
+  return captured;
+}
+
+function getTextContent(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("sg ptcValue", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns grouped structured results with merged ranges and anchored lines while keeping sg text unchanged", async () => {
+    const tool = await getSgTool();
+    const filePath = resolve(fixturesDir, "small.ts");
+    const sourceLines = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n").split("\n");
+
+    vi.mocked(cp.execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, JSON.stringify([
+        { file: filePath, range: { start: { line: 44, column: 0 }, end: { line: 44, column: 0 } } },
+        { file: filePath, range: { start: { line: 45, column: 0 }, end: { line: 48, column: 0 } } },
+      ]), "");
+      return {} as any;
+    });
+
+    const result = await tool.execute(
+      "tc",
+      { pattern: "export function $NAME($$$PARAMS) { $$$BODY }", path: filePath },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    const text = getTextContent(result);
+    const ptc = result.details?.ptcValue;
+
+    expect(ptc).toBeDefined();
+    expect(ptc).toEqual({
+      tool: "sg",
+      files: [
+        {
+          path: filePath,
+          ranges: [{ startLine: 45, endLine: 49 }],
+          lines: [45, 46, 47, 48, 49].map((lineNumber) => {
+            const raw = sourceLines[lineNumber - 1];
+            const hash = computeLineHash(lineNumber, raw);
+            return {
+              line: lineNumber,
+              hash,
+              anchor: `${lineNumber}:${hash}`,
+              raw,
+              display: escapeControlCharsForDisplay(raw),
+            };
+          }),
+        },
+      ],
+    });
+
+    const expectedText = [
+      `--- tests/fixtures/small.ts ---`,
+      ...[45, 46, 47, 48, 49].map((lineNumber) => {
+        const raw = sourceLines[lineNumber - 1];
+        const hash = computeLineHash(lineNumber, raw);
+        return `>>${lineNumber}:${hash}|${escapeControlCharsForDisplay(raw)}`;
+      }),
+    ].join("\n");
+
+    expect(text).toBe(expectedText);
+  });
+});


### PR DESCRIPTION
## Summary
- add additive `details.ptcValue` payloads to read, grep, sg, and edit
- preserve existing human-facing `content[].text` output while exposing stable structured data
- document the schema and add regression coverage for alignment, truncation, warnings, and noop metadata

## Testing
- npm run typecheck
- npm test

## Issue
Implements local issue 053-expose-ptc-native-structured-results-fro.
Closing this work in the megapowers tracker via done-phase close_issue.