### PR TITLE
refactor: unify hashline tool output builders for text and ptcValue

### DIFF
--- a/.megapowers/CHANGELOG.md
+++ b/.megapowers/CHANGELOG.md
@@ -194,3 +194,7 @@ The original PR/branch history is still valid historical context, but #039 shoul
 ### Tests
 - Added dedicated regression coverage for `read`, `grep`, `sg`, and `edit` ptcValue payloads, including metadata, truncation alignment, and noop/warning cases
 - Verified with `npm run typecheck` and `npm test` → 76 passing files / 399 passing tests
+
+## [Unreleased]
+### Changed
+- Refactored `read`, `grep`, `sg`, and `edit` so chat text and `details.ptcValue` are projected from shared internal output builders while preserving existing hashlines, warning behavior, truncation behavior, and raw-content anchor semantics (#055)

--- a/.megapowers/state.json
+++ b/.megapowers/state.json
@@ -1,49 +1,63 @@
 {
   "version": 1,
-  "activeIssue": "052-read-grep-sg-outputs-with-raw-control-ch",
-  "workflow": "bugfix",
+  "activeIssue": "055-refactor-hashline-tool-outputs-around-a-",
+  "workflow": "feature",
   "phase": "done",
   "phaseHistory": [
     {
-      "from": "reproduce",
-      "to": "diagnose",
-      "timestamp": 1773666182898
+      "from": "brainstorm",
+      "to": "spec",
+      "timestamp": 1773779508009
     },
     {
-      "from": "diagnose",
+      "from": "spec",
       "to": "plan",
-      "timestamp": 1773668013038
+      "timestamp": 1773781162768
     },
     {
       "from": "plan",
       "to": "implement",
-      "timestamp": 1773674157090
+      "timestamp": 1773787876911
     },
     {
       "from": "implement",
       "to": "verify",
-      "timestamp": 1773674599622
+      "timestamp": 1773792328263
     },
     {
       "from": "verify",
+      "to": "code-review",
+      "timestamp": 1773794379100
+    },
+    {
+      "from": "code-review",
       "to": "done",
-      "timestamp": 1773674825288
+      "timestamp": 1773795052067
     }
   ],
   "planMode": null,
   "planIteration": 3,
-  "currentTaskIndex": 5,
+  "currentTaskIndex": 14,
   "completedTasks": [
     1,
     2,
     3,
     4,
     5,
-    6
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15
   ],
   "tddTaskState": null,
   "doneActions": [
-    "generate-bugfix-summary",
+    "generate-docs",
     "write-changelog",
     "capture-learnings",
     "push-and-pr",
@@ -51,6 +65,6 @@
   ],
   "doneChecklistShown": true,
   "megaEnabled": true,
-  "branchName": "fix/052-read-grep-sg-outputs-with-raw-control-ch",
+  "branchName": "feat/055-refactor-hashline-tool-outputs-around-a-",
   "baseBranch": "main"
 }

--- a/src/edit-output.ts
+++ b/src/edit-output.ts
@@ -1,0 +1,31 @@
+import { buildPtcEditResult } from "./ptc-value.js";
+
+export interface BuildEditOutputInput {
+  path: string;
+  displayPath: string;
+  diff: string;
+  firstChangedLine: number | undefined;
+  warnings: string[];
+  noopEdits: unknown[];
+}
+
+export interface EditOutputResult {
+  text: string;
+  ptcValue: ReturnType<typeof buildPtcEditResult>;
+}
+
+export function buildEditOutput(input: BuildEditOutputInput): EditOutputResult {
+  const summary = `Updated ${input.displayPath}`;
+  const warningText = input.warnings.length ? `\n\nWarnings:\n${input.warnings.join("\n")}` : "";
+  return {
+    text: `${summary}${warningText}`,
+    ptcValue: buildPtcEditResult({
+      path: input.path,
+      summary,
+      diff: input.diff,
+      firstChangedLine: input.firstChangedLine,
+      warnings: input.warnings,
+      noopEdits: input.noopEdits,
+    }),
+  };
+}

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -7,6 +7,7 @@ import { detectLineEnding, generateCompactOrFullDiff, normalizeToLF, replaceText
 import { applyHashlineEdits, computeLineHash, ensureHashInit, parseLineRef, type HashlineEditItem, escapeControlCharsForDisplay } from "./hashline";
 import { resolveToCwd } from "./path-utils";
 import { throwIfAborted } from "./runtime";
+import { buildEditOutput } from "./edit-output.js";
 
 export function wrapWriteError(err: any, path: string): Error {
 	const code = err?.code;
@@ -230,23 +231,22 @@ export function registerEditTool(pi: ExtensionAPI): void {
 			const warnings: string[] = [];
 			if (anchorResult.warnings?.length) warnings.push(...anchorResult.warnings);
 			if (legacyNormalizationWarning) warnings.push(legacyNormalizationWarning);
-			const warn = warnings.length ? `\n\nWarnings:\n${warnings.join("\n")}` : "";
+			const builtOutput = buildEditOutput({
+				path: absolutePath,
+				displayPath: path,
+				diff: diffResult.diff,
+				firstChangedLine: anchorResult.firstChangedLine ?? diffResult.firstChangedLine,
+				warnings,
+				noopEdits: anchorResult.noopEdits ?? [],
+			});
 
+			const warn = warnings.length ? `\n\nWarnings:\n${warnings.join("\n")}` : "";
 			return {
-				content: [{ type: "text", text: `Updated ${path}${warn}` }],
+				content: [{ type: "text", text: builtOutput.text }],
 				details: {
 					diff: diffResult.diff,
 					firstChangedLine: anchorResult.firstChangedLine ?? diffResult.firstChangedLine,
-					ptcValue: {
-						tool: "edit",
-						ok: true,
-						path: absolutePath,
-						summary: `Updated ${path}`,
-						diff: diffResult.diff,
-						firstChangedLine: anchorResult.firstChangedLine ?? diffResult.firstChangedLine,
-						warnings,
-						noopEdits: anchorResult.noopEdits ?? [],
-					},
+					ptcValue: builtOutput.ptcValue,
 				} as EditToolDetails & {
 					ptcValue: {
 						tool: string;

--- a/src/grep-output.ts
+++ b/src/grep-output.ts
@@ -1,0 +1,76 @@
+import type { PtcLine } from "./ptc-value.js";
+
+export interface GrepOutputRecord extends PtcLine {
+  path: string;
+  kind: "match" | "context";
+}
+
+export type GrepOutputEntry =
+  | { kind: "match" | "context"; line: PtcLine }
+  | { kind: "separator"; text: string };
+
+export interface GrepOutputGroup {
+  displayPath: string;
+  absolutePath: string;
+  matchCount: number;
+  entries: GrepOutputEntry[];
+}
+
+export interface BuildGrepOutputInput {
+  summary: boolean;
+  totalMatches: number;
+  groups: GrepOutputGroup[];
+  limit?: number;
+  records: GrepOutputRecord[];
+}
+
+export interface GrepOutputResult {
+  text: string;
+  ptcValue: {
+    tool: "grep";
+    summary: boolean;
+    totalMatches: number;
+    records: GrepOutputRecord[];
+  };
+}
+
+function renderEntry(displayPath: string, entry: GrepOutputEntry): string {
+  if (entry.kind === "separator") return entry.text;
+  const marker = entry.kind === "match" ? ">>" : "  ";
+  return `${displayPath}:${marker}${entry.line.anchor}|${entry.line.display}`;
+}
+
+export function buildGrepOutput(input: BuildGrepOutputInput): GrepOutputResult {
+  const header = `[${input.totalMatches} matches in ${input.groups.length} files]`;
+  let text: string;
+
+  if (input.summary) {
+    const fileLines = [...input.groups]
+      .sort((a, b) => b.matchCount - a.matchCount)
+      .map((group) => `${group.absolutePath}: ${group.matchCount} matches`);
+    text = [header, ...fileLines].join("\n");
+  } else {
+    const blocks: string[] = [header];
+    for (const group of input.groups) {
+      blocks.push(`--- ${group.displayPath} (${group.matchCount} matches) ---`);
+      for (const entry of group.entries) {
+        blocks.push(renderEntry(group.displayPath, entry));
+      }
+    }
+    text = blocks.join("\n");
+  }
+
+  if (input.limit !== undefined && input.totalMatches === input.limit) {
+    text += `\n\n[Results truncated at ${input.limit} matches — refine pattern or increase limit]`;
+  }
+
+  return {
+    text,
+    ptcValue: {
+      tool: "grep",
+      summary: input.summary,
+      totalMatches: input.totalMatches,
+      records: input.records,
+    },
+  };
+}

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -7,6 +7,7 @@ import { normalizeToLF, stripBom, hasBareCarriageReturn } from "./edit-diff";
 import { looksLikeBinary } from "./binary-detect";
 import { ensureHashInit, formatHashlineDisplay } from "./hashline";
 import { buildPtcLine } from "./ptc-value.js";
+import { buildGrepOutput } from "./grep-output.js";
 import { resolveToCwd } from "./path-utils";
 import { throwIfAborted } from "./runtime";
 
@@ -446,23 +447,50 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 					files: truncatedIR.files.map((file) => ({ ...file, path: toAbsolutePath(file.path) })),
 				}
 				: truncatedIR;
-			const formattedOutput = formatGrepOutput(outputIR, { summary, limit: effectiveLimit });
-			const ptcRecords = collectPtcRecordsFromIR(outputIR, recordByRenderedLine);
-			return {
-				...result,
-				content: result.content.map((item) =>
-					item === textBlock ? ({ ...item, text: formattedOutput } as typeof item) : item,
-				),
-				details: {
-					...(typeof result.details === "object" && result.details !== null ? result.details : {}),
-					ptcValue: {
-						tool: "grep",
-						summary: !!summary,
-						totalMatches: grepIR.totalMatches,
-						records: ptcRecords,
-					},
-				},
-			};
+const ptcRecords = collectPtcRecordsFromIR(outputIR, recordByRenderedLine);
+const groups = outputIR.files.map((file) => ({
+	displayPath: file.path,
+	absolutePath: summary ? file.path : toAbsolutePath(file.path),
+	matchCount: file.matchCount,
+	entries: file.lines.map((line) => {
+		if (line.kind === "separator") {
+			return { kind: "separator" as const, text: line.raw };
+		}
+		const record = recordByRenderedLine.get(line.raw);
+		if (!record) {
+			throw new Error(`Missing grep record for rendered line: ${line.raw}`);
+		}
+
+		return {
+			kind: record.kind,
+			line: {
+				line: record.line,
+				hash: record.hash,
+				anchor: record.anchor,
+				raw: record.raw,
+				display: record.display,
+			},
+		};
+	}),
+}));
+	const builtOutput = buildGrepOutput({
+	summary: !!summary,
+	totalMatches: grepIR.totalMatches,
+	groups,
+	limit: effectiveLimit,
+	records: ptcRecords,
+});
+
+return {
+	...result,
+	content: result.content.map((item) =>
+		item === textBlock ? ({ ...item, text: builtOutput.text } as typeof item) : item,
+	),
+	details: {
+		...(typeof result.details === "object" && result.details !== null ? result.details : {}),
+		ptcValue: builtOutput.ptcValue,
+	},
+};
 		},
 	});
 }

--- a/src/ptc-value.ts
+++ b/src/ptc-value.ts
@@ -13,6 +13,29 @@ export interface PtcWarning {
   message: string;
 }
 
+export interface PtcRange {
+  startLine: number;
+  endLine: number;
+  totalLines?: number;
+}
+
+export interface PtcFileGroup {
+  path: string;
+  ranges: PtcRange[];
+  lines: PtcLine[];
+}
+
+export interface PtcEditResult {
+  tool: "edit";
+  ok: boolean;
+  path: string;
+  summary: string;
+  diff: string;
+  firstChangedLine: number | undefined;
+  warnings: string[];
+  noopEdits: unknown[];
+}
+
 export function buildPtcLine(line: number, raw: string): PtcLine {
   const hash = computeLineHash(line, raw);
   return {
@@ -26,4 +49,49 @@ export function buildPtcLine(line: number, raw: string): PtcLine {
 
 export function buildPtcLines(startLine: number, rawLines: string[]): PtcLine[] {
   return rawLines.map((raw, index) => buildPtcLine(startLine + index, raw));
+}
+
+export function renderPtcLine(line: PtcLine): string {
+  return `${line.anchor}|${line.display}`;
+}
+
+export function renderPtcLines(lines: PtcLine[]): string {
+  return lines.map(renderPtcLine).join("\n");
+}
+
+export function buildPtcWarning(code: string, message: string): PtcWarning {
+  return { code, message };
+}
+
+export function buildPtcRange(startLine: number, endLine: number, totalLines?: number): PtcRange {
+  return totalLines === undefined ? { startLine, endLine } : { startLine, endLine, totalLines };
+}
+
+export function buildPtcFileGroup(path: string, ranges: PtcRange[], lines: PtcLine[]): PtcFileGroup {
+  return {
+    path,
+    ranges: ranges.map((range) => ({ ...range })),
+    lines: lines.map((line) => ({ ...line })),
+  };
+}
+
+export function buildPtcEditResult(input: {
+  ok?: boolean;
+  path: string;
+  summary: string;
+  diff: string;
+  firstChangedLine: number | undefined;
+  warnings: string[];
+  noopEdits: unknown[];
+}): PtcEditResult {
+  return {
+    tool: "edit",
+    ok: input.ok ?? true,
+    path: input.path,
+    summary: input.summary,
+    diff: input.diff,
+    firstChangedLine: input.firstChangedLine,
+    warnings: [...input.warnings],
+    noopEdits: [...input.noopEdits],
+  };
 }

--- a/src/read-output.ts
+++ b/src/read-output.ts
@@ -1,0 +1,121 @@
+import {
+  DEFAULT_MAX_BYTES,
+  DEFAULT_MAX_LINES,
+  formatSize,
+  truncateHead,
+} from "@mariozechner/pi-coding-agent";
+import { buildPtcLines, renderPtcLines, type PtcLine, type PtcWarning } from "./ptc-value.js";
+
+export interface ReadSymbolMetadata {
+  query: string;
+  name: string;
+  kind: string;
+  parentName?: string;
+  startLine: number;
+  endLine: number;
+}
+
+export interface ReadTruncationMetadata {
+  outputLines: number;
+  totalLines: number;
+  outputBytes: number;
+  totalBytes: number;
+}
+
+export interface ReadMapMetadata {
+  requested: boolean;
+  appended: boolean;
+  text?: string | null;
+}
+
+export interface ReadContinuationMetadata {
+  nextOffset: number;
+}
+
+export interface ReadOutputInput {
+  path: string;
+  startLine: number;
+  endLine: number;
+  totalLines: number;
+  selectedLines: string[];
+  warnings?: PtcWarning[];
+  truncation?: ReadTruncationMetadata | null;
+  continuation?: ReadContinuationMetadata | null;
+  symbol?: ReadSymbolMetadata | null;
+  map?: ReadMapMetadata;
+}
+
+export interface ReadOutputResult {
+  text: string;
+  lines: PtcLine[];
+  ptcValue: {
+    tool: "read";
+    path: string;
+    range: {
+      startLine: number;
+      endLine: number;
+      totalLines: number;
+    };
+    warnings: PtcWarning[];
+    truncation: ReadTruncationMetadata | null;
+    symbol: ReadSymbolMetadata | null;
+    map: {
+      requested: boolean;
+      appended: boolean;
+    };
+    lines: PtcLine[];
+  };
+}
+
+export function buildReadOutput(input: ReadOutputInput): ReadOutputResult {
+  const lines = buildPtcLines(input.startLine, input.selectedLines);
+  const warnings = input.warnings ?? [];
+  const renderedLines = renderPtcLines(lines);
+  const truncated = truncateHead(renderedLines, {
+    maxLines: DEFAULT_MAX_LINES,
+    maxBytes: DEFAULT_MAX_BYTES,
+  });
+
+  let text = input.truncation ? truncated.content : renderedLines;
+
+  if (input.truncation) {
+    text += `\n\n[Output truncated: showing ${input.truncation.outputLines} of ${input.totalLines} lines (${formatSize(input.truncation.outputBytes)} of ${formatSize(input.truncation.totalBytes)}). Use offset=${input.startLine + input.truncation.outputLines} to continue.]`;
+  } else if (input.continuation) {
+    text += `\n\n[Showing lines ${input.startLine}-${input.endLine} of ${input.totalLines}. Use offset=${input.continuation.nextOffset} to continue.]`;
+  }
+
+  if (input.map?.appended && input.map.text) {
+    text += `\n\n${input.map.text}`;
+  }
+
+  if (input.symbol) {
+    const parentInfo = input.symbol.parentName ? ` in ${input.symbol.parentName}` : "";
+    text = `[Symbol: ${input.symbol.name} (${input.symbol.kind})${parentInfo}, lines ${input.symbol.startLine}-${input.symbol.endLine} of ${input.totalLines}]\n\n${text}`;
+  }
+
+  if (warnings.length) {
+    text = `${warnings.map((warning) => warning.message).join("\n\n")}\n\n${text}`;
+  }
+
+  return {
+    text,
+    lines,
+    ptcValue: {
+      tool: "read",
+      path: input.path,
+      range: {
+        startLine: input.startLine,
+        endLine: input.endLine,
+        totalLines: input.totalLines,
+      },
+      warnings,
+      truncation: input.truncation ?? null,
+      symbol: input.symbol ?? null,
+      map: {
+        requested: input.map?.requested ?? false,
+        appended: input.map?.appended ?? false,
+      },
+      lines,
+    },
+  };
+}

--- a/src/read.ts
+++ b/src/read.ts
@@ -11,13 +11,14 @@ import { readFileSync } from "fs";
 import { readFile as fsReadFile } from "fs/promises";
 import { normalizeToLF, stripBom, hasBareCarriageReturn } from "./edit-diff";
 import { ensureHashInit, formatHashlineDisplay } from "./hashline";
-import { buildPtcLines, type PtcWarning } from "./ptc-value.js";
+import { buildPtcWarning, buildPtcLines, type PtcWarning } from "./ptc-value.js";
 import { looksLikeBinary } from "./binary-detect";
 import { resolveToCwd } from "./path-utils";
 import { throwIfAborted } from "./runtime";
 import { getOrGenerateMap } from "./map-cache";
 import { formatFileMapWithBudget } from "./readmap/formatter.js";
 import { findSymbol, type SymbolMatch } from "./readmap/symbol-lookup.js";
+import { buildReadOutput } from "./read-output.js";
 
 const READ_DESC = readFileSync(new URL("../prompts/read.md", import.meta.url), "utf-8")
 	.replaceAll("{{DEFAULT_MAX_LINES}}", String(DEFAULT_MAX_LINES))
@@ -187,12 +188,14 @@ export function registerReadTool(pi: ExtensionAPI): void {
 				!!params.map ||
 				(!!truncation.truncated && !params.offset && !params.limit && !symbolMatch);
 			let appendedMap = false;
+			let mapText: string | null = null;
 			if (shouldAppendMap) {
 				try {
 					const fileMap = await getOrGenerateMap(absolutePath);
 					if (fileMap) {
-						const mapText = formatFileMapWithBudget(fileMap);
-						text += "\n\n" + mapText;
+						const formattedMap = formatFileMapWithBudget(fileMap);
+						text += "\n\n" + formattedMap;
+						mapText = formattedMap;
 						appendedMap = true;
 					}
 				} catch {
@@ -206,61 +209,62 @@ export function registerReadTool(pi: ExtensionAPI): void {
 			}
 
 			if (symbolWarning) {
-				structuredWarnings.push({ code: "symbol-warning", message: symbolWarning.trim() });
+				structuredWarnings.push(buildPtcWarning("symbol-warning", symbolWarning.trim()));
 				text = symbolWarning + text;
 			}
 
 			if (hasBinaryContent) {
 				const warning = "[Warning: file appears to be binary — output may be garbled]";
-				structuredWarnings.push({ code: "binary-content", message: warning });
+				structuredWarnings.push(buildPtcWarning("binary-content", warning));
 				text = `${warning}\n\n${text}`;
 			}
 
 			if (hasBareCarriageReturn(rawBuffer.toString("utf-8"))) {
 				const warning = "[Warning: file contains bare CR (\\r) line endings — line numbering may be inconsistent with grep and other tools]";
-				structuredWarnings.push({ code: "bare-cr", message: warning });
+				structuredWarnings.push(buildPtcWarning("bare-cr", warning));
 				text = `${warning}\n\n${text}`;
 			}
 
-			return {
-				content: [{ type: "text", text }],
-				details: {
-					truncation: truncation.truncated ? truncation : undefined,
-					ptcValue: {
-						tool: "read",
-						path: absolutePath,
-						range: {
-							startLine,
-							endLine: endIdx,
-							totalLines: total,
-						},
-						warnings: structuredWarnings,
-						truncation: truncation.truncated
-							? {
-								outputLines: truncation.outputLines,
-								totalLines: total,
-								outputBytes: truncation.outputBytes,
-								totalBytes: truncation.totalBytes,
-							}
-							: null,
-						symbol: symbolMatch
-							? {
-								query: params.symbol ?? symbolMatch.name,
-								name: symbolMatch.name,
-								kind: symbolMatch.kind,
-								parentName: symbolMatch.parentName,
-								startLine: symbolMatch.startLine,
-								endLine: symbolMatch.endLine,
-							}
-							: null,
-						map: {
-							requested: !!params.map,
-							appended: appendedMap,
-						},
-						lines: ptcLines,
-					},
-				},
-			};
+const readOutput = buildReadOutput({
+	path: absolutePath,
+	startLine,
+	endLine: endIdx,
+	totalLines: total,
+	selectedLines: selected,
+	warnings: structuredWarnings,
+	truncation: truncation.truncated
+		? {
+				outputLines: truncation.outputLines,
+				totalLines: total,
+				outputBytes: truncation.outputBytes,
+				totalBytes: truncation.totalBytes,
+			}
+		: null,
+	continuation: !truncation.truncated && endIdx < total ? { nextOffset: endIdx + 1 } : null,
+	symbol: symbolMatch
+		? {
+				query: params.symbol ?? symbolMatch.name,
+				name: symbolMatch.name,
+				kind: symbolMatch.kind,
+				parentName: symbolMatch.parentName,
+				startLine: symbolMatch.startLine,
+				endLine: symbolMatch.endLine,
+			}
+		: null,
+	map: {
+		requested: !!params.map,
+		appended: appendedMap,
+		text: mapText,
+	},
+});
+
+return {
+	content: [{ type: "text", text: readOutput.text }],
+	details: {
+		truncation: truncation.truncated ? truncation : undefined,
+		ptcValue: readOutput.ptcValue,
+	},
+};
 		},
 	});
 }

--- a/src/sg-output.ts
+++ b/src/sg-output.ts
@@ -1,0 +1,57 @@
+import type { PtcLine, PtcRange } from "./ptc-value.js";
+
+export interface SgOutputFile {
+  displayPath: string;
+  path: string;
+  ranges: PtcRange[];
+  lines: PtcLine[];
+}
+
+export interface BuildSgOutputInput {
+  pattern: string;
+  files: SgOutputFile[];
+}
+
+export interface SgOutputResult {
+  text: string;
+  ptcValue: {
+    tool: "sg";
+    files: Array<{
+      path: string;
+      ranges: PtcRange[];
+      lines: PtcLine[];
+    }>;
+  };
+}
+
+export function buildSgOutput(input: BuildSgOutputInput): SgOutputResult {
+  if (input.files.length === 0) {
+    return {
+      text: `No matches found for pattern: ${input.pattern}`,
+      ptcValue: {
+        tool: "sg",
+        files: [],
+      },
+    };
+  }
+
+  const blocks: string[] = [];
+  for (const file of input.files) {
+    blocks.push(`--- ${file.displayPath} ---`);
+    for (const line of file.lines) {
+      blocks.push(`>>${line.anchor}|${line.display}`);
+    }
+  }
+
+  return {
+    text: blocks.join("\n"),
+    ptcValue: {
+      tool: "sg",
+      files: input.files.map((file) => ({
+        path: file.path,
+        ranges: file.ranges.map((range) => ({ ...range })),
+        lines: file.lines.map((line) => ({ ...line })),
+      })),
+    },
+  };
+}

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -8,6 +8,7 @@ import { normalizeToLF, stripBom } from "./edit-diff.js";
 import { ensureHashInit } from "./hashline.js";
 import { buildPtcLine } from "./ptc-value.js";
 import { resolveToCwd } from "./path-utils.js";
+import { buildSgOutput } from "./sg-output.js";
 
 type SgParams = { pattern: string; lang?: string; path?: string };
 
@@ -95,13 +96,11 @@ export function registerSgTool(pi: ExtensionAPI): void {
 
         const matches = JSON.parse(stdout);
         if (!Array.isArray(matches) || matches.length === 0) {
+          const emptyOutput = buildSgOutput({ pattern: p.pattern, files: [] });
           return {
-            content: [{ type: "text", text: `No matches found for pattern: ${p.pattern}` }],
+            content: [{ type: "text", text: emptyOutput.text }],
             details: {
-              ptcValue: {
-                tool: "sg",
-                files: [],
-              },
+              ptcValue: emptyOutput.ptcValue,
             },
           };
         }
@@ -138,6 +137,7 @@ export function registerSgTool(pi: ExtensionAPI): void {
         }
         const blocks: string[] = [];
         const ptcFiles: Array<{
+          displayPath: string;
           path: string;
           ranges: SgRange[];
           lines: ReturnType<typeof buildPtcLine>[];
@@ -152,6 +152,7 @@ export function registerSgTool(pi: ExtensionAPI): void {
           }));
           const mergedRanges = mergeRanges(ranges);
           const ptcFile = {
+            displayPath: display,
             path: abs,
             ranges: mergedRanges.map((range) => ({ ...range })),
             lines: [] as ReturnType<typeof buildPtcLine>[],
@@ -168,24 +169,23 @@ export function registerSgTool(pi: ExtensionAPI): void {
         }
 
         if (blocks.length === 0) {
+          const emptyOutput = buildSgOutput({ pattern: p.pattern, files: [] });
           return {
-            content: [{ type: "text", text: `No matches found for pattern: ${p.pattern}` }],
+            content: [{ type: "text", text: emptyOutput.text }],
             details: {
-              ptcValue: {
-                tool: "sg",
-                files: [],
-              },
+              ptcValue: emptyOutput.ptcValue,
             },
           };
         }
 
+        const builtOutput = buildSgOutput({
+          pattern: p.pattern,
+          files: ptcFiles,
+        });
         return {
-          content: [{ type: "text", text: blocks.join("\n") }],
+          content: [{ type: "text", text: builtOutput.text }],
           details: {
-            ptcValue: {
-              tool: "sg",
-              files: ptcFiles,
-            },
+            ptcValue: builtOutput.ptcValue,
           },
         };
       } catch (err: any) {

--- a/tests/edit-output.test.ts
+++ b/tests/edit-output.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+import * as editModule from "../src/edit.js";
+import * as editOutputModule from "../src/edit-output.js";
+
+async function callEditTool(params: Record<string, unknown>) {
+  let capturedTool: any = null;
+  const mockPi = { registerTool(def: any) { capturedTool = def; } };
+  editModule.registerEditTool(mockPi as any);
+  if (!capturedTool) throw new Error("edit tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function makeFixtureFile(): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-output-"));
+  const filePath = resolve(dir, "sample.ts");
+  writeFileSync(filePath, [
+    "const one = 1;",
+    "const two = 2;",
+    "const three = 3;",
+  ].join("\n"), "utf-8");
+  return filePath;
+}
+
+function getTextContent(result: any): string {
+  return result.content.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("buildEditOutput", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("projects successful anchor-edit results through one shared builder", async () => {
+    const spy = vi.spyOn(editOutputModule, "buildEditOutput");
+    const filePath = makeFixtureFile();
+    const originalLines = readFileSync(filePath, "utf-8").split("\n");
+    const anchor1 = `1:${computeLineHash(1, originalLines[0])}`;
+    const anchor2 = `2:${computeLineHash(2, originalLines[1])}`;
+
+    const result = await callEditTool({
+      path: filePath,
+      edits: [
+        { set_line: { anchor: anchor1, new_text: originalLines[0] } },
+        { set_line: { anchor: anchor2, new_text: "const two = 22;" } },
+      ],
+    });
+
+    const built = spy.mock.results.at(-1)?.value;
+    expect(built.text).toBe(`Updated ${filePath}`);
+    expect(getTextContent(result)).toBe(built.text);
+    expect(result.details?.ptcValue).toEqual(built.ptcValue);
+  });
+
+  it("projects legacy normalization warnings through the shared builder", async () => {
+    const spy = vi.spyOn(editOutputModule, "buildEditOutput");
+    const filePath = makeFixtureFile();
+
+    const result = await callEditTool({
+      path: filePath,
+      oldText: "const two = 2;",
+      newText: "const two = 22;",
+    });
+
+    const built = spy.mock.results.at(-1)?.value;
+    expect(built.text.includes("Warnings:")).toBe(true);
+    expect(getTextContent(result)).toBe(built.text);
+    expect(result.details?.ptcValue).toEqual(built.ptcValue);
+  });
+});

--- a/tests/grep-output.test.ts
+++ b/tests/grep-output.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
+import { resolve, dirname, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFileSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { ensureHashInit, computeLineHash, escapeControlCharsForDisplay } from "../src/hashline.js";
+import * as grepModule from "../src/grep.js";
+import * as grepOutputModule from "../src/grep-output.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function callGrepTool(params: { pattern: string; path: string; literal?: boolean; context?: number; summary?: boolean; limit?: number }) {
+  let capturedTool: any = null;
+  const mockPi = { registerTool(def: any) { capturedTool = def; } };
+  grepModule.registerGrepTool(mockPi as any);
+  if (!capturedTool) throw new Error("grep tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function getTextContent(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+function makeManyMatchesFile(): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "pi-grep-output-"));
+  const filePath = resolve(dir, "many-matches.txt");
+  writeFileSync(filePath, Array.from({ length: 60 }, (_, index) => `match line ${index + 1}`).join("\n"), "utf-8");
+  return filePath;
+}
+
+describe("buildGrepOutput", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders grouped grep matches through one shared builder", async () => {
+    const spy = vi.spyOn(grepOutputModule, "buildGrepOutput");
+    const filePath = resolve(fixturesDir, "small.ts");
+    const displayPath = basename(filePath);
+    const sourceLines = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n").split("\n");
+    const result = await callGrepTool({ pattern: "createDemoDirectory", path: filePath, literal: true, context: 1 });
+
+    const built = spy.mock.results.at(-1)?.value;
+    const expectedText = [
+      "[1 matches in 1 files]",
+      `--- ${displayPath} (1 matches) ---`,
+      ...[
+        { lineNumber: 44, marker: "  " },
+        { lineNumber: 45, marker: ">>" },
+        { lineNumber: 46, marker: "  " },
+      ].map(({ lineNumber, marker }) => {
+        const raw = sourceLines[lineNumber - 1];
+        const hash = computeLineHash(lineNumber, raw);
+        return `${displayPath}:${marker}${lineNumber}:${hash}|${escapeControlCharsForDisplay(raw)}`;
+      }),
+    ].join("\n");
+
+    expect(built.text).toBe(expectedText);
+    expect(getTextContent(result)).toBe(built.text);
+    expect(result.details?.ptcValue).toEqual(built.ptcValue);
+  });
+
+  it("renders grep summary mode through the same shared builder", async () => {
+    const spy = vi.spyOn(grepOutputModule, "buildGrepOutput");
+    const filePath = makeManyMatchesFile();
+    const result = await callGrepTool({
+      pattern: "match",
+      path: filePath,
+      literal: true,
+      summary: true,
+      limit: 60,
+    });
+
+    const built = spy.mock.results.at(-1)?.value;
+    expect(built.text.includes(">>")).toBe(false);
+    expect(built.text).toContain(`${filePath}: 60 matches`);
+    expect(getTextContent(result)).toBe(built.text);
+    expect(result.details?.ptcValue).toEqual(built.ptcValue);
+  });
+});

--- a/tests/ptc-value-shared-output.test.ts
+++ b/tests/ptc-value-shared-output.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { ensureHashInit } from "../src/hashline.js";
+import * as ptc from "../src/ptc-value.js";
+
+describe("ptc-value shared primitives", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("builds canonical line records and renders them from display-safe text", () => {
+    expect(typeof (ptc as any).renderPtcLine).toBe("function");
+    expect(typeof (ptc as any).renderPtcLines).toBe("function");
+
+    const line = ptc.buildPtcLine(7, "hello\u0000world");
+    expect(line).toEqual({
+      line: 7,
+      hash: line.hash,
+      anchor: `7:${line.hash}`,
+      raw: "hello\u0000world",
+      display: "hello\\u0000world",
+    });
+
+    expect((ptc as any).renderPtcLine(line)).toBe(`${line.anchor}|hello\\u0000world`);
+    expect((ptc as any).renderPtcLines([line])).toBe(`${line.anchor}|hello\\u0000world`);
+  });
+
+  it("builds canonical warnings, ranges, and grouped file payloads", () => {
+    expect(typeof (ptc as any).buildPtcWarning).toBe("function");
+    expect(typeof (ptc as any).buildPtcRange).toBe("function");
+    expect(typeof (ptc as any).buildPtcFileGroup).toBe("function");
+
+    const line = ptc.buildPtcLine(10, "const answer = 42;");
+
+    expect((ptc as any).buildPtcWarning("binary-content", "[Warning: binary]")).toEqual({
+      code: "binary-content",
+      message: "[Warning: binary]",
+    });
+
+    expect((ptc as any).buildPtcRange(10, 12, 40)).toEqual({
+      startLine: 10,
+      endLine: 12,
+      totalLines: 40,
+    });
+
+    expect(
+      (ptc as any).buildPtcFileGroup(
+        "/tmp/sample.ts",
+        [(ptc as any).buildPtcRange(10, 12)],
+        [line],
+      ),
+    ).toEqual({
+      path: "/tmp/sample.ts",
+      ranges: [{ startLine: 10, endLine: 12 }],
+      lines: [line],
+    });
+  });
+
+  it("builds canonical edit result payloads from shared edit semantics", () => {
+    expect(typeof (ptc as any).buildPtcEditResult).toBe("function");
+
+    expect(
+      (ptc as any).buildPtcEditResult({
+        path: "/tmp/sample.ts",
+        summary: "Updated /tmp/sample.ts",
+        diff: "-old\n+new",
+        firstChangedLine: 2,
+        warnings: [],
+        noopEdits: [],
+      }),
+    ).toEqual({
+      tool: "edit",
+      ok: true,
+      path: "/tmp/sample.ts",
+      summary: "Updated /tmp/sample.ts",
+      diff: "-old\n+new",
+      firstChangedLine: 2,
+      warnings: [],
+      noopEdits: [],
+    });
+  });
+});

--- a/tests/read-output-metadata.test.ts
+++ b/tests/read-output-metadata.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
+import { readFileSync, writeFileSync, mkdtempSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import { ensureHashInit } from "../src/hashline.js";
+import { getOrGenerateMap } from "../src/map-cache.js";
+import { formatFileMapWithBudget } from "../src/readmap/formatter.js";
+import * as readModule from "../src/read.js";
+import * as readOutputModule from "../src/read-output.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function callReadTool(params: { path: string; offset?: number; limit?: number; symbol?: string; map?: boolean }) {
+  let capturedTool: any = null;
+  const mockPi = { registerTool(def: any) { capturedTool = def; } };
+  readModule.registerReadTool(mockPi as any);
+  if (!capturedTool) throw new Error("read tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function getTextContent(result: any): string {
+  return result.content.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+function makeBareCrFixture(): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "pi-read-output-warning-"));
+  const filePath = resolve(dir, "bare-cr.txt");
+  writeFileSync(filePath, "alpha\rbeta\rgamma", "utf-8");
+  return filePath;
+}
+
+describe("buildReadOutput metadata", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("projects explicit map requests through the shared read builder", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const selectedLines = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n").split("\n");
+    const fileMap = await getOrGenerateMap(filePath);
+    if (!fileMap) throw new Error("expected map for small.ts");
+    const mapText = formatFileMapWithBudget(fileMap);
+    const spy = vi.spyOn(readOutputModule, "buildReadOutput");
+
+    const result = await callReadTool({ path: filePath, map: true });
+
+    const lastInput = spy.mock.calls.at(-1)?.[0];
+    const built = spy.mock.results.at(-1)?.value;
+    expect(typeof lastInput?.map?.text).toBe("string");
+    expect(lastInput?.map && { requested: lastInput.map.requested, appended: lastInput.map.appended }).toEqual({
+      requested: true,
+      appended: true,
+    });
+    expect(lastInput?.map?.text).toBe(mapText);
+    expect(built.text).toContain("File Map:");
+    expect(getTextContent(result)).toBe(built.text);
+    expect(result.details?.ptcValue).toEqual(built.ptcValue);
+    expect(lastInput?.selectedLines).toEqual(selectedLines);
+  });
+
+  it("projects symbol reads through the shared read builder", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const selectedLines = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n").split("\n");
+    const spy = vi.spyOn(readOutputModule, "buildReadOutput");
+
+    const result = await callReadTool({ path: filePath, symbol: "createDemoDirectory" });
+
+    const lastInput = spy.mock.calls.at(-1)?.[0];
+    const built = spy.mock.results.at(-1)?.value;
+    expect(lastInput?.symbol).toEqual({
+      query: "createDemoDirectory",
+      name: "createDemoDirectory",
+      kind: "function",
+      parentName: undefined,
+      startLine: 45,
+      endLine: 49,
+    });
+    expect(lastInput?.selectedLines).toEqual(selectedLines.slice(44, 49));
+    expect(built.text.startsWith("[Symbol: createDemoDirectory (function), lines 45-49 of 49]")).toBe(true);
+    expect(getTextContent(result)).toBe(built.text);
+    expect(result.details?.ptcValue).toEqual(built.ptcValue);
+  });
+
+  it("projects truncation metadata through the shared read builder", async () => {
+    const filePath = resolve(fixturesDir, "large.ts");
+    const spy = vi.spyOn(readOutputModule, "buildReadOutput");
+
+    const result = await callReadTool({ path: filePath });
+
+    const lastInput = spy.mock.calls.at(-1)?.[0];
+    const built = spy.mock.results.at(-1)?.value;
+    expect(lastInput?.truncation).toEqual({
+      outputLines: result.details.truncation.outputLines,
+      totalLines: result.details.truncation.totalLines,
+      outputBytes: result.details.truncation.outputBytes,
+      totalBytes: result.details.truncation.totalBytes,
+    });
+    expect(built.text.includes("[Output truncated:")).toBe(true);
+    expect(built.text).toContain("File Map:");
+    expect(getTextContent(result)).toBe(built.text);
+    expect(result.details?.ptcValue).toEqual(built.ptcValue);
+  });
+
+  it("projects structured warnings through the shared read builder", async () => {
+    const filePath = makeBareCrFixture();
+    const spy = vi.spyOn(readOutputModule, "buildReadOutput");
+
+    const result = await callReadTool({ path: filePath });
+
+    const lastInput = spy.mock.calls.at(-1)?.[0];
+    const built = spy.mock.results.at(-1)?.value;
+    expect(lastInput?.warnings).toEqual([
+      {
+        code: "bare-cr",
+        message: "[Warning: file contains bare CR (\\r) line endings — line numbering may be inconsistent with grep and other tools]",
+      },
+    ]);
+    expect(built.text.startsWith("[Warning: file contains bare CR (\\r) line endings — line numbering may be inconsistent with grep and other tools]")).toBe(true);
+    expect(getTextContent(result)).toBe(built.text);
+    expect(result.details?.ptcValue).toEqual(built.ptcValue);
+  });
+});

