### PR TITLE
feat: add renderCall + renderResult TUI rendering to edit tool

### DIFF
--- a/.megapowers/CHANGELOG.md
+++ b/.megapowers/CHANGELOG.md
@@ -239,3 +239,14 @@ The original PR/branch history is still valid historical context, but #039 shoul
 - 12 new tests across 2 test files (tool-executors.test.ts, tool-executor-emit.test.ts)
 - 3 existing test files updated with `events` mock
 - pi-hashline-readmap: 89 files, 432 tests, 0 failures
+
+## Issue #059: Edit Tool — Add renderCall + renderResult TUI Rendering
+**Date**: 2026-03-23
+
+### Added
+- `renderCall` on edit tool: displays `edit <path>` with edit count and variant breakdown (#059)
+- `renderResult` on edit tool: diff stats, no-op indicator, warnings badge, colored expanded diff (#059)
+- `src/edit-render-helpers.ts`: pure helper functions for testable rendering logic (#059)
+- 14 new unit tests in `tests/edit-render-helpers.test.ts` (#059)
+### Tests
+- pi-hashline-readmap: 90 files, 446 tests, 0 failures

--- a/.megapowers/state.json
+++ b/.megapowers/state.json
@@ -2,15 +2,59 @@
   "version": 1,
   "activeIssue": "059-edit-tool-add-rendercall-renderresult-tu",
   "workflow": "feature",
-  "phase": "brainstorm",
-  "phaseHistory": [],
+  "phase": "done",
+  "phaseHistory": [
+    {
+      "from": "brainstorm",
+      "to": "spec",
+      "timestamp": 1774276173592
+    },
+    {
+      "from": "spec",
+      "to": "plan",
+      "timestamp": 1774276303121
+    },
+    {
+      "from": "plan",
+      "to": "implement",
+      "timestamp": 1774276466544
+    },
+    {
+      "from": "implement",
+      "to": "verify",
+      "timestamp": 1774276824382
+    },
+    {
+      "from": "verify",
+      "to": "code-review",
+      "timestamp": 1774277015608
+    },
+    {
+      "from": "code-review",
+      "to": "done",
+      "timestamp": 1774277291694
+    }
+  ],
   "planMode": null,
-  "planIteration": 0,
-  "currentTaskIndex": 0,
-  "completedTasks": [],
+  "planIteration": 1,
+  "currentTaskIndex": 5,
+  "completedTasks": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6
+  ],
   "tddTaskState": null,
-  "doneActions": [],
-  "doneChecklistShown": false,
+  "doneActions": [
+    "generate-docs",
+    "write-changelog",
+    "capture-learnings",
+    "push-and-pr",
+    "close-issue"
+  ],
+  "doneChecklistShown": true,
   "megaEnabled": true,
   "branchName": null,
   "baseBranch": null

--- a/.megapowers/state.json
+++ b/.megapowers/state.json
@@ -1,57 +1,17 @@
 {
   "version": 1,
-  "activeIssue": "057-emit-tool-executors-on-eventbus-for-ptc-",
+  "activeIssue": "059-edit-tool-add-rendercall-renderresult-tu",
   "workflow": "feature",
-  "phase": "done",
-  "phaseHistory": [
-    {
-      "from": "brainstorm",
-      "to": "spec",
-      "timestamp": 1773863299619
-    },
-    {
-      "from": "spec",
-      "to": "plan",
-      "timestamp": 1773863333889
-    },
-    {
-      "from": "plan",
-      "to": "implement",
-      "timestamp": 1773863373428
-    },
-    {
-      "from": "implement",
-      "to": "verify",
-      "timestamp": 1773863751436
-    },
-    {
-      "from": "verify",
-      "to": "code-review",
-      "timestamp": 1773863795125
-    },
-    {
-      "from": "code-review",
-      "to": "done",
-      "timestamp": 1773863831813
-    }
-  ],
+  "phase": "brainstorm",
+  "phaseHistory": [],
   "planMode": null,
-  "planIteration": 1,
-  "currentTaskIndex": 1,
-  "completedTasks": [
-    1,
-    2
-  ],
+  "planIteration": 0,
+  "currentTaskIndex": 0,
+  "completedTasks": [],
   "tddTaskState": null,
-  "doneActions": [
-    "generate-docs",
-    "write-changelog",
-    "capture-learnings",
-    "push-and-pr",
-    "close-issue"
-  ],
-  "doneChecklistShown": true,
+  "doneActions": [],
+  "doneChecklistShown": false,
   "megaEnabled": true,
-  "branchName": "feat/057-emit-tool-executors-on-eventbus-for-ptc-",
-  "baseBranch": "main"
+  "branchName": null,
+  "baseBranch": null
 }

--- a/src/edit-render-helpers.ts
+++ b/src/edit-render-helpers.ts
@@ -1,0 +1,107 @@
+export interface EditCallTextResult {
+  path: string | null;
+  suffix: string | undefined;
+}
+
+export function formatEditCallText(
+  args: Record<string, unknown> | undefined,
+  argsComplete: boolean,
+): EditCallTextResult {
+  const rawPath = typeof args?.path === "string" ? args.path : null;
+
+  if (!argsComplete) {
+    return { path: rawPath, suffix: undefined };
+  }
+
+  // Hashline edits[] mode
+  if (Array.isArray(args?.edits) && (args!.edits as unknown[]).length > 0) {
+    const editsList = args!.edits as Record<string, unknown>[];
+    const counts: Record<string, number> = {};
+    let total = 0;
+    for (const e of editsList) {
+      if ("set_line" in e) counts["set_line"] = (counts["set_line"] ?? 0) + 1;
+      else if ("replace_lines" in e) counts["replace_lines"] = (counts["replace_lines"] ?? 0) + 1;
+      else if ("insert_after" in e) counts["insert_after"] = (counts["insert_after"] ?? 0) + 1;
+      else if ("replace" in e) counts["replace"] = (counts["replace"] ?? 0) + 1;
+      total++;
+    }
+    const parts: string[] = [];
+    for (const key of ["set_line", "replace_lines", "insert_after", "replace"] as const) {
+      if ((counts[key] ?? 0) > 0) {
+        parts.push(`${counts[key]} ${key}`);
+      }
+    }
+    const word = total === 1 ? "edit" : "edits";
+    const suffix = `${total} ${word} (${parts.join(", ")})`;
+    return { path: rawPath, suffix };
+  }
+
+  // Legacy oldText/newText or old_text/new_text
+  if (
+    args?.oldText !== undefined || args?.old_text !== undefined ||
+    args?.newText !== undefined || args?.new_text !== undefined
+  ) {
+    return { path: rawPath, suffix: "replace" };
+  }
+
+  return { path: rawPath, suffix: undefined };
+}
+
+export interface EditResultTextInput {
+  isError: boolean;
+  diff: string;
+  warnings: string[];
+  noopEdits: unknown[];
+  errorText: string;
+}
+
+export interface EditResultTextOutput {
+  diffStats: string | undefined;
+  noOp: boolean;
+  warningsBadge: string | undefined;
+  errorText: string | undefined;
+}
+
+function parseDiffStats(diff: string): { added: number; removed: number } {
+  let added = 0;
+  let removed = 0;
+  if (!diff) return { added, removed };
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+") && !line.startsWith("+++")) added++;
+    if (line.startsWith("-") && !line.startsWith("---")) removed++;
+  }
+  return { added, removed };
+}
+
+export function formatEditResultText(input: EditResultTextInput): EditResultTextOutput {
+  const { isError, diff, warnings, noopEdits, errorText } = input;
+
+  // No-op detection: error + noopEdits present OR error text contains "No changes made"
+  const isNoOp = isError && (
+    (Array.isArray(noopEdits) && noopEdits.length > 0) ||
+    errorText.includes("No changes made")
+  );
+
+  // Diff stats
+  const stats = parseDiffStats(diff);
+  const hasDiffStats = stats.added > 0 || stats.removed > 0;
+  const diffStats = hasDiffStats ? `+${stats.added} / -${stats.removed}` : undefined;
+
+  // Warnings badge
+  let warningsBadge: string | undefined;
+  if (warnings.length === 1) {
+    warningsBadge = "\u26a0 1 warning";
+  } else if (warnings.length > 1) {
+    warningsBadge = `\u26a0 ${warnings.length} warnings`;
+  }
+
+  // Error text only for error results
+  const showErrorText = isError ? errorText : undefined;
+
+  return {
+    diffStats,
+    noOp: isNoOp,
+    warningsBadge,
+    errorText: showErrorText,
+  };
+}

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, EditToolDetails } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, EditToolDetails, ToolRenderResultOptions } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import type { Static } from "@sinclair/typebox";
 import { readFileSync } from "fs";
