### PR TITLE
feat: add renderCall + renderResult TUI rendering to read and grep tools

### DIFF
--- a/.megapowers/CHANGELOG.md
+++ b/.megapowers/CHANGELOG.md
@@ -251,3 +251,15 @@ The original PR/branch history is still valid historical context, but #039 shoul
 ### Tests
 - 23 new unit tests in `tests/edit-render-helpers.test.ts`
 - pi-hashline-readmap: 90 files, 455 tests, 0 failures
+
+## Issue #060: read/grep TUI rendering — CLOSED ✅
+**Date**: 2026-03-23
+
+### Added
+- `renderCall` and `renderResult` methods for the `read` tool — displays path, symbol, map, offset/limit context in call header; line count, symbol badge, map badge, warning badges, and truncation in result summary (#060)
+- `renderCall` and `renderResult` methods for the `grep` tool — displays pattern/path/glob in call header; match/file counts, truncation cap, summary mode badge, binary warning, and per-file distribution on expand (#060)
+- Pure formatting helpers: `src/read-render-helpers.ts`, `src/grep-render-helpers.ts`
+
+### Tests
+- 28 new unit tests across `tests/read-render-helpers.test.ts` and `tests/grep-render-helpers.test.ts`
+- pi-hashline-readmap: 92 files, 483 tests, 0 failures

--- a/src/grep-render-helpers.ts
+++ b/src/grep-render-helpers.ts
@@ -1,0 +1,77 @@
+export interface GrepCallTextResult {
+  pattern: string;
+  suffix: string | undefined;
+}
+
+export function formatGrepCallText(
+  args: Record<string, unknown> | undefined,
+): GrepCallTextResult {
+  const pattern = typeof args?.pattern === "string" ? args.pattern : "";
+
+  const parts: string[] = [];
+  if (typeof args?.path === "string" && args.path !== ".") {
+    parts.push(args.path as string);
+  }
+  if (typeof args?.glob === "string") {
+    parts.push(args.glob as string);
+  }
+
+  return {
+    pattern,
+    suffix: parts.length > 0 ? parts.join(" ") : undefined,
+  };
+}
+
+const GREP_TRUNCATION_THRESHOLD = 50;
+
+export interface GrepResultTextInput {
+  totalMatches: number;
+  summary: boolean;
+  records: unknown[];
+  fileCount: number;
+  hasBinaryWarning?: boolean;
+  isError?: boolean;
+  errorText?: string;
+}
+
+export interface GrepResultTextOutput {
+  summary: string;
+  badges: string[];
+  noMatches: boolean;
+  truncated: boolean;
+  errorText: string | undefined;
+}
+
+export function formatGrepResultText(input: GrepResultTextInput): GrepResultTextOutput {
+  // Error case
+  if (input.isError && input.errorText) {
+    return {
+      summary: "",
+      badges: [],
+      noMatches: false,
+      truncated: false,
+      errorText: input.errorText,
+    };
+  }
+
+  const { totalMatches, summary, fileCount } = input;
+  const noMatches = totalMatches === 0;
+  const truncated = totalMatches >= GREP_TRUNCATION_THRESHOLD;
+
+  const matchWord = totalMatches === 1 ? "match" : "matches";
+  const fileWord = fileCount === 1 ? "file" : "files";
+  const summaryText = noMatches ? "" : `\u2713 ${totalMatches} ${matchWord} in ${fileCount} ${fileWord}`;
+
+  const badges: string[] = [];
+  if (truncated) badges.push("10/file cap");
+  if (summary) badges.push("summary");
+  if (input.hasBinaryWarning) badges.push("\u26a0 binary");
+
+  return {
+    summary: summaryText,
+    badges,
+    noMatches,
+    truncated,
+    errorText: undefined,
+  };
+}

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ToolRenderResultOptions } from "@mariozechner/pi-coding-agent";
 import { createGrepTool } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { readFile as fsReadFile, stat as fsStat } from "fs/promises";
@@ -10,6 +10,8 @@ import { buildPtcLine } from "./ptc-value.js";
 import { buildGrepOutput } from "./grep-output.js";
 import { resolveToCwd } from "./path-utils";
 import { throwIfAborted } from "./runtime";
+import { Text } from "@mariozechner/pi-tui";
+import { formatGrepCallText, formatGrepResultText } from "./grep-render-helpers.js";
 
 const GREP_DESC =
 	"Search file contents for a pattern. Returns matching lines with LINE:HASH anchors for hashline edit workflows.";
@@ -501,6 +503,96 @@ return {
 		ptcValue: builtOutput.ptcValue,
 	},
 };