--- a/tests/read-output.test.ts
+++ b/tests/read-output.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { computeLineHash, ensureHashInit, escapeControlCharsForDisplay } from "../src/hashline.js";
+import * as readModule from "../src/read.js";
+import * as readOutputModule from "../src/read-output.js";
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+async function callReadTool(params: { path: string; offset?: number; limit?: number; symbol?: string; map?: boolean }) {
+  let capturedTool: any = null;
+  const mockPi = { registerTool(def: any) { capturedTool = def; } };
+  readModule.registerReadTool(mockPi as any);
+  if (!capturedTool) throw new Error("read tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+function getTextContent(result: any): string {
+  return result.content.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("buildReadOutput", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("builds plain read text and ptcValue from the same selected lines", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const selectedLines = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n").split("\n");
+    const built = readOutputModule.buildReadOutput({
+      path: filePath,
+      startLine: 1,
+      endLine: selectedLines.length,
+      totalLines: selectedLines.length,
+      selectedLines,
+    });
+
+    expect(built.text).toBe(
+      selectedLines
+        .map((rawLine, index) => {
+          const line = index + 1;
+          const hash = computeLineHash(line, rawLine);
+          return `${line}:${hash}|${escapeControlCharsForDisplay(rawLine)}`;
+        })
+        .join("\n"),
+    );
+
+    expect(built.ptcValue).toEqual({
+      tool: "read",
+      path: filePath,
+      range: {
+        startLine: 1,
+        endLine: selectedLines.length,
+        totalLines: selectedLines.length,
+      },
+      warnings: [],
+      truncation: null,
+      symbol: null,
+      map: {
+        requested: false,
+        appended: false,
+      },
+      lines: selectedLines.map((rawLine, index) => {
+        const line = index + 1;
+        const hash = computeLineHash(line, rawLine);
+        return {
+          line,
+          hash,
+          anchor: `${line}:${hash}`,
+          raw: rawLine,
+          display: escapeControlCharsForDisplay(rawLine),
+        };
+      }),
+    });
+  });
+
+  it("routes plain read results through buildReadOutput", async () => {
+    const spy = vi.spyOn(readOutputModule, "buildReadOutput");
+    const filePath = resolve(fixturesDir, "small.ts");
+    const selectedLines = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n").split("\n");
+    const result = await callReadTool({ path: filePath });
+
+    expect(spy).toHaveBeenCalled();
+    const built = spy.mock.results.at(-1)?.value;
+    expect(spy.mock.calls.at(-1)?.[0]).toEqual({
+      path: filePath,
+      startLine: 1,
+      endLine: selectedLines.length,
+      totalLines: selectedLines.length,
+      selectedLines,
+      warnings: [],
+      truncation: null,
+      continuation: null,
+      symbol: null,
+      map: {
+        requested: false,
+        appended: false,
+        text: null,
+      },
+    });
+    expect(getTextContent(result)).toBe(built.text);
+    expect(result.details?.ptcValue).toEqual(built.ptcValue);
+  });
+});