@@ -8,6 +8,8 @@ import { applyHashlineEdits, computeLineHash, ensureHashInit, parseLineRef, type
 import { resolveToCwd } from "./path-utils";
 import { throwIfAborted } from "./runtime";
 import { buildEditOutput } from "./edit-output.js";
+import { Text } from "@mariozechner/pi-tui";
+import { formatEditCallText, formatEditResultText } from "./edit-render-helpers.js";
 
 export function wrapWriteError(err: any, path: string): Error {
 	const code = err?.code;
@@ -269,6 +271,84 @@ export function registerEditTool(pi: ExtensionAPI) {
 					};
 				},
 			};
+		},
+		renderCall(args: any, theme: any, ...rest: any[]) {
+			const { path: filePath, suffix } = formatEditCallText(args, true);
+			let text = theme.fg("toolTitle", theme.bold("edit "));
+			if (filePath) {
+				text += theme.fg("accent", filePath);
+			}
+			if (suffix) {
+				text += theme.fg("dim", ` ${suffix}`);
+			}
+			return new Text(text, 0, 0);
+		},
+		renderResult(result: any, options: ToolRenderResultOptions, theme: any, ...rest: any[]) {
+			const context: { isPartial?: boolean; isError?: boolean; expanded?: boolean } =
+				rest[0] ?? options ?? {};
+			const isPartial = context.isPartial ?? (options as any)?.isPartial ?? false;
+			const isError = context.isError ?? false;
+			const expanded = context.expanded ?? (options as any)?.expanded ?? false;
+			if (isPartial) return new Text(theme.fg("warning", "Editing\u2026"), 0, 0);
+			const content = result.content?.[0];
+			const textContent = content?.type === "text" ? content.text : "";
+			const details = result.details as any;
+			const diff: string = details?.diff ?? "";
+			const ptcValue = details?.ptcValue as { warnings?: string[]; noopEdits?: unknown[] } | undefined;
+			const info = formatEditResultText({
+				isError: isError || !!result.isError,
+				diff,
+				warnings: ptcValue?.warnings ?? [],
+				noopEdits: ptcValue?.noopEdits ?? [],
+				errorText: textContent,
+			});
+
+			if (info.noOp) {
+				return new Text(theme.fg("warning", "\u26A0 no-op"), 0, 0);
+			}
+
+			if (info.errorText) {
+				const firstLine = info.errorText.split("\n")[0] || "Error";
+				return new Text(theme.fg("error", firstLine), 0, 0);
+			}
+
+			let text = "";
+			if (info.diffStats) {
+				const [addPart, remPart] = info.diffStats.split(" / ");
+				text = theme.fg("success", addPart);
+				text += theme.fg("dim", " / ");
+				text += theme.fg("error", remPart);
+			} else {
+				text = theme.fg("success", "Applied");
+			}
+
+			if (info.warningsBadge) {
+				text += " " + theme.fg("warning", info.warningsBadge);
+			}
+			if (expanded) {
+				const diffLines = diff ? diff.split("\n") : [];
+				const showLines = diffLines.slice(0, 30);
+				for (const line of showLines) {
+					if (line.startsWith("+") && !line.startsWith("+++")) {
+						text += "\n" + theme.fg("success", line);
+					} else if (line.startsWith("-") && !line.startsWith("---")) {
+						text += "\n" + theme.fg("error", line);
+					} else {
+						text += "\n" + theme.fg("dim", line);
+					}
+				}
+				if (diffLines.length > 30) {
+					text += "\n" + theme.fg("muted", `\u2026 ${diffLines.length - 30} more diff lines`);
+				}
+				const warnings = ptcValue?.warnings ?? [];
+				if (warnings.length > 0) {
+					text += "\n" + theme.fg("warning", "Warnings:");
+					for (const w of warnings) {
+						text += "\n" + theme.fg("warning", `  ${w}`);
+					}
+				}
+			}
+			return new Text(text, 0, 0);
 		},
 	} satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
 

