### PR TITLE
feat: hashline-ptc native integration — inline runtime ptc metadata and policy alignment

### DIFF
--- a/src/edit.ts
+++ b/src/edit.ts
@@ -51,12 +51,21 @@ const EDIT_DESC = readFileSync(new URL("../prompts/edit.md", import.meta.url), "
 // ─── Registration ───────────────────────────────────────────────────────
 
 export function registerEditTool(pi: ExtensionAPI): void {
-	pi.registerTool({
+	const ptc = {
+		callable: true,
+		enabled: true,
+		policy: "mutating" as const,
+		readOnly: false,
+		pythonName: "edit",
+		defaultExposure: "not-safe-by-default" as const,
+	};
+
+	const tool = {
 		name: "edit",
 		label: "Edit",
 		description: EDIT_DESC,
 		parameters: hashlineEditSchema,
-
+		ptc,
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 			await ensureHashInit();
 			const parsed = params as HashlineParams;
@@ -261,5 +270,7 @@ export function registerEditTool(pi: ExtensionAPI): void {
 				},
 			};
 		},
-	});
+	} satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
+
+	pi.registerTool(tool);
 }

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -247,16 +247,26 @@ function escapeForRegex(s: string): string {
 }
 
 export function registerGrepTool(pi: ExtensionAPI): void {
-	pi.registerTool({
+	const ptc = {
+		callable: true,
+		enabled: true,
+		policy: "read-only" as const,
+		readOnly: true,
+		pythonName: "grep",
+		defaultExposure: "safe-by-default" as const,
+	};
+
+	const tool = {
 		name: "grep",
 		label: "grep",
 		description: GREP_DESC,
 		parameters: grepSchema,
-
+		ptc,
 		async execute(toolCallId, params, signal, onUpdate, ctx) {
 			await ensureHashInit();
+			const p = params as GrepParams;
 			const builtin = createGrepTool(ctx.cwd);
-			const result = await builtin.execute(toolCallId, params, signal, onUpdate);
+			const result = await builtin.execute(toolCallId, p, signal, onUpdate);
 
 			const textBlock = result.content?.find(
 				(item): item is { type: "text"; text: string } =>
@@ -264,7 +274,7 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 			);
 			if (!textBlock?.text) return result;
 
-			const { path: rawSearchPath } = params as GrepParams;
+			const { path: rawSearchPath } = p;
 			const searchPath = resolveToCwd(rawSearchPath || ".", ctx.cwd);
 
 			let searchPathIsDirectory = false;
@@ -280,7 +290,7 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 				try {
 					const buf = await fsReadFile(searchPath);
 					if (looksLikeBinary(buf)) {
-						const warning = `[Warning: '${params.path ?? searchPath}' appears to be a binary file — grep skips binary files by default. Use a hex tool or the read tool to inspect it.]`;
+						const warning = `[Warning: '${p.path ?? searchPath}' appears to be a binary file — grep skips binary files by default. Use a hex tool or the read tool to inspect it.]`;
 						return {
 							...result,
 							content: result.content.map((item) =>
@@ -290,7 +300,7 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 								...(typeof result.details === "object" && result.details !== null ? result.details : {}),
 								ptcValue: {
 									tool: "grep",
-									summary: !!params.summary,
+									summary: !!p.summary,
 									totalMatches: 0,
 									records: [],
 								},
@@ -357,7 +367,7 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 				// parsed.kind === "match"; context lines are irrelevant here (rg won’t
 				// produce them for bare-CR files in any meaningful way).
 				if (parsed.kind === "match" && bareCRFiles.has(absolute)) {
-					const gp = params as GrepParams;
+					const gp = p;
 					const flags = gp.ignoreCase ? "i" : "";
 					let patternRe: RegExp | null = null;
 					try {
@@ -426,7 +436,7 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 						hashlineWarning: warning,
 						ptcValue: {
 							tool: "grep",
-							summary: !!params.summary,
+							summary: !!p.summary,
 							totalMatches: 0,
 							records: [],
 						},
@@ -439,7 +449,7 @@ export function registerGrepTool(pi: ExtensionAPI): void {
 				file.lines = deduplicateContext(file.lines);
 			}
 			const truncatedIR = truncateGrepIR(grepIR);
-			const { summary, limit } = params as GrepParams;
+			const { summary, limit } = p;
 			const effectiveLimit = limit ?? 100;
 			const outputIR = summary
 				? {
@@ -492,5 +502,7 @@ return {
 	},
 };
 		},
-	});
+	} satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
+
+	pi.registerTool(tool);
 }

--- a/src/ptc-tool-policy.ts
+++ b/src/ptc-tool-policy.ts
@@ -25,28 +25,28 @@ export const HASHLINE_TOOL_PTC_POLICY: HashlineToolPtcPolicy = {
   tools: {
     read: {
       toolName: "read",
-      helperName: "hashline-read",
+      helperName: "read",
       overridesBuiltin: true,
       mutability: "read-only",
       defaultExposure: "safe-by-default",
     },
     grep: {
       toolName: "grep",
-      helperName: "hashline-grep",
+      helperName: "grep",
       overridesBuiltin: true,
       mutability: "read-only",
       defaultExposure: "safe-by-default",
     },
     sg: {
       toolName: "sg",
-      helperName: "hashline-sg",
+      helperName: "sg",
       overridesBuiltin: false,
       mutability: "read-only",
       defaultExposure: "opt-in",
     },
     edit: {
       toolName: "edit",
-      helperName: "hashline-edit",
+      helperName: "edit",
       overridesBuiltin: true,
       mutability: "mutating",
       defaultExposure: "not-safe-by-default",

--- a/src/read.ts
+++ b/src/read.ts
@@ -25,8 +25,25 @@ const READ_DESC = readFileSync(new URL("../prompts/read.md", import.meta.url), "
 	.replaceAll("{{DEFAULT_MAX_BYTES}}", formatSize(DEFAULT_MAX_BYTES))
 	.trim();
 
+interface ReadParams {
+	path: string;
+	offset?: number;
+	limit?: number;
+	symbol?: string;
+	map?: boolean;
+}
+
 export function registerReadTool(pi: ExtensionAPI): void {
-	pi.registerTool({
+	const ptc = {
+		callable: true,
+		enabled: true,
+		policy: "read-only" as const,
+		readOnly: true,
+		pythonName: "read",
+		defaultExposure: "safe-by-default" as const,
+	};
+
+	const tool = {
 		name: "read",
 		label: "Read",
 		description: READ_DESC,
@@ -37,15 +54,16 @@ export function registerReadTool(pi: ExtensionAPI): void {
 			symbol: Type.Optional(Type.String({ description: "Symbol to read (e.g., functionName or ClassName.methodName)" })),
 			map: Type.Optional(Type.Boolean({ description: "Append structural map to output (cannot combine with symbol)" })),
 		}),
-
+		ptc,
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 			await ensureHashInit();
-			const rawPath = params.path.replace(/^@/, "");
+			const p = params as ReadParams;
+			const rawPath = p.path.replace(/^@/, "");
 			const absolutePath = resolveToCwd(rawPath, ctx.cwd);
 
 			throwIfAborted(signal);
 
-			if (params.symbol && (params.offset !== undefined || params.limit !== undefined)) {
+			if (p.symbol && (p.offset !== undefined || p.limit !== undefined)) {
 				return {
 					content: [{ type: "text", text: "Cannot combine symbol with offset/limit. Use one or the other." }],
 					isError: true,
@@ -53,7 +71,7 @@ export function registerReadTool(pi: ExtensionAPI): void {
 				};
 			}
 
-			if (params.map && params.symbol) {
+			if (p.map && p.symbol) {
 				return {
 					content: [{ type: "text", text: "Cannot combine map with symbol. Use one or the other." }],
 					isError: true,
@@ -66,7 +84,7 @@ export function registerReadTool(pi: ExtensionAPI): void {
 			const ext = rawPath.split(".").pop()?.toLowerCase() ?? "";
 			if (["jpg", "jpeg", "png", "gif", "webp", "bmp", "svg"].includes(ext)) {
 				const builtinRead = createReadTool(ctx.cwd);
-				return builtinRead.execute(_toolCallId, params, signal, _onUpdate);
+				return builtinRead.execute(_toolCallId, p, signal, _onUpdate);
 			}
 
 			throwIfAborted(signal);
@@ -110,35 +128,35 @@ export function registerReadTool(pi: ExtensionAPI): void {
 			const total = allLines.length;
 			const structuredWarnings: PtcWarning[] = [];
 
-			let startLine = params.offset ? Math.max(1, params.offset) : 1;
-			let endIdx = params.limit ? Math.min(startLine - 1 + params.limit, total) : total;
-			if (params.offset && startLine > total) {
+			let startLine = p.offset ? Math.max(1, p.offset) : 1;
+			let endIdx = p.limit ? Math.min(startLine - 1 + p.limit, total) : total;
+			if (p.offset && startLine > total) {
 				return {
-					content: [{ type: "text", text: `[offset ${params.offset} is past end of file (${total} lines)]` }],
+					content: [{ type: "text", text: `[offset ${p.offset} is past end of file (${total} lines)]` }],
 					isError: true,
 					details: {},
 				};
 			}
 			let symbolMatch: SymbolMatch | undefined;
 			let symbolWarning: string | undefined;
-			if (params.symbol) {
+			if (p.symbol) {
 				const fileMap = await getOrGenerateMap(absolutePath);
 				if (!fileMap) {
 					const extLabel = ext || "unknown";
 					symbolWarning = `[Warning: symbol lookup not available for .${extLabel} files — showing full file]\n\n`;
 				} else {
-					const lookup = findSymbol(fileMap, params.symbol);
+					const lookup = findSymbol(fileMap, p.symbol);
 					if (lookup.type === "ambiguous") {
 						const lines = lookup.candidates.map(
 							(c) => `- ${c.name} (${c.kind}) — lines ${c.startLine}-${c.endLine}`,
 						);
-						const hints = lookup.candidates.map((c) => `${params.symbol}@${c.startLine}`).join(" or ");
+						const hints = lookup.candidates.map((c) => `${p.symbol}@${c.startLine}`).join(" or ");
 						return {
 							content: [
 								{
 									type: "text",
 									text: [
-										`Symbol '${params.symbol}' is ambiguous.`,
+										`Symbol '${p.symbol}' is ambiguous.`,
 										"Matches:",
 										...lines,
 										`Use ${hints} to select by start line.`,
@@ -154,7 +172,7 @@ export function registerReadTool(pi: ExtensionAPI): void {
 							.slice(0, 20)
 							.map((s) => s.name)
 							.join(", ");
-						symbolWarning = `[Warning: symbol '${params.symbol}' not found. Available symbols: ${available}]\n\n`;
+						symbolWarning = `[Warning: symbol '${p.symbol}' not found. Available symbols: ${available}]\n\n`;
 					}
 					if (lookup.type === "found") {
 						startLine = Math.max(1, lookup.symbol.startLine);
@@ -183,10 +201,10 @@ export function registerReadTool(pi: ExtensionAPI): void {
 				text += `\n\n[Showing lines ${startLine}-${endIdx} of ${total}. Use offset=${endIdx + 1} to continue.]`;
 			}
 
-			// Append structural map: on-demand (params.map) or auto on truncated full-file reads
+			// Append structural map: on-demand (p.map) or auto on truncated full-file reads
 			const shouldAppendMap =
-				!!params.map ||
-				(!!truncation.truncated && !params.offset && !params.limit && !symbolMatch);
+				!!p.map ||
+				(!!truncation.truncated && !p.offset && !p.limit && !symbolMatch);
 			let appendedMap = false;
 			let mapText: string | null = null;
 			if (shouldAppendMap) {
@@ -203,7 +221,7 @@ export function registerReadTool(pi: ExtensionAPI): void {
 				}
 			}
 
-			if (params.symbol && symbolMatch) {
+			if (p.symbol && symbolMatch) {
 				const parentInfo = symbolMatch.parentName ? ` in ${symbolMatch.parentName}` : "";
 				text = `[Symbol: ${symbolMatch.name} (${symbolMatch.kind})${parentInfo}, lines ${symbolMatch.startLine}-${symbolMatch.endLine} of ${total}]\n\n${text}`;
 			}
@@ -243,7 +261,7 @@ const readOutput = buildReadOutput({
 	continuation: !truncation.truncated && endIdx < total ? { nextOffset: endIdx + 1 } : null,
 	symbol: symbolMatch
 		? {
-				query: params.symbol ?? symbolMatch.name,
+				query: p.symbol ?? symbolMatch.name,
 				name: symbolMatch.name,
 				kind: symbolMatch.kind,
 				parentName: symbolMatch.parentName,
@@ -252,7 +270,7 @@ const readOutput = buildReadOutput({
 			}
 		: null,
 	map: {
-		requested: !!params.map,
+		requested: !!p.map,
 		appended: appendedMap,
 		text: mapText,
 	},
@@ -266,5 +284,7 @@ return {
 	},
 };
 		},
-	});
+	} satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
+
+	pi.registerTool(tool);
 }

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -68,7 +68,16 @@ function execFileText(
 }
 
 export function registerSgTool(pi: ExtensionAPI): void {
-  pi.registerTool({
+  const ptc = {
+    callable: true,
+    enabled: true,
+    policy: "read-only" as const,
+    readOnly: true,
+    pythonName: "sg",
+    defaultExposure: "opt-in" as const,
+  };
+
+  const tool = {
     name: "sg",
     label: "AST Grep",
     description: SG_DESC,
@@ -77,7 +86,7 @@ export function registerSgTool(pi: ExtensionAPI): void {
       lang: Type.Optional(Type.String({ description: "Language hint for ast-grep (e.g. 'typescript')" })),
       path: Type.Optional(Type.String({ description: "Directory or file to search (default: cwd)" })),
     }),
-
+    ptc,
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       await ensureHashInit();
       const p = params as SgParams;
@@ -203,5 +212,7 @@ export function registerSgTool(pi: ExtensionAPI): void {
         };
       }
     },
-  });
+  } satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
+
+  pi.registerTool(tool);
 }

--- a/tests/hashline-runtime-ptc-read-grep.test.ts
+++ b/tests/hashline-runtime-ptc-read-grep.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+
+async function captureTools() {
+  const { registerReadTool } = await import("../src/read.js");
+  const { registerGrepTool } = await import("../src/grep.js");
+  const tools: Record<string, any> = {};
+  const pi = {
+    registerTool(def: any) {
+      tools[def.name] = def;
+    },
+  };
+  registerReadTool(pi as any);
+  registerGrepTool(pi as any);
+  return tools;
+}
+
+describe("hashline runtime ptc metadata — read and grep", () => {
+  it("registers safe-by-default read-only callable metadata for read and grep", async () => {
+    const tools = await captureTools();
+    expect(tools.read.ptc).toEqual({
+      callable: true,
+      enabled: true,
+      policy: "read-only",
+      readOnly: true,
+      pythonName: "read",
+      defaultExposure: "safe-by-default",
+    });
+    expect(tools.grep.ptc).toEqual({
+      callable: true,
+      enabled: true,
+      policy: "read-only",
+      readOnly: true,
+      pythonName: "grep",
+      defaultExposure: "safe-by-default",
+    });
+  });
+});

--- a/tests/hashline-runtime-ptc-sg-edit.test.ts
+++ b/tests/hashline-runtime-ptc-sg-edit.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+
+async function captureTools() {
+  const { registerSgTool } = await import("../src/sg.js");
+  const { registerEditTool } = await import("../src/edit.js");
+  const tools: Record<string, any> = {};
+  const pi = {
+    registerTool(def: any) {
+      tools[def.name] = def;
+    },
+  };
+  registerSgTool(pi as any);
+  registerEditTool(pi as any);
+  return tools;
+}
+
+describe("hashline runtime ptc metadata — sg and edit", () => {
+  it("registers opt-in metadata for sg and mutating metadata for edit", async () => {
+    const tools = await captureTools();
+    expect(tools.sg.ptc).toEqual({
+      callable: true,
+      enabled: true,
+      policy: "read-only",
+      readOnly: true,
+      pythonName: "sg",
+      defaultExposure: "opt-in",
+    });
+    expect(tools.edit.ptc).toEqual({
+      callable: true,
+      enabled: true,
+      policy: "mutating",
+      readOnly: false,
+      pythonName: "edit",
+      defaultExposure: "not-safe-by-default",
+    });
+  });
+});

--- a/tests/ptc-tool-policy.test.ts
+++ b/tests/ptc-tool-policy.test.ts
@@ -1,43 +1,72 @@
 import { describe, it, expect } from "vitest";
+import { registerReadTool } from "../src/read.js";
+import { registerGrepTool } from "../src/grep.js";
+import { registerSgTool } from "../src/sg.js";
+import { registerEditTool } from "../src/edit.js";
+import { HASHLINE_TOOL_PTC_POLICY, getHashlineToolPtcPolicy } from "../src/ptc-tool-policy.js";
+
+function captureTools() {
+  const tools: Record<string, any> = {};
+  const pi = {
+    registerTool(def: any) {
+      tools[def.name] = def;
+    },
+  };
+  registerReadTool(pi as any);
+  registerGrepTool(pi as any);
+  registerSgTool(pi as any);
+  registerEditTool(pi as any);
+  return tools;
+}
 
 describe("hashline tool ptc policy contract", () => {
-  it("exports canonical tool policies with exact policy tiers and a versioned minimal shape", async () => {
-    const mod = await import("../src/ptc-tool-policy.js");
-
-    expect(mod.getHashlineToolPtcPolicy()).toBe(mod.HASHLINE_TOOL_PTC_POLICY);
-    expect(Object.keys(mod.HASHLINE_TOOL_PTC_POLICY.tools)).toEqual(["read", "grep", "sg", "edit"]);
-    expect(mod.HASHLINE_TOOL_PTC_POLICY).toEqual({
+  it("mirrors the inline runtime ptc metadata for all hashline tools", () => {
+    const tools = captureTools();
+    expect(getHashlineToolPtcPolicy()).toBe(HASHLINE_TOOL_PTC_POLICY);
+    expect(HASHLINE_TOOL_PTC_POLICY).toEqual({
       version: 1,
       tools: {
         read: {
           toolName: "read",
-          helperName: "hashline-read",
+          helperName: "read",
           overridesBuiltin: true,
           mutability: "read-only",
           defaultExposure: "safe-by-default",
         },
         grep: {
           toolName: "grep",
-          helperName: "hashline-grep",
+          helperName: "grep",
           overridesBuiltin: true,
           mutability: "read-only",
           defaultExposure: "safe-by-default",
         },
         sg: {
           toolName: "sg",
-          helperName: "hashline-sg",
+          helperName: "sg",
           overridesBuiltin: false,
           mutability: "read-only",
           defaultExposure: "opt-in",
         },
         edit: {
           toolName: "edit",
-          helperName: "hashline-edit",
+          helperName: "edit",
           overridesBuiltin: true,
           mutability: "mutating",
           defaultExposure: "not-safe-by-default",
         },
       },
     });
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.read.helperName).toBe(tools.read.ptc.pythonName);
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.grep.helperName).toBe(tools.grep.ptc.pythonName);
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.sg.helperName).toBe(tools.sg.ptc.pythonName);
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.edit.helperName).toBe(tools.edit.ptc.pythonName);
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.read.mutability).toBe(tools.read.ptc.policy);
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.grep.mutability).toBe(tools.grep.ptc.policy);
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.sg.mutability).toBe(tools.sg.ptc.policy);
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.edit.mutability).toBe(tools.edit.ptc.policy);
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.read.defaultExposure).toBe(tools.read.ptc.defaultExposure);
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.grep.defaultExposure).toBe(tools.grep.ptc.defaultExposure);
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.sg.defaultExposure).toBe(tools.sg.ptc.defaultExposure);
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.edit.defaultExposure).toBe(tools.edit.ptc.defaultExposure);
   });
 });


### PR DESCRIPTION
## Summary

Makes `pi-hashline-readmap` and `pi-ptc-next` behave as one native stack for Python-driven hashline workflows.

### Changes (pi-hashline-readmap)

- **Inline runtime PTC metadata** on `read`, `grep`, `sg`, `edit` tool definitions with `callable`/`policy`/`pythonName`/`defaultExposure` fields
- **Policy alignment** — `HASHLINE_TOOL_PTC_POLICY` helper names updated from `hashline-read` → `read` etc. to match runtime metadata
- **Drift-guard test** expanded to cross-check exported policy against captured runtime tool metadata for all 4 tools
- **New test files**: `hashline-runtime-ptc-read-grep.test.ts`, `hashline-runtime-ptc-sg-edit.test.ts`

### Backward Compatibility

- Both `enabled`/`callable` and `readOnly`/`policy` fields coexist for legacy consumer support
- No changes to `content[].text` output or edit/search semantics

### Tests

- pi-hashline-readmap: 87 files, 419 tests, 0 failures, typecheck clean
- pi-ptc-next: 70 tests, 0 failures

Batch issue #056 (sources: #053, #054, #055)