+		},
+		renderCall(args: any, theme: any, ...rest: any[]) {
+			const _context = rest[0];
+			const { pattern, suffix } = formatGrepCallText(args);
+
+			let text = theme.fg("toolTitle", theme.bold("grep "));
+			text += theme.fg("accent", pattern);
+			if (suffix) {
+				text += theme.fg("dim", ` ${suffix}`);
+			}
+			return new Text(text, 0, 0);
+		},
+		renderResult(result: any, options: ToolRenderResultOptions, theme: any, ...rest: any[]) {
+			const context: { isPartial?: boolean; isError?: boolean; expanded?: boolean; cwd?: string } =
+				rest[0] ?? options ?? {};
+			const isPartial = context.isPartial ?? (options as any)?.isPartial ?? false;
+			const isError = context.isError ?? false;
+			const expanded = context.expanded ?? (options as any)?.expanded ?? false;
+			const cwd = context.cwd ?? process.cwd();
+
+			if (isPartial) return new Text(theme.fg("warning", "Searching\u2026"), 0, 0);
+
+			const content = result.content?.[0];
+			const textContent = content?.type === "text" ? content.text : "";
+
+			if (isError || result.isError) {
+				const firstLine = textContent.split("\n")[0] || "Error";
+				return new Text(theme.fg("error", firstLine), 0, 0);
+			}
+
+			const ptcValue = (result.details as any)?.ptcValue as {
+				tool: "grep";
+				summary: boolean;
+				totalMatches: number;
+				records: Array<{ path: string; kind: string }>;
+			} | undefined;
+
+			const hasBinaryWarning = textContent.includes("appears to be a binary file");
+
+			const fileSet = new Set<string>();
+			for (const r of ptcValue?.records ?? []) {
+				if (r.path) fileSet.add(r.path);
+			}
+
+			const info = formatGrepResultText({
+				totalMatches: ptcValue?.totalMatches ?? 0,
+				summary: ptcValue?.summary ?? false,
+				records: ptcValue?.records ?? [],
+				fileCount: fileSet.size,
+				hasBinaryWarning,
+			});
+
+			if (info.noMatches && !hasBinaryWarning) {
+				return new Text(theme.fg("muted", "No matches"), 0, 0);
+			}
+
+			const parts: string[] = [];
+			if (info.summary) {
+				parts.push(theme.fg(info.truncated ? "warning" : "success", info.summary));
+			}
+
+			for (const badge of info.badges) {
+				if (badge.startsWith("\u26a0")) {
+					parts.push(theme.fg("warning", badge));
+				} else {
+					parts.push(theme.fg("dim", badge));
+				}
+			}
+
+			let text = parts.join("  ") || theme.fg("muted", "No matches");
+
+			if (expanded && ptcValue?.records) {
+				const fileCounts = new Map<string, number>();
+				for (const r of ptcValue.records) {
+					if (r.path && r.kind === "match") {
+						fileCounts.set(r.path, (fileCounts.get(r.path) ?? 0) + 1);
+					}
+				}
+				const entries = [...fileCounts.entries()].sort((a, b) => b[1] - a[1]);
+				const showEntries = entries.slice(0, 20);
+				for (const [filePath, count] of showEntries) {
+					const display = path.relative(cwd, filePath) || filePath;
+					text += "\n" + theme.fg("dim", `  ${display} (${count})`);
+				}
+				if (entries.length > 20) {
+					text += "\n" + theme.fg("muted", `  \u2026 and ${entries.length - 20} more files`);
+				}
+			}
+
+			return new Text(text, 0, 0);
 		},
 	} satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
 

