### PR TITLE
feat: emit tool executors on EventBus for PTC consumption

### DIFF
--- a/.megapowers/CHANGELOG.md
+++ b/.megapowers/CHANGELOG.md
@@ -207,3 +207,24 @@ The original PR/branch history is still valid historical context, but #039 shoul
 ### Tests
 - Added dedicated regression coverage for the canonical contract, package-root export, and README policy documentation
 - Verified with `npm test` and `npm run typecheck` → 79 passing files / 402 passing tests
+
+## Issue #056 (Batch): Hashline + PTC Native Integration — CLOSED ✅
+**Date**: 2026-03-18
+**Source Issues**: #053 (ptcValue payloads), #054 (PTC metadata), #055 (shared IR)
+### Added
+- Inline runtime `ptc` metadata on `read`, `grep`, `sg`, `edit` tool definitions with callable/policy/pythonName/defaultExposure fields, backward-compatible with legacy `enabled`/`readOnly` (#056)
+- Runtime metadata discovery in pi-ptc-next ToolRegistry — discovers hashline tool eligibility from active tools' inline `ptc` metadata instead of hard-coded contracts (#056)
+- Active tool override execution — nested `code_execution` calls the hashline implementations directly when overrides are active (#056)
+- `details.ptcValue` passthrough in pi-ptc-next — structured values returned to Python unchanged without text parsing (#056)
+- `defaultExposure: "opt-in"` gating — `sg` requires explicit `PTC_CALLABLE_TOOLS` inclusion (#056)
+- `read` Python helper expanded with `symbol` and `map` keyword arguments (#056)
+- Full TypedDict models: `ReadResult`, `GrepResult`, `SgResult`, `AnchoredEditResult`, `EditNoop` (#056)
+- Live contract tests for read/grep/sg/edit that fail if TypedDict or README examples drift from real payloads (#056)
+- Real interop harness: sg → read(symbol) → edit → grep through CodeExecutor against actual pi-hashline-readmap (#056)
+### Fixed
+- Flaky `CustomToolManager` reload test — added polling fallback (mtime+size signatures at 250ms) for when `fs.watch` drops events (#056)
+- Policy drift-guard test now cross-checks `read.defaultExposure` alongside grep/sg/edit (#056)
+- Indentation fix on `reconcileFile` closing brace in pi-ptc-next (#056)
+### Tests
+- pi-hashline-readmap: 87 files, 419 tests, 0 failures
+- pi-ptc-next: 70 tests, 0 failures (up from ~55)

--- a/.megapowers/state.json
+++ b/.megapowers/state.json
@@ -1,70 +1,51 @@
 {
   "version": 1,
-  "activeIssue": "055-refactor-hashline-tool-outputs-around-a-",
+  "activeIssue": "057-emit-tool-executors-on-eventbus-for-ptc-",
   "workflow": "feature",
   "phase": "done",
   "phaseHistory": [
     {
       "from": "brainstorm",
       "to": "spec",
-      "timestamp": 1773779508009
+      "timestamp": 1773863299619
     },
     {
       "from": "spec",
       "to": "plan",
-      "timestamp": 1773781162768
+      "timestamp": 1773863333889
     },
     {
       "from": "plan",
       "to": "implement",
-      "timestamp": 1773787876911
+      "timestamp": 1773863373428
     },
     {
       "from": "implement",
       "to": "verify",
-      "timestamp": 1773792328263
+      "timestamp": 1773863751436
     },
     {
       "from": "verify",
       "to": "code-review",
-      "timestamp": 1773794379100
+      "timestamp": 1773863795125
     },
     {
       "from": "code-review",
       "to": "done",
-      "timestamp": 1773795052067
+      "timestamp": 1773863831813
     }
   ],
   "planMode": null,
-  "planIteration": 3,
-  "currentTaskIndex": 14,
+  "planIteration": 1,
+  "currentTaskIndex": 1,
   "completedTasks": [
     1,
-    2,
-    3,
-    4,
-    5,
-    6,
-    7,
-    8,
-    9,
-    10,
-    11,
-    12,
-    13,
-    14,
-    15
+    2
   ],
   "tddTaskState": null,
-  "doneActions": [
-    "generate-docs",
-    "write-changelog",
-    "capture-learnings",
-    "push-and-pr",
-    "close-issue"
-  ],
-  "doneChecklistShown": true,
+  "doneActions": [],
+  "doneChecklistShown": false,
   "megaEnabled": true,
-  "branchName": "feat/055-refactor-hashline-tool-outputs-around-a-",
+  "branchName": "feat/057-emit-tool-executors-on-eventbus-for-ptc-",
   "baseBranch": "main"
 }

--- a/index.ts
+++ b/index.ts
@@ -24,11 +24,20 @@ export type {
 const BASH_FILTER_ENABLED = true;
 
 export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
-  registerReadTool(pi);
-  registerEditTool(pi);
-  registerGrepTool(pi);
-  registerSgTool(pi);
+  const readTool = registerReadTool(pi);
+  const editTool = registerEditTool(pi);
+  const grepTool = registerGrepTool(pi);
+  const sgTool = registerSgTool(pi);
 
+  const toolExecutors = {
+    read: readTool,
+    edit: editTool,
+    grep: grepTool,
+    sg: sgTool,
+  };
+
+  (globalThis as any).__hashlineToolExecutors = toolExecutors;
+  pi.events.emit("hashline:tool-executors", toolExecutors);
   pi.on("tool_result", (event) => {
     if (!isBashToolResult(event)) {
       return undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",
@@ -201,9 +201,9 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1009.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1009.0.tgz",
-      "integrity": "sha512-0k9d0oO6nw3Y6jtgs1cmMPNuwAVPQahIoshKK3NDfhVQR1wNC90/gSpdfa9GKswe8XRq/ZZlq7ny0qM1rd/Hkg==",
+      "version": "3.1011.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1011.0.tgz",
+      "integrity": "sha512-yn5oRLLP1TsGLZqlnyqBjAVmiexYR8/rPG8D+rI5f5+UIvb3zHOmHLXA1m41H/sKXI4embmXfUjvArmjTmfsIw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -219,7 +219,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.21",
         "@aws-sdk/middleware-websocket": "^3.972.13",
         "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/token-providers": "3.1009.0",
+        "@aws-sdk/token-providers": "3.1011.0",
         "@aws-sdk/types": "^3.973.6",
         "@aws-sdk/util-endpoints": "^3.996.5",
         "@aws-sdk/util-user-agent-browser": "^3.972.8",
@@ -253,6 +253,25 @@
         "@smithy/util-retry": "^4.2.12",
         "@smithy/util-stream": "^4.5.19",
         "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1011.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1011.0.tgz",
+      "integrity": "sha512-WSfBVDQ9uyh1GCR+DxxgHEvAKv+beMIlSeJ2pMAG1HTci340+xbtz1VFwnTJ5qCxrMi+E4dyDMiSAhDvHnq73A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3727,9 +3746,9 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
-      "integrity": "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==",
+      "version": "21.3.3",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.3.tgz",
+      "integrity": "sha512-pNwbwz8c3aZ+GvbJnIsCnDjKvgCZLHxkFWLEFxU3RMa+Ey++ZSEfisvsWQMcdys6PpxQjWUOIDi1fifXsW3YRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -50,7 +50,7 @@ const EDIT_DESC = readFileSync(new URL("../prompts/edit.md", import.meta.url), "
 
 // ─── Registration ───────────────────────────────────────────────────────
 
-export function registerEditTool(pi: ExtensionAPI): void {
+export function registerEditTool(pi: ExtensionAPI) {
 	const ptc = {
 		callable: true,
 		enabled: true,
@@ -273,4 +273,5 @@ export function registerEditTool(pi: ExtensionAPI): void {
 	} satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
 
 	pi.registerTool(tool);
+	return tool;
 }

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -246,7 +246,7 @@ function escapeForRegex(s: string): string {
 	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-export function registerGrepTool(pi: ExtensionAPI): void {
+export function registerGrepTool(pi: ExtensionAPI) {
 	const ptc = {
 		callable: true,
 		enabled: true,
@@ -505,4 +505,5 @@ return {
 	} satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
 
 	pi.registerTool(tool);
+	return tool;
 }

--- a/src/read.ts
+++ b/src/read.ts
@@ -33,7 +33,7 @@ interface ReadParams {
 	map?: boolean;
 }
 
-export function registerReadTool(pi: ExtensionAPI): void {
+export function registerReadTool(pi: ExtensionAPI) {
 	const ptc = {
 		callable: true,
 		enabled: true,
@@ -287,4 +287,5 @@ return {
 	} satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
 
 	pi.registerTool(tool);
+	return tool;
 }

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -67,7 +67,7 @@ function execFileText(
   });
 }
 
-export function registerSgTool(pi: ExtensionAPI): void {
+export function registerSgTool(pi: ExtensionAPI) {
   const ptc = {
     callable: true,
     enabled: true,
@@ -215,4 +215,5 @@ export function registerSgTool(pi: ExtensionAPI): void {
   } satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
 
   pi.registerTool(tool);
+  return tool;
 }

--- a/tests/bash-filter-integration.test.ts
+++ b/tests/bash-filter-integration.test.ts
@@ -26,6 +26,7 @@ describe("bash filter integration", () => {
       on(event: string, handler: Function) {
         handlers[event] = handler;
       },
+      events: { emit() {}, on() {} },
     };
 
     mod.default(mockPi as any);
@@ -59,6 +60,7 @@ describe("savings logging", () => {
       on(event: string, handler: Function) {
         handlers[event] = handler;
       },
+      events: { emit() {}, on() {} },
     };
 
     const bashEvent = makeEvent("bash", "t-log", { command: "echo hello" }, "\x1b[32mhello\x1b[0m");

--- a/tests/entry-point.test.ts
+++ b/tests/entry-point.test.ts
@@ -27,6 +27,7 @@ describe("extension entry point (AC8)", () => {
         tools.push(def.name);
       },
       on() {},
+      events: { emit() {}, on() {} },
     };
     mod.default(mockPi as any);
     expect(tools).toContain("sg");

--- a/tests/ptc-value-shared-output.test.ts
+++ b/tests/ptc-value-shared-output.test.ts
@@ -24,6 +24,22 @@ describe("ptc-value shared primitives", () => {
     expect((ptc as any).renderPtcLines([line])).toBe(`${line.anchor}|hello\\u0000world`);
   });
 
+  it("builds a batch of canonical line records from a start line and raw strings", () => {
+    const lines = ptc.buildPtcLines(5, ["alpha", "beta", "gamma"]);
+    expect(lines).toHaveLength(3);
+    expect(lines[0].line).toBe(5);
+    expect(lines[0].raw).toBe("alpha");
+    expect(lines[1].line).toBe(6);
+    expect(lines[1].raw).toBe("beta");
+    expect(lines[2].line).toBe(7);
+    expect(lines[2].raw).toBe("gamma");
+    // Each entry is a full PtcLine with anchor
+    for (const l of lines) {
+      expect(l.anchor).toBe(`${l.line}:${l.hash}`);
+      expect(l.display).toBe(l.raw); // no control chars to escape
+    }
+  });
+
   it("builds canonical warnings, ranges, and grouped file payloads", () => {
     expect(typeof (ptc as any).buildPtcWarning).toBe("function");
     expect(typeof (ptc as any).buildPtcRange).toBe("function");

--- a/tests/tool-executor-emit.test.ts
+++ b/tests/tool-executor-emit.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+function createMockPi() {
+  return {
+    registerTool: vi.fn(),
+    events: { emit: vi.fn(), on: vi.fn() },
+    on: vi.fn(),
+  };
+}
+
+describe("index.ts emits and stashes tool executors (task 2)", () => {
+  beforeEach(() => {
+    delete (globalThis as any).__hashlineToolExecutors;
+  });
+
+  it("stashes executors on globalThis with correct keys", async () => {
+    const pi = createMockPi();
+    const { default: init } = await import("../index.js");
+    init(pi as any);
+    const stash = (globalThis as any).__hashlineToolExecutors;
+    expect(stash).toBeDefined();
+    expect(Object.keys(stash).sort()).toEqual(["edit", "grep", "read", "sg"]);
+  });
+
+  it("emit channel is exactly 'hashline:tool-executors'", async () => {
+    const pi = createMockPi();
+    const { default: init } = await import("../index.js");
+    init(pi as any);
+    const emitCall = pi.events.emit.mock.calls.find(
+      (c: any[]) => c[0] === "hashline:tool-executors"
+    );
+    expect(emitCall).toBeDefined();
+    // Payload should be the SAME object reference as globalThis stash
+    expect(emitCall![1]).toBe((globalThis as any).__hashlineToolExecutors);
+  });
+});

--- a/tests/tool-executors.test.ts
+++ b/tests/tool-executors.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+function createMockPi() {
+  return {
+    registerTool: vi.fn(),
+    events: { emit: vi.fn(), on: vi.fn() },
+    on: vi.fn(),
+  };
+}
+
+describe("register functions return tool definitions", () => {
+  it("registerReadTool returns a tool with name, execute, description, parameters", async () => {
+    const { registerReadTool } = await import("../src/read.js");
+    const pi = createMockPi();
+    const tool = registerReadTool(pi as any);
+    expect(tool).toBeDefined();
+    expect(tool.name).toBe("read");
+    expect(typeof tool.execute).toBe("function");
+    expect(typeof tool.description).toBe("string");
+    expect(tool.parameters).toBeDefined();
+  });
+
+  it("registerEditTool returns a tool with name, execute, description, parameters", async () => {
+    const { registerEditTool } = await import("../src/edit.js");
+    const pi = createMockPi();
+    const tool = registerEditTool(pi as any);
+    expect(tool).toBeDefined();
+    expect(tool.name).toBe("edit");
+    expect(typeof tool.execute).toBe("function");
+    expect(typeof tool.description).toBe("string");
+    expect(tool.parameters).toBeDefined();
+  });
+
+  it("registerGrepTool returns a tool with name, execute, description, parameters", async () => {
+    const { registerGrepTool } = await import("../src/grep.js");
+    const pi = createMockPi();
+    const tool = registerGrepTool(pi as any);
+    expect(tool).toBeDefined();
+    expect(tool.name).toBe("grep");
+    expect(typeof tool.execute).toBe("function");
+    expect(typeof tool.description).toBe("string");
+    expect(tool.parameters).toBeDefined();
+  });
+
+  it("registerSgTool returns a tool with name, execute, description, parameters", async () => {
+    const { registerSgTool } = await import("../src/sg.js");
+    const pi = createMockPi();
+    const tool = registerSgTool(pi as any);
+    expect(tool).toBeDefined();
+    expect(tool.name).toBe("sg");
+    expect(typeof tool.execute).toBe("function");
+    expect(typeof tool.description).toBe("string");
+    expect(tool.parameters).toBeDefined();
+  });
+
+  it("pi.registerTool is still called for each tool", async () => {
+    const pi = createMockPi();
+
+    const { registerReadTool } = await import("../src/read.js");
+    const { registerEditTool } = await import("../src/edit.js");
+    const { registerGrepTool } = await import("../src/grep.js");
+    const { registerSgTool } = await import("../src/sg.js");
+
+    registerReadTool(pi as any);
+    registerEditTool(pi as any);
+    registerGrepTool(pi as any);
+    registerSgTool(pi as any);
+
+    expect(pi.registerTool).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe("index.ts emits and stashes tool executors", () => {
+  beforeEach(() => {
+    delete (globalThis as any).__hashlineToolExecutors;
+  });
+
+  it("stashes executors on globalThis.__hashlineToolExecutors", async () => {
+    const pi = createMockPi();
+    const { default: init } = await import("../index.js");
+    init(pi as any);
+    const stash = (globalThis as any).__hashlineToolExecutors;
+    expect(stash).toBeDefined();
+    expect(stash.read).toBeDefined();
+    expect(stash.edit).toBeDefined();
+    expect(stash.grep).toBeDefined();
+    expect(stash.sg).toBeDefined();
+  });
+
+  it("emits on hashline:tool-executors channel", async () => {
+    const pi = createMockPi();
+    const { default: init } = await import("../index.js");
+    init(pi as any);
+    expect(pi.events.emit).toHaveBeenCalledWith(
+      "hashline:tool-executors",
+      expect.objectContaining({
+        read: expect.objectContaining({ name: "read" }),
+        edit: expect.objectContaining({ name: "edit" }),
+        grep: expect.objectContaining({ name: "grep" }),
+        sg: expect.objectContaining({ name: "sg" }),
+      })
+    );
+  });
+
+  it("all stashed tools have callable execute functions", async () => {
+    const pi = createMockPi();
+    const { default: init } = await import("../index.js");
+    init(pi as any);
+    const stash = (globalThis as any).__hashlineToolExecutors;
+    for (const key of ["read", "edit", "grep", "sg"]) {
+      expect(typeof stash[key].execute).toBe("function");
+    }
+  });
+
+  it("globalThis stash and events emit happen in correct order (stash before emit)", async () => {
+    const pi = createMockPi();
+    let stashAtEmitTime: any = undefined;
+    pi.events.emit = vi.fn((_channel: string, _data: unknown) => {
+      stashAtEmitTime = (globalThis as any).__hashlineToolExecutors;
+    });
+    const { default: init } = await import("../index.js");
+    init(pi as any);
+    // globalThis should have been set BEFORE emit was called
+    expect(stashAtEmitTime).toBeDefined();
+    expect(stashAtEmitTime.read).toBeDefined();
+    // This assertion will fail until emit ordering is verified
+    expect(stashAtEmitTime).toBe((globalThis as any).__hashlineToolExecutors);
+  });
+
+  it("emitted payload includes full tool definitions with description and parameters", async () => {
+    const pi = createMockPi();
+    const { default: init } = await import("../index.js");
+    init(pi as any);
+    const payload = pi.events.emit.mock.calls.find(
+      (c: any[]) => c[0] === "hashline:tool-executors"
+    )?.[1] as Record<string, any>;
+    expect(payload).toBeDefined();
+    for (const key of ["read", "edit", "grep", "sg"]) {
+      expect(typeof payload[key].description).toBe("string");
+      expect(payload[key].parameters).toBeDefined();
+      expect(typeof payload[key].execute).toBe("function");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Each `register*Tool` function now returns its full `ToolDefinition` (including `execute`). `index.ts` captures all four, stashes them on `globalThis.__hashlineToolExecutors`, and emits on `pi.events` channel `hashline:tool-executors`.

This bridges the gap until pi ships a `getToolExecutor()` API upstream, allowing pi-ptc-next to call hashline-enhanced tools from `code_execution` instead of falling back to stock builtins.

## Changes
- `src/read.ts`, `src/edit.ts`, `src/grep.ts`, `src/sg.ts`: Remove `: void` return type, add `return tool;`
- `index.ts`: Capture returns, build payload, stash on `globalThis`, emit on EventBus
- 12 new tests across 2 test files
- 3 existing test files updated (mock pi needs `events`)

~18 lines of production code. 432 tests pass, typecheck clean.

Closes #57