### PR TITLE
feat: additive output contracts for grep scope=symbol and read bundle=local

### DIFF
--- a/src/grep-output.ts
+++ b/src/grep-output.ts
@@ -1,4 +1,4 @@
-import type { PtcLine } from "./ptc-value.js";
+import type { PtcLine, PtcWarning } from "./ptc-value.js";
 
 export interface GrepOutputRecord extends PtcLine {
   path: string;
@@ -9,11 +9,29 @@ export type GrepOutputEntry =
   | { kind: "match" | "context"; line: PtcLine }
   | { kind: "separator"; text: string };
 
+export interface GrepOutputScopeSymbol {
+  name: string;
+  kind: string;
+  startLine: number;
+  endLine: number;
+  parentName?: string;
+}
+
+export interface GrepScopeWarning extends PtcWarning {
+  path?: string;
+  line?: number;
+}
+
 export interface GrepOutputGroup {
   displayPath: string;
   absolutePath: string;
   matchCount: number;
   entries: GrepOutputEntry[];
+  scope?: {
+    mode: "symbol";
+    symbol: GrepOutputScopeSymbol;
+    matchLines: number[];
+  };
 }
 
 export interface BuildGrepOutputInput {
@@ -22,6 +40,8 @@ export interface BuildGrepOutputInput {
   groups: GrepOutputGroup[];
   limit?: number;
   records: GrepOutputRecord[];
+  scopeMode?: "symbol";
+  scopeWarnings?: GrepScopeWarning[];
 }
 
 export interface GrepOutputResult {
@@ -31,6 +51,18 @@ export interface GrepOutputResult {
     summary: boolean;
     totalMatches: number;
     records: GrepOutputRecord[];
+    scopes?: {
+      mode: "symbol";
+      groups: Array<{
+        path: string;
+        displayPath: string;
+        symbol: GrepOutputScopeSymbol;
+        matchCount: number;
+        matchLines: number[];
+        lineAnchors: string[];
+      }>;
+      warnings: GrepScopeWarning[];
+    };
   };
 }
 
@@ -40,8 +72,35 @@ function renderEntry(displayPath: string, entry: GrepOutputEntry): string {
   return `${displayPath}:${marker}${entry.line.anchor}|${entry.line.display}`;
 }
 
+function renderGroupHeader(group: GrepOutputGroup): string {
+  if (!group.scope) {
+    return `--- ${group.displayPath} (${group.matchCount} matches) ---`;
+  }
+
+  const parent = group.scope.symbol.parentName ? ` in ${group.scope.symbol.parentName}` : "";
+  return `--- ${group.displayPath} :: ${group.scope.symbol.kind} ${group.scope.symbol.name}${parent} (${group.scope.symbol.startLine}-${group.scope.symbol.endLine}, ${group.matchCount} matches) ---`;
+}
+
+function buildScopeMetadata(groups: GrepOutputGroup[], warnings: GrepScopeWarning[]) {
+  return {
+    mode: "symbol" as const,
+    groups: groups
+      .filter((group) => group.scope)
+      .map((group) => ({
+        path: group.absolutePath,
+        displayPath: group.displayPath,
+        symbol: group.scope!.symbol,
+        matchCount: group.matchCount,
+        matchLines: [...group.scope!.matchLines],
+        lineAnchors: group.entries.flatMap((entry) => (entry.kind === "separator" ? [] : [entry.line.anchor])),
+      })),
+    warnings: [...warnings],
+  };
+}
+
 export function buildGrepOutput(input: BuildGrepOutputInput): GrepOutputResult {
-  const header = `[${input.totalMatches} matches in ${input.groups.length} files]`;
+  const fileCount = new Set(input.groups.map((group) => group.absolutePath)).size;
+  const header = `[${input.totalMatches} matches in ${fileCount} files]`;
   let text: string;
 
   if (input.summary) {
@@ -52,7 +111,7 @@ export function buildGrepOutput(input: BuildGrepOutputInput): GrepOutputResult {
   } else {
     const blocks: string[] = [header];
     for (const group of input.groups) {
-      blocks.push(`--- ${group.displayPath} (${group.matchCount} matches) ---`);
+      blocks.push(renderGroupHeader(group));
       for (const entry of group.entries) {
         blocks.push(renderEntry(group.displayPath, entry));
       }
@@ -64,13 +123,23 @@ export function buildGrepOutput(input: BuildGrepOutputInput): GrepOutputResult {
     text += `\n\n[Results truncated at ${input.limit} matches — refine pattern or increase limit]`;
   }
 
+  if (!input.summary && input.scopeMode === "symbol" && (input.scopeWarnings?.length ?? 0) > 0) {
+    text = `${input.scopeWarnings!.map((warning) => warning.message).join("\n\n")}\n\n${text}`;
+  }
+
+  const ptcValue: GrepOutputResult["ptcValue"] = {
+    tool: "grep",
+    summary: input.summary,
+    totalMatches: input.totalMatches,
+    records: input.records,
+  };
+
+  if (!input.summary && input.scopeMode === "symbol") {
+    ptcValue.scopes = buildScopeMetadata(input.groups, input.scopeWarnings ?? []);
+  }
+
   return {
     text,
-    ptcValue: {
-      tool: "grep",
-      summary: input.summary,
-      totalMatches: input.totalMatches,
-      records: input.records,
-    },
+    ptcValue,
   };
 }

--- a/src/grep-symbol-scope.ts
+++ b/src/grep-symbol-scope.ts
@@ -1,0 +1,164 @@
+import { buildPtcLine } from "./ptc-value.js";
+import type { GrepOutputEntry, GrepOutputGroup, GrepOutputScopeSymbol, GrepScopeWarning } from "./grep-output.js";
+import type { FileMap, FileSymbol } from "./readmap/types.js";
+
+interface FlatSymbol extends GrepOutputScopeSymbol {
+  rangeSize: number;
+}
+
+function flattenSymbols(symbols: FileSymbol[], parentName?: string): FlatSymbol[] {
+  const flattened: FlatSymbol[] = [];
+  for (const symbol of symbols) {
+    flattened.push({
+      name: symbol.name,
+      kind: symbol.kind,
+      startLine: symbol.startLine,
+      endLine: symbol.endLine,
+      parentName,
+      rangeSize: symbol.endLine - symbol.startLine,
+    });
+    if (symbol.children?.length) flattened.push(...flattenSymbols(symbol.children, symbol.name));
+  }
+  return flattened;
+}
+
+function findEnclosingSymbol(map: FileMap, lineNumber: number): GrepOutputScopeSymbol | null {
+  const candidates = flattenSymbols(map.symbols)
+    .filter((s) => lineNumber >= s.startLine && lineNumber <= s.endLine)
+    .sort((a, b) => {
+      if (a.rangeSize !== b.rangeSize) return a.rangeSize - b.rangeSize;
+      if (a.startLine !== b.startLine) return a.startLine - b.startLine;
+      return a.name.localeCompare(b.name);
+    });
+  if (!candidates.length) return null;
+  const { rangeSize: _rangeSize, ...symbol } = candidates[0];
+  return symbol;
+}
+
+function firstLineNumber(group: GrepOutputGroup): number {
+  const first = group.entries.find((e) => e.kind !== "separator");
+  return first ? first.line.line : Number.MAX_SAFE_INTEGER;
+}
+
+function buildSymbolEntries(fileLines: string[], symbol: GrepOutputScopeSymbol, matchLines: Set<number>): GrepOutputEntry[] {
+  const entries: GrepOutputEntry[] = [];
+  for (let lineNumber = symbol.startLine; lineNumber <= symbol.endLine; lineNumber++) {
+    const built = buildPtcLine(lineNumber, fileLines[lineNumber - 1] ?? "");
+    entries.push({ kind: matchLines.has(lineNumber) ? "match" : "context", line: built });
+  }
+  return entries;
+}
+
+function buildFallbackEntries(fileLines: string[], matchLines: number[], contextLines: number): GrepOutputEntry[] {
+  const lineMap = new Map<number, GrepOutputEntry>();
+  for (const matchLine of matchLines) {
+    const start = Math.max(1, matchLine - contextLines);
+    const end = Math.min(fileLines.length, matchLine + contextLines);
+    for (let lineNumber = start; lineNumber <= end; lineNumber++) {
+      const built = buildPtcLine(lineNumber, fileLines[lineNumber - 1] ?? "");
+      const candidate: GrepOutputEntry = { kind: lineNumber === matchLine ? "match" : "context", line: built };
+      const existing = lineMap.get(lineNumber);
+      if (!existing || (existing.kind === "context" && candidate.kind === "match")) {
+        lineMap.set(lineNumber, candidate);
+      }
+    }
+  }
+  const ordered = [...lineMap.entries()].sort(([a], [b]) => a - b);
+  const entries: GrepOutputEntry[] = [];
+  for (let i = 0; i < ordered.length; i++) {
+    if (i > 0 && ordered[i][0] > ordered[i - 1][0] + 1) entries.push({ kind: "separator", text: "--" });
+    entries.push(ordered[i][1]);
+  }
+  return entries;
+}
+
+export function scopeGrepGroupsToSymbols(input: {
+  groups: GrepOutputGroup[];
+  fileLinesByPath: Map<string, string[]>;
+  fileMapsByPath: Map<string, FileMap | null>;
+  contextLines: number;
+}): { groups: GrepOutputGroup[]; warnings: GrepScopeWarning[] } {
+  const warnings: GrepScopeWarning[] = [];
+  const rendered: Array<{ order: number; group: GrepOutputGroup }> = [];
+
+  for (const group of input.groups) {
+    const fileLines = input.fileLinesByPath.get(group.absolutePath);
+    const fileMap = input.fileMapsByPath.get(group.absolutePath) ?? null;
+
+    if (!fileLines || !fileMap) {
+      warnings.push({
+        code: "unmappable-file",
+        message: `[Warning: symbol scoping unavailable for ${group.absolutePath} — showing normal grep lines for this file]`,
+        path: group.absolutePath,
+      });
+      rendered.push({ order: firstLineNumber(group), group });
+      continue;
+    }
+
+    const symbolBuckets = new Map<string, { symbol: GrepOutputScopeSymbol; matchLines: Set<number> }>();
+    const fallbackMatchLines: number[] = [];
+
+    for (const entry of group.entries) {
+      if (entry.kind !== "match") continue;
+      const symbol = findEnclosingSymbol(fileMap, entry.line.line);
+      if (!symbol) {
+        fallbackMatchLines.push(entry.line.line);
+        warnings.push({
+          code: "no-enclosing-symbol",
+          message: `[Warning: no enclosing symbol for ${group.absolutePath}:${entry.line.line} — showing normal grep lines for this match]`,
+          path: group.absolutePath,
+          line: entry.line.line,
+        });
+        continue;
+      }
+
+      const key = `${symbol.startLine}:${symbol.endLine}:${symbol.parentName ?? ""}:${symbol.name}`;
+      const bucket = symbolBuckets.get(key) ?? { symbol, matchLines: new Set<number>() };
+      bucket.matchLines.add(entry.line.line);
+      symbolBuckets.set(key, bucket);
+    }
+
+    const scopedGroups = [...symbolBuckets.values()]
+      .sort((a, b) => {
+        if (a.symbol.startLine !== b.symbol.startLine) return a.symbol.startLine - b.symbol.startLine;
+        return a.symbol.name.localeCompare(b.symbol.name);
+      })
+      .map(({ symbol, matchLines }) => ({
+        displayPath: group.displayPath,
+        absolutePath: group.absolutePath,
+        matchCount: matchLines.size,
+        scope: {
+          mode: "symbol" as const,
+          symbol,
+          matchLines: [...matchLines].sort((a, b) => a - b),
+        },
+        entries: buildSymbolEntries(fileLines, symbol, matchLines),
+      }));
+
+    for (const scopedGroup of scopedGroups) rendered.push({ order: scopedGroup.scope!.symbol.startLine, group: scopedGroup });
+
+    if (fallbackMatchLines.length > 0) {
+      rendered.push({
+        order: Math.min(...fallbackMatchLines),
+        group: {
+          displayPath: group.displayPath,
+          absolutePath: group.absolutePath,
+          matchCount: fallbackMatchLines.length,
+          entries: buildFallbackEntries(fileLines, fallbackMatchLines, input.contextLines),
+        },
+      });
+    }
+
+    if (scopedGroups.length === 0 && fallbackMatchLines.length === 0) {
+      rendered.push({ order: firstLineNumber(group), group });
+    }
+  }
+
+  rendered.sort((a, b) => {
+    if (a.order !== b.order) return a.order - b.order;
+    if (a.group.absolutePath !== b.group.absolutePath) return a.group.absolutePath.localeCompare(b.group.absolutePath);
+    return a.group.displayPath.localeCompare(b.group.displayPath);
+  });
+
+  return { groups: rendered.map((item) => item.group), warnings };
+}

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -8,6 +8,8 @@ import { looksLikeBinary } from "./binary-detect";
 import { ensureHashInit, formatHashlineDisplay } from "./hashline";
 import { buildPtcLine } from "./ptc-value.js";
 import { buildGrepOutput } from "./grep-output.js";
+import { getOrGenerateMap } from "./map-cache.js";
+import { scopeGrepGroupsToSymbols } from "./grep-symbol-scope.js";
 import { resolveToCwd } from "./path-utils";
 import { throwIfAborted } from "./runtime";
 import { Text } from "@mariozechner/pi-tui";
@@ -25,6 +27,11 @@ const grepSchema = Type.Object({
 	context: Type.Optional(Type.Number({ description: "Number of lines to show before and after each match (default: 0)" })),
 	limit: Type.Optional(Type.Number({ description: "Maximum number of matches to return (default: 100)" })),
 	summary: Type.Optional(Type.Boolean({ description: "Return per-file match counts only (no hashline anchors)" })),
+	scope: Type.Optional(
+		Type.Literal("symbol", {
+			description: 'Scope matches to enclosing symbol blocks. Only "symbol" is defined, and it is ignored when summary: true.',
+		}),
+	),
 });
 
 interface GrepParams {
@@ -36,6 +43,7 @@ interface GrepParams {
 	context?: number;
 	limit?: number;
 	summary?: boolean;
+	scope?: "symbol";
 }
 
 const MATCH_LINE_RE = /^(.*):(\d+): (.*)$/;
@@ -459,8 +467,7 @@ export function registerGrepTool(pi: ExtensionAPI) {
 					files: truncatedIR.files.map((file) => ({ ...file, path: toAbsolutePath(file.path) })),
 				}
 				: truncatedIR;
-const ptcRecords = collectPtcRecordsFromIR(outputIR, recordByRenderedLine);
-const groups = outputIR.files.map((file) => ({
+let renderedGroups = outputIR.files.map((file) => ({
 	displayPath: file.path,
 	absolutePath: summary ? file.path : toAbsolutePath(file.path),
 	matchCount: file.matchCount,
@@ -472,7 +479,6 @@ const groups = outputIR.files.map((file) => ({
 		if (!record) {
 			throw new Error(`Missing grep record for rendered line: ${line.raw}`);
 		}
-
 		return {
 			kind: record.kind,
 			line: {
@@ -485,12 +491,55 @@ const groups = outputIR.files.map((file) => ({
 		};
 	}),
 }));
+
+let ptcRecords = collectPtcRecordsFromIR(outputIR, recordByRenderedLine);
+let scopeWarnings: import("./grep-output.js").GrepScopeWarning[] = [];
+
+if (p.scope === "symbol" && !summary) {
+	const fileLinesByPath = new Map<string, string[]>();
+	const fileMapsByPath = new Map<string, Awaited<ReturnType<typeof getOrGenerateMap>>>();
+
+	for (const group of renderedGroups) {
+		const lines = await getFileLines(group.absolutePath);
+		if (lines) fileLinesByPath.set(group.absolutePath, lines);
+		fileMapsByPath.set(group.absolutePath, await getOrGenerateMap(group.absolutePath));
+	}
+
+	const scoped = scopeGrepGroupsToSymbols({
+		groups: renderedGroups,
+		fileLinesByPath,
+		fileMapsByPath,
+		contextLines: p.context ?? 0,
+	});
+
+	renderedGroups = scoped.groups;
+	scopeWarnings = scoped.warnings;
+	ptcRecords = renderedGroups.flatMap((group) =>
+		group.entries.flatMap((entry) =>
+			entry.kind === "separator"
+				? []
+				: [
+					{
+						path: group.absolutePath,
+						kind: entry.kind,
+						line: entry.line.line,
+						hash: entry.line.hash,
+						anchor: entry.line.anchor,
+						raw: entry.line.raw,
+						display: entry.line.display,
+					},
+				],
+		),
+	);
+}
 	const builtOutput = buildGrepOutput({
 	summary: !!summary,
 	totalMatches: grepIR.totalMatches,
-	groups,
+	groups: renderedGroups,
 	limit: effectiveLimit,
 	records: ptcRecords,
+	scopeMode: p.scope === "symbol" && !summary ? "symbol" : undefined,
+	scopeWarnings,
 });
 
 return {

--- a/src/read-local-bundle.ts
+++ b/src/read-local-bundle.ts
@@ -1,0 +1,87 @@
+import { SymbolKind } from "./readmap/enums.js";
+import type { SymbolMatch } from "./readmap/symbol-lookup.js";
+import type { FileMap, FileSymbol } from "./readmap/types.js";
+
+export interface LocalBundleSupport {
+  symbol: SymbolMatch;
+  lines: string[];
+}
+
+export interface LocalBundlePlan {
+  requested: SymbolMatch;
+  support: LocalBundleSupport[];
+}
+
+interface FlatSymbol {
+  symbol: FileSymbol;
+  parentName?: string;
+}
+
+const CONTAINER_KINDS = new Set<SymbolKind>([
+  SymbolKind.Class,
+  SymbolKind.Module,
+  SymbolKind.Namespace,
+]);
+
+function flattenSymbols(symbols: FileSymbol[], parentName?: string): FlatSymbol[] {
+  const flattened: FlatSymbol[] = [];
+
+  for (const symbol of symbols) {
+    flattened.push({ symbol, parentName });
+    if (symbol.children?.length) {
+      flattened.push(...flattenSymbols(symbol.children, symbol.name));
+    }
+  }
+
+  return flattened;
+}
+
+export function buildLocalBundle(
+  fileMap: FileMap,
+  requested: SymbolMatch,
+  allLines: string[],
+): LocalBundlePlan | null {
+  const requestedText = allLines.slice(requested.startLine - 1, requested.endLine).join("\n");
+  const identifiers = new Set(requestedText.match(/\b[A-Za-z_][A-Za-z0-9_]*\b/g) ?? []);
+
+  const candidates = flattenSymbols(fileMap.symbols).filter(({ symbol }) => {
+    if (CONTAINER_KINDS.has(symbol.kind as SymbolKind)) return false;
+    return !(symbol.name === requested.name && symbol.startLine === requested.startLine && symbol.endLine === requested.endLine);
+  });
+
+  const symbolsByName = new Map<string, FlatSymbol[]>();
+  for (const candidate of candidates) {
+    const bucket = symbolsByName.get(candidate.symbol.name) ?? [];
+    bucket.push(candidate);
+    symbolsByName.set(candidate.symbol.name, bucket);
+  }
+
+  const support: LocalBundleSupport[] = [];
+  for (const identifier of identifiers) {
+    const matches = symbolsByName.get(identifier) ?? [];
+    if (matches.length === 0) continue;
+    if (matches.length > 1) return null;
+
+    const match = matches[0];
+    support.push({
+      symbol: {
+        name: match.symbol.name,
+        kind: match.symbol.kind,
+        startLine: match.symbol.startLine,
+        endLine: match.symbol.endLine,
+        ...(match.parentName ? { parentName: match.parentName } : {}),
+      },
+      lines: allLines.slice(match.symbol.startLine - 1, match.symbol.endLine),
+    });
+  }
+
+  support.sort((a, b) => {
+    if (a.symbol.startLine !== b.symbol.startLine) return a.symbol.startLine - b.symbol.startLine;
+    return a.symbol.name.localeCompare(b.symbol.name);
+  });
+
+  return {
+    requested,
+    support,
+  };
+}

--- a/src/read-output.ts
+++ b/src/read-output.ts
@@ -32,6 +32,18 @@ export interface ReadContinuationMetadata {
   nextOffset: number;
 }
 
+export interface ReadBundleSupportItem {
+  symbol: ReadSymbolMetadata;
+  lines: string[];
+}
+
+export interface ReadBundleMetadata {
+  mode: "local";
+  applied: boolean;
+  localSupport: ReadBundleSupportItem[];
+  warnings?: PtcWarning[];
+}
+
 export interface ReadOutputInput {
   path: string;
   startLine: number;
@@ -43,6 +55,7 @@ export interface ReadOutputInput {
   continuation?: ReadContinuationMetadata | null;
   symbol?: ReadSymbolMetadata | null;
   map?: ReadMapMetadata;
+  bundle?: ReadBundleMetadata | null;
 }
 
 export interface ReadOutputResult {
@@ -64,6 +77,19 @@ export interface ReadOutputResult {
       appended: boolean;
     };
     lines: PtcLine[];
+    bundle?: {
+      mode: "local";
+      applied: boolean;
+      localSupport: Array<{
+        name: string;
+        kind: string;
+        parentName?: string;
+        startLine: number;
+        endLine: number;
+        lineAnchors: string[];
+      }>;
+      warnings: PtcWarning[];
+    };
   };
 }
 
@@ -84,6 +110,21 @@ export function buildReadOutput(input: ReadOutputInput): ReadOutputResult {
     text += `\n\n[Showing lines ${input.startLine}-${input.endLine} of ${input.totalLines}. Use offset=${input.continuation.nextOffset} to continue.]`;
   }
 
+  if (input.bundle?.applied) {
+    const supportBlocks = input.bundle.localSupport.map((item) => {
+      const supportLines = buildPtcLines(item.symbol.startLine, item.lines);
+      return renderPtcLines(supportLines);
+    });
+
+    text = [
+      "## Requested symbol",
+      text,
+      "",
+      "## Local support",
+      ...supportBlocks,
+    ].join("\n");
+  }
+
   if (input.map?.appended && input.map.text) {
     text += `\n\n${input.map.text}`;
   }
@@ -97,25 +138,46 @@ export function buildReadOutput(input: ReadOutputInput): ReadOutputResult {
     text = `${warnings.map((warning) => warning.message).join("\n\n")}\n\n${text}`;
   }
 
+  const ptcValue: ReadOutputResult["ptcValue"] = {
+    tool: "read",
+    path: input.path,
+    range: {
+      startLine: input.startLine,
+      endLine: input.endLine,
+      totalLines: input.totalLines,
+    },
+    warnings,
+    truncation: input.truncation ?? null,
+    symbol: input.symbol ?? null,
+    map: {
+      requested: input.map?.requested ?? false,
+      appended: input.map?.appended ?? false,
+    },
+    lines,
+  };
+
+  if (input.bundle) {
+    ptcValue.bundle = {
+      mode: input.bundle.mode,
+      applied: input.bundle.applied,
+      localSupport: input.bundle.localSupport.map((item) => {
+        const supportLines = buildPtcLines(item.symbol.startLine, item.lines);
+        return {
+          name: item.symbol.name,
+          kind: item.symbol.kind,
+          parentName: item.symbol.parentName,
+          startLine: item.symbol.startLine,
+          endLine: item.symbol.endLine,
+          lineAnchors: supportLines.map((line) => line.anchor),
+        };
+      }),
+      warnings: input.bundle.warnings ?? [],
+    };
+  }
+
   return {
     text,
     lines,
-    ptcValue: {
-      tool: "read",
-      path: input.path,
-      range: {
-        startLine: input.startLine,
-        endLine: input.endLine,
-        totalLines: input.totalLines,
-      },
-      warnings,
-      truncation: input.truncation ?? null,
-      symbol: input.symbol ?? null,
-      map: {
-        requested: input.map?.requested ?? false,
-        appended: input.map?.appended ?? false,
-      },
-      lines,
-    },
+    ptcValue,
   };
 }

--- a/src/read.ts
+++ b/src/read.ts
@@ -19,6 +19,7 @@ import { getOrGenerateMap } from "./map-cache";
 import { formatFileMapWithBudget } from "./readmap/formatter.js";
 import { findSymbol, type SymbolMatch } from "./readmap/symbol-lookup.js";
 import { buildReadOutput } from "./read-output.js";
+import { buildLocalBundle } from "./read-local-bundle.js";
 import { Text } from "@mariozechner/pi-tui";
 import { formatReadCallText, formatReadResultText } from "./read-render-helpers.js";
 
@@ -33,6 +34,7 @@ interface ReadParams {
 	limit?: number;
 	symbol?: string;
 	map?: boolean;
+	bundle?: "local";
 }
 
 export function registerReadTool(pi: ExtensionAPI) {
@@ -55,6 +57,11 @@ export function registerReadTool(pi: ExtensionAPI) {
 			limit: Type.Optional(Type.Number({ description: "Maximum number of lines to read" })),
 			symbol: Type.Optional(Type.String({ description: "Symbol to read (e.g., functionName or ClassName.methodName)" })),
 			map: Type.Optional(Type.Boolean({ description: "Append structural map to output (cannot combine with symbol)" })),
+			bundle: Type.Optional(
+				Type.Literal("local", {
+					description: 'Include the requested symbol plus direct same-file local support. Only "local" is defined.',
+				}),
+			),
 		}),
 		ptc,
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
@@ -68,6 +75,22 @@ export function registerReadTool(pi: ExtensionAPI) {
 			if (p.symbol && (p.offset !== undefined || p.limit !== undefined)) {
 				return {
 					content: [{ type: "text", text: "Cannot combine symbol with offset/limit. Use one or the other." }],
+					isError: true,
+					details: {},
+				};
+			}
+
+			if (p.bundle && !p.symbol) {
+				return {
+					content: [{ type: "text", text: 'Cannot use bundle without symbol. Use read({ path, symbol, bundle: "local" }).' }],
+					isError: true,
+					details: {},
+				};
+			}
+
+			if (p.bundle && p.map) {
+				return {
+					content: [{ type: "text", text: "Cannot combine bundle with map. Use one or the other." }],
 					isError: true,
 					details: {},
 				};
@@ -140,18 +163,35 @@ export function registerReadTool(pi: ExtensionAPI) {
 				};
 			}
 			let symbolMatch: SymbolMatch | undefined;
+			let symbolFileMap: Awaited<ReturnType<typeof getOrGenerateMap>> | null = null;
 			let symbolWarning: string | undefined;
+			let bundleMetadata:
+				| {
+						mode: "local";
+						applied: boolean;
+						localSupport: Array<{
+							symbol: {
+								query: string;
+								name: string;
+								kind: string;
+								parentName?: string;
+								startLine: number;
+								endLine: number;
+							};
+							lines: string[];
+						}>;
+						warnings: PtcWarning[];
+				  }
+				| null = null;
 			if (p.symbol) {
-				const fileMap = await getOrGenerateMap(absolutePath);
-				if (!fileMap) {
+				symbolFileMap = await getOrGenerateMap(absolutePath);
+				if (!symbolFileMap) {
 					const extLabel = ext || "unknown";
 					symbolWarning = `[Warning: symbol lookup not available for .${extLabel} files — showing full file]\n\n`;
 				} else {
-					const lookup = findSymbol(fileMap, p.symbol);
+					const lookup = findSymbol(symbolFileMap, p.symbol);
 					if (lookup.type === "ambiguous") {
-						const lines = lookup.candidates.map(
-							(c) => `- ${c.name} (${c.kind}) — lines ${c.startLine}-${c.endLine}`,
-						);
+						const lines = lookup.candidates.map((c) => `- ${c.name} (${c.kind}) — lines ${c.startLine}-${c.endLine}`);
 						const hints = lookup.candidates.map((c) => `${p.symbol}@${c.startLine}`).join(" or ");
 						return {
 							content: [
@@ -170,7 +210,7 @@ export function registerReadTool(pi: ExtensionAPI) {
 						};
 					}
 					if (lookup.type === "not-found") {
-						const available = fileMap.symbols
+						const available = symbolFileMap.symbols
 							.slice(0, 20)
 							.map((s) => s.name)
 							.join(", ");
@@ -180,6 +220,62 @@ export function registerReadTool(pi: ExtensionAPI) {
 						startLine = Math.max(1, lookup.symbol.startLine);
 						endIdx = Math.min(total, lookup.symbol.endLine);
 						symbolMatch = lookup.symbol;
+					}
+				}
+			}
+
+			if (p.bundle === "local") {
+				if (!symbolFileMap) {
+					const extLabel = ext || "unknown";
+					const warning = buildPtcWarning(
+						"bundle-unmappable",
+						`[Warning: local bundle unavailable because symbol mapping is not available for .${extLabel} files — showing plain symbol read]`,
+					);
+					structuredWarnings.push(warning);
+					bundleMetadata = {
+						mode: "local",
+						applied: false,
+						localSupport: [],
+						warnings: [warning],
+					};
+				} else if (!symbolMatch) {
+					bundleMetadata = {
+						mode: "local",
+						applied: false,
+						localSupport: [],
+						warnings: [],
+					};
+				} else {
+					const bundle = buildLocalBundle(symbolFileMap, symbolMatch, allLines);
+					if (!bundle) {
+						const warning = buildPtcWarning(
+							"bundle-context-unavailable",
+							`[Warning: local bundle context could not be determined for symbol '${symbolMatch.name}' — showing plain symbol read]`,
+						);
+						structuredWarnings.push(warning);
+						bundleMetadata = {
+							mode: "local",
+							applied: false,
+							localSupport: [],
+							warnings: [warning],
+						};
+					} else {
+						bundleMetadata = {
+							mode: "local",
+							applied: true,
+							localSupport: bundle.support.map((item) => ({
+								symbol: {
+									query: item.symbol.name,
+									name: item.symbol.name,
+									kind: item.symbol.kind,
+									parentName: item.symbol.parentName,
+									startLine: item.symbol.startLine,
+									endLine: item.symbol.endLine,
+								},
+								lines: item.lines,
+							})),
+							warnings: [],
+						};
 					}
 				}
 			}
@@ -276,6 +372,7 @@ const readOutput = buildReadOutput({
 		appended: appendedMap,
 		text: mapText,
 	},
+	...(bundleMetadata ? { bundle: bundleMetadata } : {}),
 });
 
 return {

--- a/tests/grep-output-scopes.test.ts
+++ b/tests/grep-output-scopes.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { buildPtcLine } from "../src/ptc-value.js";
+import { ensureHashInit } from "../src/hashline.js";
+import { buildGrepOutput, type GrepOutputRecord } from "../src/grep-output.js";
+
+describe("buildGrepOutput symbol scope", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+  it("renders grouped symbol blocks and additive scopes metadata without replacing records", () => {
+    const absolutePath = "/tmp/scoped.ts";
+    const displayPath = "scoped.ts";
+    const rawLines = [
+      "export function alpha() {",
+      "  const target = 1;",
+      "  return target + target;",
+      "}",
+    ];
+
+    const ptcLines = rawLines.map((raw, index) => buildPtcLine(index + 1, raw));
+    const records: GrepOutputRecord[] = ptcLines.map((line, index) => ({
+      ...line,
+      path: absolutePath,
+      kind: index === 1 || index === 2 ? "match" : "context",
+    }));
+
+    const built = buildGrepOutput({
+      summary: false,
+      totalMatches: 2,
+      groups: [
+        {
+          displayPath,
+          absolutePath,
+          matchCount: 2,
+          scope: {
+            mode: "symbol",
+            symbol: {
+              name: "alpha",
+              kind: "function",
+              startLine: 1,
+              endLine: 4,
+            },
+            matchLines: [2, 3],
+          },
+          entries: ptcLines.map((line, index) => ({
+            kind: index === 1 || index === 2 ? ("match" as const) : ("context" as const),
+            line,
+          })),
+        },
+      ],
+      records,
+      scopeMode: "symbol",
+      scopeWarnings: [],
+    });
+
+    expect(built.text).toBe([
+      "[2 matches in 1 files]",
+      "--- scoped.ts :: function alpha (1-4, 2 matches) ---",
+      `scoped.ts:  ${ptcLines[0].anchor}|${ptcLines[0].display}`,
+      `scoped.ts:>>${ptcLines[1].anchor}|${ptcLines[1].display}`,
+      `scoped.ts:>>${ptcLines[2].anchor}|${ptcLines[2].display}`,
+      `scoped.ts:  ${ptcLines[3].anchor}|${ptcLines[3].display}`,
+    ].join("\n"));
+
+    expect(built.ptcValue.records).toEqual(records);
+    expect(built.ptcValue.scopes).toEqual({
+      mode: "symbol",
+      groups: [
+        {
+          path: absolutePath,
+          displayPath,
+          symbol: {
+            name: "alpha",
+            kind: "function",
+            startLine: 1,
+            endLine: 4,
+          },
+          matchCount: 2,
+          matchLines: [2, 3],
+          lineAnchors: ptcLines.map((line) => line.anchor),
+        },
+      ],
+      warnings: [],
+    });
+  });
+});

--- a/tests/grep-symbol-scope-first-line.test.ts
+++ b/tests/grep-symbol-scope-first-line.test.ts
@@ -1,0 +1,46 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { ensureHashInit } from "../src/hashline.js";
+import { buildPtcLine } from "../src/ptc-value.js";
+import { scopeGrepGroupsToSymbols } from "../src/grep-symbol-scope.js";
+import { DetailLevel, SymbolKind } from "../src/readmap/enums.js";
+import type { FileMap } from "../src/readmap/types.js";
+
+describe("scopeGrepGroupsToSymbols ordering", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("keeps deterministic ordering when groups include separators", () => {
+    const lines = ["export function alpha() {", "  const x = 1;", "}"];
+    const map: FileMap = {
+      path: "/tmp/a.ts",
+      totalLines: 3,
+      totalBytes: lines.join("\n").length,
+      language: "typescript",
+      detailLevel: DetailLevel.Full,
+      imports: [],
+      symbols: [{ name: "alpha", kind: SymbolKind.Function, startLine: 1, endLine: 3 }],
+    };
+
+    const scoped = scopeGrepGroupsToSymbols({
+      groups: [
+        {
+          displayPath: "a.ts",
+          absolutePath: "/tmp/a.ts",
+          matchCount: 1,
+          entries: [
+            { kind: "separator", text: "--" },
+            { kind: "match", line: buildPtcLine(2, lines[1]) },
+          ],
+        },
+      ],
+      fileLinesByPath: new Map([["/tmp/a.ts", lines]]),
+      fileMapsByPath: new Map([["/tmp/a.ts", map]]),
+      contextLines: 0,
+    });
+
+    expect(scoped.warnings).toEqual([]);
+    expect(scoped.groups).toHaveLength(1);
+    expect(scoped.groups[0].scope?.symbol.name).toBe("alpha");
+  });
+});

--- a/tests/grep-symbol-scope-schema.test.ts
+++ b/tests/grep-symbol-scope-schema.test.ts
@@ -1,0 +1,71 @@
+// tests/grep-symbol-scope-schema.test.ts
+import { describe, it, expect } from "vitest";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { registerGrepTool } from "../src/grep.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function getGrepTool() {
+  let capturedTool: any = null;
+  registerGrepTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  if (!capturedTool) throw new Error("grep tool was not registered");
+  return capturedTool;
+}
+
+async function callGrepTool(params: {
+  pattern: string;
+  path: string;
+  literal?: boolean;
+  context?: number;
+  summary?: boolean;
+  scope?: "symbol";
+}) {
+  const tool = await getGrepTool();
+  return tool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function getTextContent(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("grep scope schema passthrough", () => {
+  it("adds optional scope while preserving summary mode and default output", async () => {
+    const tool = await getGrepTool();
+    expect(tool.parameters.properties.scope).toBeDefined();
+    expect(tool.parameters.properties.scope.const).toBe("symbol");
+    expect(tool.parameters.required ?? []).not.toContain("scope");
+
+    const filePath = resolve(fixturesDir, "small.ts");
+
+    const summaryBaseline = await callGrepTool({
+      pattern: "export",
+      path: filePath,
+      literal: true,
+      summary: true,
+    });
+
+    const summaryScoped = await callGrepTool({
+      pattern: "export",
+      path: filePath,
+      literal: true,
+      summary: true,
+      scope: "symbol",
+    });
+
+    expect(getTextContent(summaryScoped)).toBe(getTextContent(summaryBaseline));
+    expect(summaryScoped.details?.ptcValue).toEqual(summaryBaseline.details?.ptcValue);
+
+    const normal = await callGrepTool({
+      pattern: "createDemoDirectory",
+      path: filePath,
+      literal: true,
+      context: 1,
+    });
+
+    expect(getTextContent(normal)).toContain("--- small.ts (1 matches) ---");
+    expect(normal.details?.ptcValue?.records).toHaveLength(3);
+    expect((normal.details?.ptcValue as any).scopes).toBeUndefined();
+  });
+});

--- a/tests/grep-symbol-scope.test.ts
+++ b/tests/grep-symbol-scope.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve, dirname, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import { computeLineHash, ensureHashInit, escapeControlCharsForDisplay } from "../src/hashline.js";
+import { registerGrepTool } from "../src/grep.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function getGrepTool() {
+  let capturedTool: any = null;
+  registerGrepTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  if (!capturedTool) throw new Error("grep tool was not registered");
+  return capturedTool;
+}
+
+async function callGrepTool(params: {
+  pattern: string;
+  path: string;
+  literal?: boolean;
+  context?: number;
+  summary?: boolean;
+  scope?: "symbol";
+}) {
+  const tool = await getGrepTool();
+  return tool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function getTextContent(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+function writeFixture(name: string, content: string): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "pi-grep-scope-"));
+  const filePath = resolve(dir, name);
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+describe("grep scope=symbol integration", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("groups multiple matches from the same symbol into one deterministic symbol block", async () => {
+    const filePath = writeFixture("scoped.ts", [
+      "export function alpha() {",
+      "  const scoped = 1;",
+      "  console.log(scoped);",
+      "  return scoped;",
+      "}",
+    ].join("\n"));
+
+    const lines = [
+      "export function alpha() {",
+      "  const scoped = 1;",
+      "  console.log(scoped);",
+      "  return scoped;",
+      "}",
+    ];
+
+    const result = await callGrepTool({ pattern: "scoped", path: filePath, literal: true, scope: "symbol" });
+    const text = getTextContent(result);
+    const ptc = result.details?.ptcValue;
+    const displayPath = basename(filePath);
+
+    expect(text).toBe([
+      "[3 matches in 1 files]",
+      `--- ${displayPath} :: function alpha (1-5, 3 matches) ---`,
+      ...lines.map((raw, index) => {
+        const lineNumber = index + 1;
+        const hash = computeLineHash(lineNumber, raw);
+        const marker = lineNumber >= 2 && lineNumber <= 4 ? ">>" : "  ";
+        return `${displayPath}:${marker}${lineNumber}:${hash}|${escapeControlCharsForDisplay(raw)}`;
+      }),
+    ].join("\n"));
+
+    expect(text.match(/:: function alpha/g)).toHaveLength(1);
+    expect(ptc.records).toHaveLength(5);
+    expect(ptc.scopes).toEqual({
+      mode: "symbol",
+      groups: [{
+        path: filePath,
+        displayPath,
+        symbol: { name: "alpha", kind: "function", startLine: 1, endLine: 5 },
+        matchCount: 3,
+        matchLines: [2, 3, 4],
+        lineAnchors: lines.map((raw, index) => {
+          const lineNumber = index + 1;
+          return `${lineNumber}:${computeLineHash(lineNumber, raw)}`;
+        }),
+      }],
+      warnings: [],
+    });
+  });
+
+  it("falls back to normal grep output with warnings when a match has no enclosing symbol", async () => {
+    const filePath = writeFixture("no-symbol.ts", [
+      "// lonely marker",
+      "export function alpha() {",
+      "  return 1;",
+      "}",
+    ].join("\n"));
+
+    const result = await callGrepTool({ pattern: "lonely", path: filePath, literal: true, context: 1, scope: "symbol" });
+    const text = getTextContent(result);
+    const ptc = result.details?.ptcValue;
+
+    expect(text).toContain(`[Warning: no enclosing symbol for ${filePath}:1 — showing normal grep lines for this match]`);
+    expect(text).toContain("--- no-symbol.ts (1 matches) ---");
+    expect(text).not.toContain(":: function");
+    expect(ptc.scopes.warnings).toEqual([{ code: "no-enclosing-symbol", message: `[Warning: no enclosing symbol for ${filePath}:1 — showing normal grep lines for this match]`, path: filePath, line: 1 }]);
+  });
+
+  it("falls back to normal grep output with warnings when the file is unmappable", async () => {
+    const filePath = resolve(fixturesDir, "plain.txt");
+    const result = await callGrepTool({ pattern: "plain text", path: filePath, literal: true, scope: "symbol" });
+    const text = getTextContent(result);
+    const ptc = result.details?.ptcValue;
+
+    expect(text).toContain(`[Warning: symbol scoping unavailable for ${filePath} — showing normal grep lines for this file]`);
+    expect(text).toContain("--- plain.txt (1 matches) ---");
+    expect(ptc.records.length).toBeGreaterThan(0);
+    expect(ptc.scopes.warnings).toEqual([{ code: "unmappable-file", message: `[Warning: symbol scoping unavailable for ${filePath} — showing normal grep lines for this file]`, path: filePath }]);
+  });
+});

--- a/tests/read-bundle-schema.test.ts
+++ b/tests/read-bundle-schema.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { registerReadTool } from "../src/read.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function getReadTool() {
+  let capturedTool: any = null;
+  registerReadTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  if (!capturedTool) throw new Error("read tool was not registered");
+  return capturedTool;
+}
+
+async function callReadTool(params: { path: string; offset?: number; limit?: number; symbol?: string; map?: boolean; bundle?: "local"; }) {
+  const tool = await getReadTool();
+  return tool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function getTextContent(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("read bundle schema validation", () => {
+  it("adds bundle and validates combos", async () => {
+    const tool = await getReadTool();
+    expect(tool.parameters.properties.bundle).toBeDefined();
+    expect(tool.parameters.properties.bundle.const).toBe("local");
+    expect(tool.parameters.required ?? []).not.toContain("bundle");
+
+    const filePath = resolve(fixturesDir, "small.ts");
+    const baseline = await callReadTool({ path: filePath, symbol: "createDemoDirectory" });
+    expect(getTextContent(baseline)).toMatch(/^\[Symbol: createDemoDirectory \(function\), lines 45-49 of 49\]/);
+    expect(getTextContent(baseline)).not.toContain("## Requested symbol");
+    expect((baseline.details?.ptcValue as any).bundle).toBeUndefined();
+
+    const withoutSymbol = await callReadTool({ path: filePath, bundle: "local" });
+    expect(withoutSymbol.isError).toBe(true);
+    expect(getTextContent(withoutSymbol)).toBe('Cannot use bundle without symbol. Use read({ path, symbol, bundle: "local" }).');
+
+    const withMap = await callReadTool({ path: filePath, symbol: "createDemoDirectory", bundle: "local", map: true });
+    expect(withMap.isError).toBe(true);
+    expect(getTextContent(withMap)).toBe("Cannot combine bundle with map. Use one or the other.");
+
+    const withOffset = await callReadTool({ path: filePath, symbol: "createDemoDirectory", bundle: "local", offset: 1 });
+    expect(withOffset.isError).toBe(true);
+    expect(getTextContent(withOffset)).toBe("Cannot combine symbol with offset/limit. Use one or the other.");
+  });
+});

--- a/tests/read-local-bundle-integration.test.ts
+++ b/tests/read-local-bundle-integration.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import { computeLineHash, ensureHashInit, escapeControlCharsForDisplay } from "../src/hashline.js";
+import { clearMapCache } from "../src/map-cache.js";
+import * as bundleModule from "../src/read-local-bundle.js";
+import { registerReadTool } from "../src/read.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function getReadTool() {
+  let capturedTool: any = null;
+  registerReadTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  if (!capturedTool) throw new Error("read tool was not registered");
+  return capturedTool;
+}
+
+async function callReadTool(params: { path: string; symbol?: string; bundle?: "local"; map?: boolean; offset?: number; limit?: number; }) {
+  const tool = await getReadTool();
+  return tool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function getTextContent(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+function writeFixture(name: string, content: string): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "pi-read-bundle-"));
+  const filePath = resolve(dir, name);
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+describe("read bundle=local integration", () => {
+  beforeAll(async () => { await ensureHashInit(); });
+  beforeEach(() => { clearMapCache(); });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("renders requested symbol plus local support", async () => {
+    const sourceLines = [
+      "function helperOne() {", "  return 1;", "}", "",
+      "function helperTwo(value: number) {", "  return value * 2;", "}", "",
+      "export function target() {", "  const value = helperOne();", "  return helperTwo(value);", "}",
+    ];
+    const filePath = writeFixture("local-bundle.ts", sourceLines.join("\n"));
+    const result = await callReadTool({ path: filePath, symbol: "target", bundle: "local" });
+    const text = getTextContent(result);
+    const ptc = result.details?.ptcValue;
+
+    expect(text).toBe([
+      "[Symbol: target (function), lines 9-12 of 12]", "", "## Requested symbol",
+      ...sourceLines.slice(8, 12).map((raw, index) => {
+        const lineNumber = index + 9;
+        return `${lineNumber}:${computeLineHash(lineNumber, raw)}|${escapeControlCharsForDisplay(raw)}`;
+      }),
+      "", "## Local support",
+      ...sourceLines.slice(0, 3).map((raw, index) => {
+        const lineNumber = index + 1;
+        return `${lineNumber}:${computeLineHash(lineNumber, raw)}|${escapeControlCharsForDisplay(raw)}`;
+      }),
+      ...sourceLines.slice(4, 7).map((raw, index) => {
+        const lineNumber = index + 5;
+        return `${lineNumber}:${computeLineHash(lineNumber, raw)}|${escapeControlCharsForDisplay(raw)}`;
+      }),
+    ].join("\n"));
+
+    expect(ptc.symbol).toEqual({ query: "target", name: "target", kind: "function", parentName: undefined, startLine: 9, endLine: 12 });
+    expect(ptc.bundle).toEqual({
+      mode: "local",
+      applied: true,
+      localSupport: [
+        {
+          name: "helperOne", kind: "function", startLine: 1, endLine: 3,
+          lineAnchors: sourceLines.slice(0, 3).map((raw, index) => `${index + 1}:${computeLineHash(index + 1, raw)}`),
+        },
+        {
+          name: "helperTwo", kind: "function", startLine: 5, endLine: 7,
+          lineAnchors: sourceLines.slice(4, 7).map((raw, index) => `${index + 5}:${computeLineHash(index + 5, raw)}`),
+        },
+      ],
+      warnings: [],
+    });
+  });
+
+  it("falls back to plain symbol read when local bundle context cannot be determined", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    vi.spyOn(bundleModule, "buildLocalBundle").mockReturnValue(null);
+    const result = await callReadTool({ path: filePath, symbol: "createDemoDirectory", bundle: "local" });
+    const text = getTextContent(result);
+    const ptc = result.details?.ptcValue;
+
+    expect(text).toContain("[Warning: local bundle context could not be determined for symbol 'createDemoDirectory' — showing plain symbol read]");
+    expect(text).toMatch(/^\[Warning: local bundle context could not be determined for symbol 'createDemoDirectory' — showing plain symbol read\]\n\n\[Symbol: createDemoDirectory \(function\), lines 45-49 of 49\]/);
+    expect(text).not.toContain("## Requested symbol");
+    expect(ptc.bundle).toEqual({
+      mode: "local",
+      applied: false,
+      localSupport: [],
+      warnings: [{ code: "bundle-context-unavailable", message: "[Warning: local bundle context could not be determined for symbol 'createDemoDirectory' — showing plain symbol read]" }],
+    });
+  });
+
+  it("falls back with warnings when symbol mapping is unavailable", async () => {
+    const mapCacheModule = await import("../src/map-cache.js");
+    vi.spyOn(mapCacheModule, "getOrGenerateMap").mockResolvedValue(null);
+
+    const filePath = resolve(fixturesDir, "plain.txt");
+    const result = await callReadTool({ path: filePath, symbol: "anything", bundle: "local" });
+    const text = getTextContent(result);
+    const ptc = result.details?.ptcValue;
+
+    expect(text).toContain("[Warning: local bundle unavailable because symbol mapping is not available for .txt files — showing plain symbol read]");
+    expect(text).toContain("[Warning: symbol lookup not available for .txt files — showing full file]");
+    expect(ptc.bundle).toEqual({
+      mode: "local",
+      applied: false,
+      localSupport: [],
+      warnings: [{ code: "bundle-unmappable", message: "[Warning: local bundle unavailable because symbol mapping is not available for .txt files — showing plain symbol read]" }],
+    });
+  });
+});

--- a/tests/read-local-bundle.test.ts
+++ b/tests/read-local-bundle.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import type { FileMap } from "../src/readmap/types.js";
+import { DetailLevel, SymbolKind } from "../src/readmap/enums.js";
+import { buildLocalBundle } from "../src/read-local-bundle.js";
+
+const sourceLines = [
+  "function helperOne() {",
+  "  return 1;",
+  "}",
+  "",
+  "function helperTwo(value: number) {",
+  "  return value * 2;",
+  "}",
+  "",
+  "export function target() {",
+  "  const value = helperOne();",
+  "  return helperTwo(value);",
+  "}",
+  "",
+  "function unusedHelper() {",
+  "  return 99;",
+  "}",
+];
+
+const fileMap: FileMap = {
+  path: "/tmp/local-bundle.ts",
+  totalLines: sourceLines.length,
+  totalBytes: sourceLines.join("\n").length,
+  language: "typescript",
+  detailLevel: DetailLevel.Full,
+  imports: [],
+  symbols: [
+    { name: "helperOne", kind: SymbolKind.Function, startLine: 1, endLine: 3 },
+    { name: "helperTwo", kind: SymbolKind.Function, startLine: 5, endLine: 7 },
+    { name: "target", kind: SymbolKind.Function, startLine: 9, endLine: 12 },
+    { name: "unusedHelper", kind: SymbolKind.Function, startLine: 14, endLine: 16 },
+  ],
+};
+
+describe("buildLocalBundle", () => {
+  it("returns direct same-file support in source order without unrelated symbols", () => {
+    const bundle = buildLocalBundle(
+      fileMap,
+      { name: "target", kind: SymbolKind.Function, startLine: 9, endLine: 12 },
+      sourceLines,
+    );
+
+    expect(bundle).toEqual({
+      requested: { name: "target", kind: "function", startLine: 9, endLine: 12 },
+      support: [
+        {
+          symbol: { name: "helperOne", kind: "function", startLine: 1, endLine: 3 },
+          lines: sourceLines.slice(0, 3),
+        },
+        {
+          symbol: { name: "helperTwo", kind: "function", startLine: 5, endLine: 7 },
+          lines: sourceLines.slice(4, 7),
+        },
+      ],
+    });
+  });
+
+  it("returns null when a directly referenced local symbol name is ambiguous", () => {
+    const ambiguousMap: FileMap = {
+      ...fileMap,
+      symbols: [
+        { name: "helper", kind: SymbolKind.Function, startLine: 1, endLine: 3 },
+        { name: "helper", kind: SymbolKind.Function, startLine: 5, endLine: 7 },
+        { name: "target", kind: SymbolKind.Function, startLine: 9, endLine: 12 },
+      ],
+    };
+
+    const ambiguousLines = [
+      "function helper() {",
+      "  return 1;",
+      "}",
+      "",
+      "function helper() {",
+      "  return 2;",
+      "}",
+      "",
+      "export function target() {",
+      "  return helper();",
+      "}",
+    ];
+
+    expect(
+      buildLocalBundle(
+        ambiguousMap,
+        { name: "target", kind: SymbolKind.Function, startLine: 9, endLine: 11 },
+        ambiguousLines,
+      ),
+    ).toBeNull();
+  });
+});

--- a/tests/read-output-bundle.test.ts
+++ b/tests/read-output-bundle.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { buildPtcLine } from "../src/ptc-value.js";
+import { ensureHashInit } from "../src/hashline.js";
+import { buildReadOutput } from "../src/read-output.js";
+
+describe("buildReadOutput bundle sections", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("renders requested symbol and local support sections while adding ptcValue.bundle", () => {
+    const sourceLines = [
+      "function helperOne() {",
+      "  return 1;",
+      "}",
+      "",
+      "function helperTwo(value: number) {",
+      "  return value * 2;",
+      "}",
+      "",
+      "export function target() {",
+      "  const value = helperOne();",
+      "  return helperTwo(value);",
+      "}",
+    ];
+
+    const built = buildReadOutput({
+      path: "/tmp/local-bundle.ts",
+      startLine: 9,
+      endLine: 12,
+      totalLines: 12,
+      selectedLines: sourceLines.slice(8, 12),
+      warnings: [],
+      truncation: null,
+      continuation: null,
+      symbol: {
+        query: "target",
+        name: "target",
+        kind: "function",
+        startLine: 9,
+        endLine: 12,
+      },
+      bundle: {
+        mode: "local",
+        applied: true,
+        localSupport: [
+          {
+            symbol: {
+              query: "helperOne",
+              name: "helperOne",
+              kind: "function",
+              startLine: 1,
+              endLine: 3,
+            },
+            lines: sourceLines.slice(0, 3),
+          },
+          {
+            symbol: {
+              query: "helperTwo",
+              name: "helperTwo",
+              kind: "function",
+              startLine: 5,
+              endLine: 7,
+            },
+            lines: sourceLines.slice(4, 7),
+          },
+        ],
+        warnings: [],
+      },
+    } as any);
+
+    const requestedLines = sourceLines.slice(8, 12).map((raw, index) => buildPtcLine(index + 9, raw));
+    const helperOneLines = sourceLines.slice(0, 3).map((raw, index) => buildPtcLine(index + 1, raw));
+    const helperTwoLines = sourceLines.slice(4, 7).map((raw, index) => buildPtcLine(index + 5, raw));
+
+    expect(built.text).toBe([
+      "[Symbol: target (function), lines 9-12 of 12]",
+      "",
+      "## Requested symbol",
+      ...requestedLines.map((line) => `${line.anchor}|${line.display}`),
+      "",
+      "## Local support",
+      ...helperOneLines.map((line) => `${line.anchor}|${line.display}`),
+      ...helperTwoLines.map((line) => `${line.anchor}|${line.display}`),
+    ].join("\n"));
+
+    expect((built.ptcValue as any).bundle).toEqual({
+      mode: "local",
+      applied: true,
+      localSupport: [
+        {
+          name: "helperOne",
+          kind: "function",
+          startLine: 1,
+          endLine: 3,
+          lineAnchors: helperOneLines.map((line) => line.anchor),
+        },
+        {
+          name: "helperTwo",
+          kind: "function",
+          startLine: 5,
+          endLine: 7,
+          lineAnchors: helperTwoLines.map((line) => line.anchor),
+        },
+      ],
+      warnings: [],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds two additive API extensions to `grep` and `read` that provide symbol-aware context without breaking existing consumers.

### `grep({ scope: "symbol" })`
- Groups matches by enclosing symbol block with full symbol context
- Deterministic fallback for unmappable files and orphan matches (with structured + human warnings)
- Adds `ptcValue.scopes` metadata alongside unchanged `ptcValue.records`
- `summary: true` ignores `scope` — preserves existing per-file summary behavior

### `read({ symbol, bundle: "local" })`
- Returns the requested symbol plus directly-referenced same-file helper symbols
- Renders `## Requested symbol` and `## Local support` sections
- Adds `ptcValue.bundle` metadata alongside existing symbol output
- Conservative bailout: ambiguous identifier matches → fallback to plain symbol read with warning
- Invalid combos (`bundle` without `symbol`, `bundle` + `map`, `bundle` + `offset`) return clear errors

### Design principles
- **Strictly additive** — omitting the new params produces byte-identical output
- **Backward compatible** — `ptcValue.records` unchanged, existing consumers unaffected
- **Hashline-safe** — all anchors in scoped/bundled output are standard hashlines

### New files
- `src/grep-symbol-scope.ts` — symbol scoping resolver
- `src/read-local-bundle.ts` — same-file bundle resolver

### Tests
- 8 new test files, 13 new tests
- Full suite: 100 files, 496 tests, 0 failures
- Typecheck clean

Closes #062