--- a/src/read-render-helpers.ts
+++ b/src/read-render-helpers.ts
@@ -1,0 +1,97 @@
+import type { PtcWarning } from "./ptc-value.js";
+export interface ReadCallTextResult {
+  path: string | null;
+  suffix: string | undefined;
+}
+
+export function formatReadCallText(
+  args: Record<string, unknown> | undefined,
+): ReadCallTextResult {
+  const rawPath = typeof args?.path === "string" ? args.path : null;
+
+  if (typeof args?.symbol === "string" && args.symbol) {
+    return { path: rawPath, suffix: `→ symbol ${args.symbol}` };
+  }
+
+  if (args?.map === true) {
+    return { path: rawPath, suffix: "+ map" };
+  }
+
+  if (typeof args?.offset === "number") {
+    const offset = args.offset as number;
+    const limit = typeof args?.limit === "number" ? (args.limit as number) : undefined;
+    if (limit !== undefined) {
+      return { path: rawPath, suffix: `lines ${offset}-${offset + limit - 1}` };
+    }
+    return { path: rawPath, suffix: `from line ${offset}` };
+  }
+
+  return { path: rawPath, suffix: undefined };
+}
+
+
+export interface ReadResultTextInput {
+  range: { startLine: number; endLine: number; totalLines: number };
+  truncation: { outputLines: number; totalLines: number; outputBytes: number; totalBytes: number } | null;
+  symbol: { query: string; name: string; kind: string; parentName?: string; startLine: number; endLine: number } | null;
+  map: { requested: boolean; appended: boolean };
+  warnings: PtcWarning[];
+  isError?: boolean;
+  errorText?: string;
+}
+
+export interface ReadResultTextOutput {
+  summary: string;
+  symbolBadge: string | undefined;
+  badges: string[];
+  truncated: boolean;
+  errorText: string | undefined;
+}
+
+export function formatReadResultText(input: ReadResultTextInput): ReadResultTextOutput {
+  const { range, truncation, symbol, map, warnings } = input;
+
+  // Error case
+  if (input.isError && input.errorText) {
+    return {
+      summary: "",
+      symbolBadge: undefined,
+      badges: [],
+      truncated: false,
+      errorText: input.errorText,
+    };
+  }
+
+  // Line count
+  const lineCount = range.endLine - range.startLine + 1;
+  const isFullFile = range.startLine === 1 && range.endLine === range.totalLines;
+  const isTruncated = !!truncation;
+
+  let summary: string;
+  if (isTruncated) {
+    summary = `\u2713 ${truncation!.outputLines} of ${truncation!.totalLines} lines (truncated)`;
+  } else if (isFullFile) {
+    summary = `\u2713 ${lineCount} lines`;
+  } else {
+    summary = `\u2713 ${lineCount} lines (${range.startLine}-${range.endLine} of ${range.totalLines})`;
+  }
+
+  // Symbol badge
+  const symbolBadge = symbol ? `${symbol.kind} ${symbol.name}` : undefined;
+
+  // Badges
+  const badges: string[] = [];
+  if (map.appended) badges.push("\ud83d\udcd0 map");
+  for (const w of warnings) {
+    if (w.code === "binary-content") badges.push("\u26a0 binary");
+    if (w.code === "bare-cr") badges.push("\u26a0 bare CR");
+  }
+
+  return {
+    summary,
+    symbolBadge,
+    badges,
+    truncated: isTruncated,
+    errorText: undefined,
+  };
+}

--- a/src/read.ts
+++ b/src/read.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ToolRenderResultOptions } from "@mariozechner/pi-coding-agent";
 import {
 	createReadTool,
 	truncateHead,
@@ -19,6 +19,8 @@ import { getOrGenerateMap } from "./map-cache";
 import { formatFileMapWithBudget } from "./readmap/formatter.js";
 import { findSymbol, type SymbolMatch } from "./readmap/symbol-lookup.js";
 import { buildReadOutput } from "./read-output.js";
+import { Text } from "@mariozechner/pi-tui";
+import { formatReadCallText, formatReadResultText } from "./read-render-helpers.js";
 
 const READ_DESC = readFileSync(new URL("../prompts/read.md", import.meta.url), "utf-8")
 	.replaceAll("{{DEFAULT_MAX_LINES}}", String(DEFAULT_MAX_LINES))
@@ -283,6 +285,87 @@ return {
 		ptcValue: readOutput.ptcValue,
 	},
 };