--- a/tests/sg-output.test.ts
+++ b/tests/sg-output.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import * as cp from "node:child_process";
+import { resolve, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import { ensureHashInit, computeLineHash, escapeControlCharsForDisplay } from "../src/hashline.js";
+import * as sgModule from "../src/sg.js";
+import * as sgOutputModule from "../src/sg-output.js";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function getSgTool() {
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  sgModule.registerSgTool(mockPi as any);
+  if (!captured) throw new Error("sg tool was not registered");
+  return captured;
+}
+
+function getTextContent(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("buildSgOutput", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders grouped sg matches through one shared builder", async () => {
+    const spy = vi.spyOn(sgOutputModule, "buildSgOutput");
+    const tool = await getSgTool();
+    const filePath = resolve(fixturesDir, "small.ts");
+    const displayPath = relative(process.cwd(), filePath);
+    const sourceLines = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n").split("\n");
+
+    vi.mocked(cp.execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, JSON.stringify([
+        { file: filePath, range: { start: { line: 44, column: 0 }, end: { line: 44, column: 0 } } },
+        { file: filePath, range: { start: { line: 45, column: 0 }, end: { line: 48, column: 0 } } },
+      ]), "");
+      return {} as any;
+    });
+
+    const result = await tool.execute(
+      "tc",
+      { pattern: "export function $NAME($$$PARAMS) { $$$BODY }", path: filePath },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    const built = spy.mock.results.at(-1)?.value;
+    const expectedText = [
+      `--- ${displayPath} ---`,
+      ...[45, 46, 47, 48, 49].map((lineNumber) => {
+        const raw = sourceLines[lineNumber - 1];
+        const hash = computeLineHash(lineNumber, raw);
+        return `>>${lineNumber}:${hash}|${escapeControlCharsForDisplay(raw)}`;
+      }),
+    ].join("\n");
+
+    expect(built.text).toBe(expectedText);
+    expect(getTextContent(result)).toBe(built.text);
+    expect(result.details?.ptcValue).toEqual(built.ptcValue);
+  });
+
+  it("projects no-match responses through the shared sg builder", async () => {
+    expect(sgOutputModule.buildSgOutput({ pattern: "does-not-match", files: [] }).text).toBe(
+      "No matches found for pattern: does-not-match",
+    );
+
+    const spy = vi.spyOn(sgOutputModule, "buildSgOutput");
+    const tool = await getSgTool();
+    vi.mocked(cp.execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, "[]", "");
+      return {} as any;
+    });
+
+    const result = await tool.execute(
+      "tc",
+      { pattern: "does-not-match" },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    const built = spy.mock.results.at(-1)?.value;
+    expect(getTextContent(result)).toBe(built.text);
+    expect(result.details?.ptcValue).toEqual(built.ptcValue);
+  });
+});


### PR DESCRIPTION
## Summary
This refactors the hashline tool family so `read`, `grep`, `sg`, and `edit` project both chat text and `details.ptcValue` from the same underlying semantics instead of maintaining parallel output implementations.

## What changed
- added shared canonical output primitives for lines, warnings, ranges, grouped file results, and edit result summaries
- introduced shared output builders for `read`, `grep`, `sg`, and `edit`
- routed each tool to return text and `ptcValue` from the same builder call
- preserved raw-content hashing/anchors while keeping control-character rendering display-safe
- added regression coverage to keep human-facing output and structured output aligned

## Verification
- `npm test`
- `npm run typecheck`
- targeted vitest suites for shared primitives and read/grep/sg/edit output alignment

Closes #55
