### PR TITLE
feat: add renderCall + renderResult TUI rendering to sg tool

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,11 +1,23 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { isBashToolResult } from "@mariozechner/pi-coding-agent";
 import { registerReadTool } from "./src/read.js";
 import { registerEditTool } from "./src/edit.js";
 import { registerGrepTool } from "./src/grep.js";
 import { registerSgTool } from "./src/sg.js";
 import { filterBashOutput } from "./src/rtk/bash-filter.js";
 import { stripAnsi } from "./src/rtk/ansi.js";
+
+// Compatibility note:
+// - Upstream @mariozechner/pi-coding-agent exports isBashToolResult in newer builds.
+// - GSD aliases that package name to its vendored @gsd/pi-coding-agent, whose public
+//   root export surface differs and does not export isBashToolResult.
+// Keep this local guard instead of importing the helper so the extension works in both runtimes.
+function isBashToolResult(event: unknown): event is {
+  toolName: string;
+  input: { command?: string };
+  content: Array<{ type: string; text?: string }>;
+} {
+  return !!event && typeof event === "object" && (event as { toolName?: unknown }).toolName === "bash";
+}
 
 export {
   HASHLINE_TOOL_PTC_POLICY,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "*",
+    "@mariozechner/pi-tui": "*",
     "@sinclair/typebox": "*"
   },
   "devDependencies": {

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -1,4 +1,5 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ToolRenderResultOptions } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import * as cp from "node:child_process";
 import path from "node:path";
@@ -211,6 +212,62 @@ export function registerSgTool(pi: ExtensionAPI) {
           details: {},
         };
       }
+    },
+    renderCall(args: any, theme: any, ...rest: any[]) {
+      const _context = rest[0];
+      let text = theme.fg("toolTitle", theme.bold("sg "));
+      text += theme.fg("accent", args.pattern);
+      if (args.lang) {
+        text += theme.fg("dim", ` (${args.lang})`);
+      }
+      if (args.path && args.path !== ".") {
+        text += theme.fg("dim", ` ${args.path}`);
+      }
+      return new Text(text, 0, 0);
+    },
+    renderResult(result: any, options: ToolRenderResultOptions, theme: any, ...rest: any[]) {
+      const context: { isPartial?: boolean; isError?: boolean; expanded?: boolean; cwd?: string } =
+        rest[0] ?? options ?? {};
+      // In older pi versions, options has expanded/isPartial directly.
+      // In newer pi versions, context (4th arg) has expanded/isPartial/isError.
+      const isPartial = context.isPartial ?? (options as any)?.isPartial ?? false;
+      const isError = context.isError ?? false;
+      const expanded = context.expanded ?? (options as any)?.expanded ?? false;
+      const cwd = context.cwd ?? process.cwd();
+
+      if (isPartial) return new Text(theme.fg("warning", "Searching\u2026"), 0, 0);
+
+      const content = result.content?.[0];
+      const textContent = content?.type === "text" ? content.text : "";
+      if (isError || result.isError) {
+        const firstLine = textContent.split("\n")[0] || "Error";
+        return new Text(theme.fg("error", firstLine), 0, 0);
+      }
+      const ptcValue = (result.details as any)?.ptcValue as
+        | { tool: "sg"; files: Array<{ path: string; lines: any[] }> }
+        | undefined;
+      const files = ptcValue?.files ?? [];
+      if (files.length === 0) {
+        return new Text(theme.fg("muted", "No matches"), 0, 0);
+      }
+      const fileCount = files.length;
+      const totalMatches = files.reduce((sum: number, f: any) => sum + f.lines.length, 0);
+      const matchWord = totalMatches === 1 ? "match" : "matches";
+      const fileWord = fileCount === 1 ? "file" : "files";
+      let text = theme.fg("success", `\u2713 ${totalMatches} ${matchWord} in ${fileCount} ${fileWord}`);
+
+      if (expanded) {
+        const showFiles = files.slice(0, 20);
+        for (const file of showFiles) {
+          const display = path.relative(cwd, file.path) || file.path;
+          text += "\n" + theme.fg("dim", `  ${display} (${file.lines.length})`);
+        }
+        if (files.length > 20) {
+          text += "\n" + theme.fg("muted", `  \u2026 and ${files.length - 20} more files`);
+        }
+      }
+
+      return new Text(text, 0, 0);
     },
   } satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
 


### PR DESCRIPTION
## Summary
The `sg` (AST grep) tool was the only tool with no TUI rendering — it fell through to generic raw text display. This adds `renderCall` and `renderResult` methods.

### renderCall
- Shows bold **sg** + pattern in accent color
- Optional language hint: *(typescript)*
- Optional search path when non-default

### renderResult
- **Partial**: "Searching…" in warning color
- **Error**: first line of error message in red
- **No matches**: muted "No matches"
- **Success (collapsed)**: `✓ 14 matches in 5 files`
- **Success (expanded)**: per-file breakdown with match counts (capped at 20 files)

### Other
- Added `@mariozechner/pi-tui` as peer dependency
- Compatible with both old (0.55) and new (0.62+) pi `ToolDefinition` signatures via `...rest` pattern

### Testing
- `npm run typecheck` ✅
- `npm test` — 89 files, 432 tests, all passing ✅
- TUI rendering requires manual verification in interactive pi