+		},
+		renderCall(args: any, theme: any, ...rest: any[]) {
+			const _context = rest[0];
+			const { path: filePath, suffix } = formatReadCallText(args);
+
+			let text = theme.fg("toolTitle", theme.bold("read"));
+			if (filePath) {
+				text += ` ${theme.fg("accent", filePath)}`;
+			} else {
+				text += ` ${theme.fg("toolOutput", "...")}`;
+			}
+			if (suffix) {
+				text += ` ${theme.fg("dim", suffix)}`;
+			}
+			return new Text(text, 0, 0);
+		},
+		renderResult(result: any, options: ToolRenderResultOptions, theme: any, ...rest: any[]) {
+			const context: { isPartial?: boolean; isError?: boolean; expanded?: boolean; cwd?: string } =
+				rest[0] ?? options ?? {};
+			const isPartial = context.isPartial ?? (options as any)?.isPartial ?? false;
+			const isError = context.isError ?? false;
+			const expanded = context.expanded ?? (options as any)?.expanded ?? false;
+
+			if (isPartial) return new Text(theme.fg("dim", "Reading\u2026"), 0, 0);
+
+			const content = result.content?.[0];
+			const textContent = content?.type === "text" ? content.text : "";
+
+			if (isError || result.isError) {
+				const firstLine = textContent.split("\n")[0] || "Error";
+				if (expanded) {
+					return new Text(theme.fg("error", textContent || firstLine), 0, 0);
+				}
+				return new Text(theme.fg("error", firstLine), 0, 0);
+			}
+
+			const ptcValue = (result.details as any)?.ptcValue as {
+				tool: "read";
+				range: { startLine: number; endLine: number; totalLines: number };
+				warnings: Array<{ code: string; message: string }>;
+				truncation: { outputLines: number; totalLines: number; outputBytes: number; totalBytes: number } | null;
+				symbol: { query: string; name: string; kind: string; parentName?: string; startLine: number; endLine: number } | null;
+				map: { requested: boolean; appended: boolean };
+			} | undefined;
+
+			if (!ptcValue) {
+				const lines = textContent.split("\n").length;
+				return new Text(theme.fg("success", `\u2713 ${lines} lines`), 0, 0);
+			}
+
+			const info = formatReadResultText({
+				range: ptcValue.range,
+				truncation: ptcValue.truncation,
+				symbol: ptcValue.symbol,
+				map: ptcValue.map,
+				warnings: ptcValue.warnings,
+			});
+
+			const parts: string[] = [];
+
+			if (info.symbolBadge) {
+				parts.push(theme.fg("success", `\u2713 ${info.symbolBadge}`));
+			}
+
+			parts.push(theme.fg(info.truncated ? "warning" : "success", info.summary));
+
+			for (const badge of info.badges) {
+				if (badge.startsWith("\u26a0")) {
+					parts.push(theme.fg("warning", badge));
+				} else {
+					parts.push(theme.fg("dim", badge));
+				}
+			}
+
+			let text = parts.join("  ");
+
+			if (expanded && textContent) {
+				text += "\n" + textContent;
+			}
+
+			return new Text(text, 0, 0);
 		},
 	} satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
 

--- a/tests/grep-render-helpers.test.ts
+++ b/tests/grep-render-helpers.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { formatGrepCallText, formatGrepResultText } from "../src/grep-render-helpers.js";
+
+describe("formatGrepCallText", () => {
+  it("returns pattern only when no path or glob", () => {
+    const result = formatGrepCallText({ pattern: "TODO" });
+    expect(result).toEqual({ pattern: "TODO", suffix: undefined });
+  });
+
+  it("includes path when not '.'", () => {
+    const result = formatGrepCallText({ pattern: "TODO", path: "src/utils" });
+    expect(result).toEqual({ pattern: "TODO", suffix: "src/utils" });
+  });
+
+  it("excludes path when it is '.'", () => {
+    const result = formatGrepCallText({ pattern: "TODO", path: "." });
+    expect(result).toEqual({ pattern: "TODO", suffix: undefined });
+  });
+
+  it("includes glob", () => {
+    const result = formatGrepCallText({ pattern: "TODO", glob: "*.ts" });
+    expect(result).toEqual({ pattern: "TODO", suffix: "*.ts" });
+  });
+
+  it("includes both path and glob", () => {
+    const result = formatGrepCallText({ pattern: "TODO", path: "src", glob: "*.ts" });
+    expect(result).toEqual({ pattern: "TODO", suffix: "src *.ts" });
+  });
+
+  it("returns empty pattern for missing args", () => {
+    const result = formatGrepCallText({});
+    expect(result).toEqual({ pattern: "", suffix: undefined });
+  });
+});
+
+describe("formatGrepResultText", () => {
+  it("returns match and file count for normal results", () => {
+    const result = formatGrepResultText({
+      totalMatches: 42,
+      summary: false,
+      records: new Array(42).fill(null),
+      fileCount: 8,
+    });
+    expect(result.summary).toBe("✓ 42 matches in 8 files");
+    expect(result.badges).toEqual([]);
+    expect(result.noMatches).toBe(false);
+  });
+
+  it("returns no-matches indicator for zero matches", () => {
+    const result = formatGrepResultText({
+      totalMatches: 0,
+      summary: false,
+      records: [],
+      fileCount: 0,
+    });
+    expect(result.noMatches).toBe(true);
+  });
+
+  it("shows truncation badge when totalMatches >= 50", () => {
+    const result = formatGrepResultText({
+      totalMatches: 50,
+      summary: false,
+      records: new Array(50).fill(null),
+      fileCount: 12,
+    });
+    expect(result.badges).toContain("10/file cap");
+    expect(result.truncated).toBe(true);
+  });
+
+  it("shows summary badge when summary is true", () => {
+    const result = formatGrepResultText({
+      totalMatches: 10,
+      summary: true,
+      records: [],
+      fileCount: 3,
+    });
+    expect(result.badges).toContain("summary");
+  });
+
+  it("shows binary badge when hasBinaryWarning is true", () => {
+    const result = formatGrepResultText({
+      totalMatches: 0,
+      summary: false,
+      records: [],
+      fileCount: 0,
+      hasBinaryWarning: true,
+    });
+    expect(result.badges).toContain("⚠ binary");
+  });
+
+  it("singularizes match and file for count of 1", () => {
+    const result = formatGrepResultText({
+      totalMatches: 1,
+      summary: false,
+      records: [null as any],
+      fileCount: 1,
+    });
+    expect(result.summary).toBe("✓ 1 match in 1 file");
+  });
+
+  it("returns error text when isError is true", () => {
+    const result = formatGrepResultText({
+      totalMatches: 0,
+      summary: false,
+      records: [],
+      fileCount: 0,
+      isError: true,
+      errorText: "Invalid regex pattern",
+    });
+    expect(result.errorText).toBe("Invalid regex pattern");
+  });
+});