--- a/tests/edit-render-helpers.test.ts
+++ b/tests/edit-render-helpers.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { formatEditCallText, formatEditResultText } from "../src/edit-render-helpers.js";
+
+describe("formatEditCallText", () => {
+  it("returns path-only when argsComplete is false", () => {
+    const result = formatEditCallText({ path: "src/foo.ts" }, false);
+    expect(result).toEqual({ path: "src/foo.ts", suffix: undefined });
+  });
+
+  it("returns placeholder when path is missing", () => {
+    const result = formatEditCallText({}, false);
+    expect(result).toEqual({ path: null, suffix: undefined });
+  });
+
+  it("returns edit breakdown when edits[] is present and args complete", () => {
+    const args = {
+      path: "src/foo.ts",
+      edits: [
+        { set_line: { anchor: "1:ab", new_text: "x" } },
+        { set_line: { anchor: "2:cd", new_text: "y" } },
+        { replace: { old_text: "a", new_text: "b" } },
+      ],
+    };
+    const result = formatEditCallText(args, true);
+    expect(result.path).toBe("src/foo.ts");
+    expect(result.suffix).toBe("3 edits (2 set_line, 1 replace)");
+  });
+
+  it("returns 'replace' for legacy oldText/newText mode", () => {
+    const args = { path: "src/foo.ts", oldText: "a", newText: "b" };
+    const result = formatEditCallText(args, true);
+    expect(result.path).toBe("src/foo.ts");
+    expect(result.suffix).toBe("replace");
+  });
+
+  it("returns 'replace' for legacy old_text/new_text mode", () => {
+    const args = { path: "src/foo.ts", old_text: "a", new_text: "b" };
+    const result = formatEditCallText(args, true);
+    expect(result.path).toBe("src/foo.ts");
+    expect(result.suffix).toBe("replace");
+  });
+
+  it("returns no suffix when args complete but no edits or legacy fields", () => {
+    const result = formatEditCallText({ path: "src/foo.ts" }, true);
+    expect(result).toEqual({ path: "src/foo.ts", suffix: undefined });
+  });
+
+  it("formats single edit without breakdown parenthetical", () => {
+    const args = {
+      path: "src/foo.ts",
+      edits: [{ set_line: { anchor: "1:ab", new_text: "x" } }],
+    };
+    const result = formatEditCallText(args, true);
+    expect(result.suffix).toBe("1 edit (1 set_line)");
+  });
+
+  it("only includes non-zero type counts in breakdown", () => {
+    const args = {
+      path: "src/foo.ts",
+      edits: [
+        { insert_after: { anchor: "1:ab", new_text: "x" } },
+        { insert_after: { anchor: "2:cd", new_text: "y" } },
+      ],
+    };
+    const result = formatEditCallText(args, true);
+    expect(result.suffix).toBe("2 edits (2 insert_after)");
+  });
+});
+
+describe("formatEditResultText", () => {
+  it("returns diff stats for a successful result", () => {
+    const diff = "@@ -1,2 +1,3 @@\n-old\n+new1\n+new2\n ctx";
+    const result = formatEditResultText({
+      isError: false,
+      diff,
+      warnings: [],
+      noopEdits: [],
+      errorText: "",
+    });
+    expect(result.diffStats).toBe("+2 / -1");
+    expect(result.noOp).toBe(false);
+    expect(result.warningsBadge).toBeUndefined();
+    expect(result.errorText).toBeUndefined();
+  });
+
+  it("returns no-op indicator for noop error", () => {
+    const result = formatEditResultText({
+      isError: true,
+      diff: "",
+      warnings: [],
+      noopEdits: [{ editIndex: 0, loc: "1:ab" }],
+      errorText: "No changes made to src/foo.ts. The edits produced identical content.",
+    });
+    expect(result.noOp).toBe(true);
+    expect(result.errorText).toContain("No changes made");
+  });
+
+  it("returns warnings badge singular", () => {
+    const result = formatEditResultText({
+      isError: false,
+      diff: "@@ -1,1 +1,1 @@\n-a\n+b",
+      warnings: ["anchor mismatch on line 5"],
+      noopEdits: [],
+      errorText: "",
+    });
+    expect(result.warningsBadge).toBe("⚠ 1 warning");
+  });
+
+  it("returns warnings badge plural", () => {
+    const result = formatEditResultText({
+      isError: false,
+      diff: "@@ -1,1 +1,1 @@\n-a\n+b",
+      warnings: ["warning1", "warning2", "warning3"],
+      noopEdits: [],
+      errorText: "",
+    });
+    expect(result.warningsBadge).toBe("⚠ 3 warnings");
+  });
+
+  it("returns error text for non-noop errors", () => {
+    const result = formatEditResultText({
+      isError: true,
+      diff: "",
+      warnings: [],
+      noopEdits: [],
+      errorText: "File not found: src/missing.ts",
+    });
+    expect(result.noOp).toBe(false);
+    expect(result.errorText).toBe("File not found: src/missing.ts");
+  });
+
+  it("returns empty diff stats when diff is empty", () => {
+    const result = formatEditResultText({
+      isError: false,
+      diff: "",
+      warnings: [],
+      noopEdits: [],
+      errorText: "",
+    });
+    expect(result.diffStats).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The built-in edit tool's `renderCall` was designed for `oldText/newText` format, so our hashline `edits[]` array never triggered the preview feature — it was silently broken. Similarly, `renderResult` didn't surface hashline-specific diagnostics like no-op edits or anchor warnings.

## Changes

**`src/edit.ts`** — Added `renderCall` and `renderResult` to the tool definition:
- `renderCall`: Shows `edit <path>` with edit count and variant breakdown (e.g., `3 edits (2 set_line, 1 replace)`), legacy `replace` label, or path-only streaming fallback
- `renderResult`: Shows `+N / -M` diff stats, `⚠ no-op` indicator, `⚠ N warnings` badge, colored expanded diff, and streaming/error states
- Both follow the `sg.ts` compat pattern for `options` vs `rest` args across pi versions

**`src/edit-render-helpers.ts`** — Extracted pure helper functions (`formatEditCallText`, `formatEditResultText`) so rendering logic is testable without TUI context.

**`tests/edit-render-helpers.test.ts`** — 14 unit tests covering variant counting, legacy detection, diff stats parsing, no-op detection, and warning badge formatting.

All 446 tests pass, typecheck clean.