### PR TITLE
feat: add PTC tool policy contract metadata

### DIFF
--- a/.megapowers/CHANGELOG.md
+++ b/.megapowers/CHANGELOG.md
@@ -194,3 +194,13 @@ The original PR/branch history is still valid historical context, but #039 shoul
 ### Tests
 - Added dedicated regression coverage for `read`, `grep`, `sg`, and `edit` ptcValue payloads, including metadata, truncation alignment, and noop/warning cases
 - Verified with `npm run typecheck` and `npm test` → 76 passing files / 399 passing tests
+
+## Issue #054: Add PTC tool policy contract metadata — CLOSED ✅
+**Date**: 2026-03-17
+### Added
+- Added `HASHLINE_TOOL_PTC_POLICY` and `getHashlineToolPtcPolicy()` as a canonical, machine-readable PTC policy contract for `read`, `grep`, `sg`, and `edit` (#054)
+- Re-exported the PTC policy contract and related types from the package root so downstream consumers can import it programmatically without prose parsing (#054)
+- Documented recommended PTC exposure tiers in `README.md`, including optional downstream consumption by `pi-prompt-assembler` without introducing a runtime dependency (#054)
+### Tests
+- Added dedicated regression coverage for the canonical contract, package-root export, and README policy documentation
+- Verified with `npm test` and `npm run typecheck` → 79 passing files / 402 passing tests

--- a/README.md
+++ b/README.md
@@ -252,6 +252,21 @@ Current structured shapes:
   - `noopEdits: Array<{ editIndex, loc, currentContent }>`
 
 Hashes and anchors remain tied to raw file content semantics. `display` stays escaped for safe rendering, while `raw` preserves the underlying file text for programmatic consumers.
+
+### PTC tool policy contract
+
+In addition to `details.ptcValue`, the package exports a machine-readable policy contract at `HASHLINE_TOOL_PTC_POLICY` and `getHashlineToolPtcPolicy()`.
+
+```ts
+import { HASHLINE_TOOL_PTC_POLICY } from "pi-hashline-readmap";
+```
+
+Recommended exposure tiers:
+- `read` and `grep` are safe-by-default, read-only helpers.
+- `sg` is opt-in, read-only.
+- `edit` is not safe-by-default and is mutating/write-capable.
+
+`pi-prompt-assembler` may optionally consume this contract, but `pi-hashline-readmap` does not require `pi-prompt-assembler` to be installed in order to function.
 ## Why this is especially good for agents
 
 This extension is optimized around the actual failure modes of coding agents:

--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,18 @@ import { registerSgTool } from "./src/sg.js";
 import { filterBashOutput } from "./src/rtk/bash-filter.js";
 import { stripAnsi } from "./src/rtk/ansi.js";
 
+export {
+  HASHLINE_TOOL_PTC_POLICY,
+  getHashlineToolPtcPolicy,
+} from "./src/ptc-tool-policy.js";
+export type {
+  HashlineToolDefaultExposure,
+  HashlineToolMutability,
+  HashlineToolName,
+  HashlineToolPtcPolicy,
+  HashlineToolPtcPolicyEntry,
+} from "./src/ptc-tool-policy.js";
+
 // Set to false to disable semantic compression (test summaries, git, build, etc.).
 // ANSI stripping always runs regardless.
 const BASH_FILTER_ENABLED = true;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.2.0",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, and bash output compression",
   "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  },
   "keywords": [
     "pi-package",
     "pi-extension",

--- a/src/ptc-tool-policy.ts
+++ b/src/ptc-tool-policy.ts
@@ -1,0 +1,59 @@
+export type HashlineToolName = "read" | "grep" | "sg" | "edit";
+
+export type HashlineToolMutability = "read-only" | "mutating";
+
+export type HashlineToolDefaultExposure =
+  | "safe-by-default"
+  | "opt-in"
+  | "not-safe-by-default";
+
+export interface HashlineToolPtcPolicyEntry {
+  toolName: HashlineToolName;
+  helperName: string;
+  overridesBuiltin: boolean;
+  mutability: HashlineToolMutability;
+  defaultExposure: HashlineToolDefaultExposure;
+}
+
+export interface HashlineToolPtcPolicy {
+  version: 1;
+  tools: Record<HashlineToolName, HashlineToolPtcPolicyEntry>;
+}
+
+export const HASHLINE_TOOL_PTC_POLICY: HashlineToolPtcPolicy = {
+  version: 1,
+  tools: {
+    read: {
+      toolName: "read",
+      helperName: "hashline-read",
+      overridesBuiltin: true,
+      mutability: "read-only",
+      defaultExposure: "safe-by-default",
+    },
+    grep: {
+      toolName: "grep",
+      helperName: "hashline-grep",
+      overridesBuiltin: true,
+      mutability: "read-only",
+      defaultExposure: "safe-by-default",
+    },
+    sg: {
+      toolName: "sg",
+      helperName: "hashline-sg",
+      overridesBuiltin: false,
+      mutability: "read-only",
+      defaultExposure: "opt-in",
+    },
+    edit: {
+      toolName: "edit",
+      helperName: "hashline-edit",
+      overridesBuiltin: true,
+      mutability: "mutating",
+      defaultExposure: "not-safe-by-default",
+    },
+  },
+};
+
+export function getHashlineToolPtcPolicy(): HashlineToolPtcPolicy {
+  return HASHLINE_TOOL_PTC_POLICY;
+}

--- a/tests/ptc-tool-policy.test.ts
+++ b/tests/ptc-tool-policy.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+
+describe("hashline tool ptc policy contract", () => {
+  it("exports canonical tool policies with exact policy tiers and a versioned minimal shape", async () => {
+    const mod = await import("../src/ptc-tool-policy.js");
+
+    expect(mod.getHashlineToolPtcPolicy()).toBe(mod.HASHLINE_TOOL_PTC_POLICY);
+    expect(Object.keys(mod.HASHLINE_TOOL_PTC_POLICY.tools)).toEqual(["read", "grep", "sg", "edit"]);
+    expect(mod.HASHLINE_TOOL_PTC_POLICY).toEqual({
+      version: 1,
+      tools: {
+        read: {
+          toolName: "read",
+          helperName: "hashline-read",
+          overridesBuiltin: true,
+          mutability: "read-only",
+          defaultExposure: "safe-by-default",
+        },
+        grep: {
+          toolName: "grep",
+          helperName: "hashline-grep",
+          overridesBuiltin: true,
+          mutability: "read-only",
+          defaultExposure: "safe-by-default",
+        },
+        sg: {
+          toolName: "sg",
+          helperName: "hashline-sg",
+          overridesBuiltin: false,
+          mutability: "read-only",
+          defaultExposure: "opt-in",
+        },
+        edit: {
+          toolName: "edit",
+          helperName: "hashline-edit",
+          overridesBuiltin: true,
+          mutability: "mutating",
+          defaultExposure: "not-safe-by-default",
+        },
+      },
+    });
+  });
+});

--- a/tests/public-api-ptc-policy.test.ts
+++ b/tests/public-api-ptc-policy.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+describe("public API ptc policy export", () => {
+  it("re-exports the policy contract from the package root without adding a prompt-assembler dependency", async () => {
+    const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+
+    expect(pkg.exports).toEqual({ ".": "./index.ts" });
+    expect(pkg.dependencies?.["pi-prompt-assembler"]).toBeUndefined();
+    expect(pkg.peerDependencies?.["pi-prompt-assembler"]).toBeUndefined();
+
+    const mod = await import(pathToFileURL(resolve(root, "index.ts")).href);
+
+    expect(typeof mod.default).toBe("function");
+    expect(mod.HASHLINE_TOOL_PTC_POLICY).toEqual(mod.getHashlineToolPtcPolicy());
+    expect(mod.HASHLINE_TOOL_PTC_POLICY.tools.read.defaultExposure).toBe("safe-by-default");
+    expect(mod.HASHLINE_TOOL_PTC_POLICY.tools.sg.defaultExposure).toBe("opt-in");
+    expect(mod.HASHLINE_TOOL_PTC_POLICY.tools.edit.defaultExposure).toBe("not-safe-by-default");
+  });
+});

--- a/tests/readme-ptc-policy.test.ts
+++ b/tests/readme-ptc-policy.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+describe("README.md ptc policy docs", () => {
+  const readme = readFileSync(resolve(root, "README.md"), "utf8");
+
+  it("documents the exported policy contract and recommended exposure tiers", () => {
+    expect(readme).toContain("### PTC tool policy contract");
+    expect(readme).toContain("`HASHLINE_TOOL_PTC_POLICY`");
+    expect(readme).toContain("`read` and `grep` are safe-by-default");
+    expect(readme).toContain("`sg` is opt-in");
+    expect(readme).toContain("`edit` is not safe-by-default");
+    expect(readme).toContain("`pi-prompt-assembler` may optionally consume this contract");
+  });
+});


### PR DESCRIPTION
## Summary
- add a canonical machine-readable PTC policy contract for read, grep, sg, and edit
- re-export the contract and related types from the package root without adding a pi-prompt-assembler dependency
- document the recommended exposure tiers in the README

## Testing
- npm test
- npm run typecheck
- npx vitest run tests/ptc-tool-policy.test.ts tests/public-api-ptc-policy.test.ts tests/readme-ptc-policy.test.ts tests/read-ptc-value.test.ts tests/grep-ptc-value.test.ts tests/sg-ptc-value.test.ts tests/edit-ptc-value.test.ts tests/entry-point.test.ts tests/read-integration.test.ts

## Notes
- existing tool execution semantics and existing details.ptcValue payloads remain unchanged
- downstream consumers such as pi-prompt-assembler may consume the contract, but no runtime dependency was added