--- a/tests/read-render-helpers.test.ts
+++ b/tests/read-render-helpers.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { formatReadCallText, formatReadResultText } from "../src/read-render-helpers.js";
+
+describe("formatReadCallText", () => {
+  it("returns path only when no symbol or map", () => {
+    const result = formatReadCallText({ path: "src/foo.ts" });
+    expect(result).toEqual({ path: "src/foo.ts", suffix: undefined });
+  });
+
+  it("returns symbol suffix when symbol is present", () => {
+    const result = formatReadCallText({ path: "src/foo.ts", symbol: "MyClass.myMethod" });
+    expect(result).toEqual({ path: "src/foo.ts", suffix: "→ symbol MyClass.myMethod" });
+  });
+
+  it("returns map suffix when map is true", () => {
+    const result = formatReadCallText({ path: "src/foo.ts", map: true });
+    expect(result).toEqual({ path: "src/foo.ts", suffix: "+ map" });
+  });
+
+  it("returns null path when path is missing", () => {
+    const result = formatReadCallText({});
+    expect(result).toEqual({ path: null, suffix: undefined });
+  });
+
+  it("ignores map when false", () => {
+    const result = formatReadCallText({ path: "src/foo.ts", map: false });
+    expect(result).toEqual({ path: "src/foo.ts", suffix: undefined });
+  });
+
+  it("prefers symbol over map when both present (mutual exclusion in schema)", () => {
+    const result = formatReadCallText({ path: "src/foo.ts", symbol: "foo", map: true });
+    expect(result.suffix).toBe("→ symbol foo");
+  });
+
+  it("includes offset/limit in suffix when present", () => {
+    const result = formatReadCallText({ path: "src/foo.ts", offset: 10, limit: 20 });
+    expect(result).toEqual({ path: "src/foo.ts", suffix: "lines 10-29" });
+  });
+});
+
+describe("formatReadResultText", () => {
+  it("returns line count and range for a normal read", () => {
+    const result = formatReadResultText({
+      range: { startLine: 1, endLine: 50, totalLines: 200 },
+      truncation: null,
+      symbol: null,
+      map: { requested: false, appended: false },
+      warnings: [],
+    });
+    expect(result.summary).toBe("✓ 50 lines (1-50 of 200)");
+    expect(result.badges).toEqual([]);
+    expect(result.errorText).toBeUndefined();
+  });
+
+  it("returns simple line count when range covers full file", () => {
+    const result = formatReadResultText({
+      range: { startLine: 1, endLine: 50, totalLines: 50 },
+      truncation: null,
+      symbol: null,
+      map: { requested: false, appended: false },
+      warnings: [],
+    });
+    expect(result.summary).toBe("✓ 50 lines");
+  });
+
+  it("includes symbol info when symbol is present", () => {
+    const result = formatReadResultText({
+      range: { startLine: 10, endLine: 30, totalLines: 200 },
+      truncation: null,
+      symbol: { query: "foo", name: "registerReadTool", kind: "function", startLine: 10, endLine: 30 },
+      map: { requested: false, appended: false },
+      warnings: [],
+    });
+    expect(result.symbolBadge).toBe("function registerReadTool");
+  });
+
+  it("includes map badge when map is appended", () => {
+    const result = formatReadResultText({
+      range: { startLine: 1, endLine: 50, totalLines: 200 },
+      truncation: null,
+      symbol: null,
+      map: { requested: true, appended: true },
+      warnings: [],
+    });
+    expect(result.badges).toContain("📐 map");
+  });
+
+  it("includes binary warning badge", () => {
+    const result = formatReadResultText({
+      range: { startLine: 1, endLine: 50, totalLines: 50 },
+      truncation: null,
+      symbol: null,
+      map: { requested: false, appended: false },
+      warnings: [{ code: "binary-content", message: "[Warning: file appears to be binary]" }],
+    });
+    expect(result.badges).toContain("⚠ binary");
+  });
+
+  it("includes bare-cr warning badge", () => {
+    const result = formatReadResultText({
+      range: { startLine: 1, endLine: 50, totalLines: 50 },
+      truncation: null,
+      symbol: null,
+      map: { requested: false, appended: false },
+      warnings: [{ code: "bare-cr", message: "[Warning: bare CR]" }],
+    });
+    expect(result.badges).toContain("⚠ bare CR");
+  });
+
+  it("shows truncation in summary", () => {
+    const result = formatReadResultText({
+      range: { startLine: 1, endLine: 2000, totalLines: 5000 },
+      truncation: { outputLines: 2000, totalLines: 5000, outputBytes: 50000, totalBytes: 120000 },
+      symbol: null,
+      map: { requested: false, appended: false },
+      warnings: [],
+    });
+    expect(result.summary).toContain("2000");
+    expect(result.summary).toContain("5000");
+    expect(result.truncated).toBe(true);
+  });
+
+  it("returns error text for error results", () => {
+    const result = formatReadResultText({
+      range: { startLine: 1, endLine: 0, totalLines: 0 },
+      truncation: null,
+      symbol: null,
+      map: { requested: false, appended: false },
+      warnings: [],
+      isError: true,
+      errorText: "File not found: src/missing.ts",
+    });
+    expect(result.errorText).toBe("File not found: src/missing.ts");
+  });
+});


### PR DESCRIPTION
## Summary

Adds context-aware `renderCall` and `renderResult` methods to the **read** and **grep** tool objects, replacing generic fallback TUI rendering with enriched summaries. This completes custom TUI rendering across all four hashline tools (read, edit, grep, sg).

## What's New

### read tool
- **renderCall**: displays `read <path>` with optional suffixes for symbol (`→ symbol Name`), map (`+ map`), and offset/limit (`lines N-M`)
- **renderResult**: collapsed summary with line count/range, symbol kind+name badge, `📐 map` badge, `⚠ binary`/`⚠ bare CR` warning badges, truncation indicator; expanded view shows full text content

### grep tool
- **renderCall**: displays `grep <pattern>` with optional path and glob suffixes
- **renderResult**: collapsed summary with match/file counts (`✓ 42 matches in 8 files`), `10/file cap` truncation badge, `summary` mode badge, `⚠ binary` warning; expanded view shows per-file match distribution (up to 20 files)

## Architecture

Follows the established pattern from `sg.ts` and `edit.ts`:
- Pure formatting helpers in `*-render-helpers.ts` (testable without TUI mocking)
- Renderer methods on tool objects wire helpers to `Text` components
- Backward-compatible context extraction for old/new pi versions
- No changes to `execute()` methods or `ptcValue` structures

## Files Changed

| File | Change |
|------|--------|
| `src/read-render-helpers.ts` | New — formatReadCallText, formatReadResultText |
| `src/grep-render-helpers.ts` | New — formatGrepCallText, formatGrepResultText |
| `src/read.ts` | Added renderCall + renderResult methods |
| `src/grep.ts` | Added renderCall + renderResult methods |
| `tests/read-render-helpers.test.ts` | 15 new tests |
| `tests/grep-render-helpers.test.ts` | 13 new tests |

## Test Results

92 test files, 483 tests passing, 0 failures. `tsc --noEmit` clean.

Closes #060