### PR TITLE
feat: add semantic edit summaries with optional difftastic

### DIFF
--- a/.megapowers/CHANGELOG.md
+++ b/.megapowers/CHANGELOG.md
@@ -263,3 +263,33 @@ The original PR/branch history is still valid historical context, but #039 shoul
 ### Tests
 - 28 new unit tests across `tests/read-render-helpers.test.ts` and `tests/grep-render-helpers.test.ts`
 - pi-hashline-readmap: 92 files, 483 tests, 0 failures
+
+## Issue #062: Additive Output Contracts for grep scope="symbol" and read bundle="local" — CLOSED ✅
+**Date**: 2026-03-24
+
+### Added
+- `grep` tool accepts optional `scope: "symbol"` parameter that groups matches by enclosing symbol block with deterministic fallback for unmappable files and orphan matches (#062)
+- `grep` scoped output adds additive `ptcValue.scopes` metadata (mode, groups, warnings) alongside unchanged `ptcValue.records` (#062)
+- `read` tool accepts optional `bundle: "local"` parameter that includes the requested symbol plus directly-referenced same-file helper symbols (#062)
+- `read` bundled output renders `## Requested symbol` and `## Local support` sections with additive `ptcValue.bundle` metadata (#062)
+- Invalid `bundle` parameter combinations (`bundle` without `symbol`, `bundle` + `map`, `bundle` + `offset`) return clear error messages (#062)
+- Structured + human-readable fallback warnings for: unmappable files, no enclosing symbol, bundle context unavailable, symbol mapping unavailable (#062)
+- New modules: `src/grep-symbol-scope.ts`, `src/grep-output.ts` (extended), `src/read-local-bundle.ts`, `src/read-output.ts` (extended) (#062)
+
+### Tests
+- 8 new test files, 13 new tests covering schema, output rendering, integration, and fallback paths
+- pi-hashline-readmap: 100 files, 496 tests, 0 failures
+
+## Issue #066: Agent Ecosystem Local Navigation Upgrade — CLOSED ✅
+**Date**: 2026-03-24
+
+### Added
+- Added semantic edit classification for `edit` results with additive `details.ptcValue.semanticSummary` metadata (`no-op`, `whitespace-only`, `semantic`, `mixed`) (#066)
+- Added optional difftastic-backed semantic classification with process-lifetime availability caching and silent fallback to internal heuristics (#066)
+- Added moved-block counting for matching lhs-only/rhs-only difftastic chunks and surfaced semantic badges in edit TUI results (`ws-only`, `✓ semantic`, `mixed`) (#066)
+- Documented semantic edit classification and optional difftastic support in `README.md` (#066)
+- Marked source issues #063 and #064 as done because they were already shipped in PR #26 (#066)
+
+### Tests
+- Added 7 semantic-classification test files covering heuristics, difftastic availability, JSON parsing, subprocess fallback, edit integration, ptc output, and TUI badges
+- pi-hashline-readmap: 107 files, 524 tests, 0 failures

--- a/.megapowers/state.json
+++ b/.megapowers/state.json
@@ -1,17 +1,75 @@
 {
   "version": 1,
-  "activeIssue": null,
-  "workflow": null,
-  "phase": null,
-  "phaseHistory": [],
+  "activeIssue": "066-agent-ecosystem-local-navigation-upgrade",
+  "workflow": "feature",
+  "phase": "done",
+  "phaseHistory": [
+    {
+      "from": "brainstorm",
+      "to": "spec",
+      "timestamp": 1774355407432
+    },
+    {
+      "from": "spec",
+      "to": "plan",
+      "timestamp": 1774355960362
+    },
+    {
+      "from": "plan",
+      "to": "implement",
+      "timestamp": 1774356283048
+    },
+    {
+      "from": "implement",
+      "to": "verify",
+      "timestamp": 1774357387206
+    },
+    {
+      "from": "verify",
+      "to": "implement",
+      "timestamp": 1774358551212
+    },
+    {
+      "from": "implement",
+      "to": "verify",
+      "timestamp": 1774358645465
+    },
+    {
+      "from": "verify",
+      "to": "code-review",
+      "timestamp": 1774358807846
+    },
+    {
+      "from": "code-review",
+      "to": "done",
+      "timestamp": 1774358949460
+    }
+  ],
   "planMode": null,
-  "planIteration": 0,
+  "planIteration": 1,
   "currentTaskIndex": 0,
-  "completedTasks": [],
+  "completedTasks": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    1
+  ],
   "tddTaskState": null,
-  "doneActions": [],
-  "doneChecklistShown": false,
+  "doneActions": [
+    "generate-docs",
+    "write-changelog",
+    "capture-learnings",
+    "push-and-pr",
+    "close-issue"
+  ],
+  "doneChecklistShown": true,
   "megaEnabled": true,
-  "branchName": null,
-  "baseBranch": null
+  "branchName": "feat/066-agent-ecosystem-local-navigation-upgrade",
+  "baseBranch": "main"
 }

--- a/README.md
+++ b/README.md
@@ -3,125 +3,200 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![npm](https://img.shields.io/npm/v/pi-hashline-readmap)](https://www.npmjs.com/package/pi-hashline-readmap)
 
-A drop-in [pi](https://github.com/mariozechner/pi-coding-agent) extension that replaces the stock `read`, `edit`, `grep`, and `sg` tools with a unified toolset built for reliable agent coding. It also compresses noisy `bash` output so more context budget goes to code.
+A drop-in [pi](https://github.com/mariozechner/pi-coding-agent) extension that upgrades the agent’s local coding workflow with hash-anchored reads and edits, structural file maps, symbol-aware navigation, structural search, and compressed `bash` output.
 
-## Why use this instead of the stock tools?
+It replaces the stock `read`, `edit`, and `grep` tools, provides an enhanced `sg` tool, and post-processes `bash` output so more context budget goes to useful information instead of noise.
+
+## Why install this?
+
+If you use pi for real code changes, the stock toolchain has a few recurring problems:
+- search and read output is easy for a model to paraphrase incorrectly
+- follow-up edits can drift to the wrong line when the file changes
+- large files cost too many tokens to navigate
+- searching often requires an extra read just to understand symbol context
+- raw `bash` output wastes context on noise from tests, builds, Git, linters, and package managers
+
+`pi-hashline-readmap` fixes those problems with a single coherent package instead of stacking multiple overlapping extensions.
+
+## Benefits
 
 ### Safer edits
-
-Stock read/search output is easy for a model to paraphrase or drift from. This package returns **`LINE:HASH|content` anchors** so follow-up edits target the exact line that was read:
+`read`, `grep`, and `sg` return `LINE:HASH|content` anchors. Those anchors can be fed directly into `edit`, which means the model edits exactly the line it read.
 
 ```text
 45:e4|router.addRoute("/api", handler);
 ```
 
-Fewer accidental wrong-line edits, better resistance to file drift, more reliable surgical changes.
+That reduces wrong-line edits, makes file drift visible, and keeps surgical changes reliable.
 
-### Better navigation on large files
+### Faster navigation in real codebases
+Instead of opening big files blindly, the `read` tool can append a structural map of classes, functions, methods, and ranges. You can jump directly to the relevant symbol or section.
 
-Reads can append a **structural map** showing classes, functions, methods, and line ranges — so the agent sees the shape of a file instead of scrolling blind.
+### Better local code understanding
+This package stays focused on local file and symbol work:
+- symbol lookup in `read`
+- symbol-scoped grep with enclosing symbol blocks
+- local same-file support bundles for `read(symbol=...)`
+- structural code search via `sg`
 
-### Direct symbol lookup
+That gives agents more context without turning this package into a repo-wide code graph tool.
 
-Instead of hunting with offsets:
+### Lower context waste from shell output
+`bash` output is filtered and compressed for common noisy commands, including test runners, build tools, Git, Docker, linters, and package managers.
 
-```ts
-read({ path: "src/server.ts", symbol: "handleRequest" })
-read({ path: "src/router.ts", symbol: "Router.addRoute" })
-```
+### One extension instead of extension conflicts
+A common pi failure mode is installing several packages that all want to own `read`, `grep`, or `edit`. This package intentionally unifies those improvements in one place.
 
-Cuts tokens and reduces exploratory round-trips.
+## Common use cases
 
-### Search results that are immediately editable
+This package is a good fit when you want pi to:
+- make precise, anchor-safe edits in source files
+- inspect large files without reading the entire file
+- jump directly to a function, method, or class by name
+- search for code and immediately edit the result without an extra cleanup read
+- search within enclosing symbols instead of only matching lines
+- inspect a symbol together with nearby same-file support code
+- run tests or builds without flooding the model context with irrelevant output
 
-`grep` and `sg` output is hashline-anchored, so the agent can go straight from search to edit without a cleanup read in between.
+## What this package includes
+
+## `read`
+- `LINE:HASH|content` output
+- structural maps via `map: true`
+- automatic map append on truncated reads
+- symbol lookup via `symbol`
+- local symbol bundles via `bundle: "local"`
+- image delegation to pi’s built-in image handling
+- binary detection and display-safe control character escaping
+- custom TUI rendering with symbol, map, warning, and truncation badges
+
+### `read` feature details
+- Structural maps support **17 languages**: TypeScript, JavaScript, Python, Rust, Go, C, C++, Clojure, SQL, JSON, JSONL, Markdown, YAML, TOML, CSV, and related mapped variants in the readmap engine.
+- `symbol` and `map` are mutually exclusive.
+- `symbol` cannot be combined with `offset` or `limit`.
+- `bundle: "local"` requires `symbol` and cannot be combined with `map` or `offset`.
+
+## `edit`
+- hash-verified anchored edits using `LINE:HASH` anchors from `read`, `grep`, or `sg`
+- operations: `set_line`, `replace_lines`, `insert_after`, `replace`
+- compact diff and full diff support
+- mismatch diagnostics with context
+- custom TUI rendering with diff stats and warnings
+- additive semantic summaries in structured output
 
 ### Semantic edit classification
+After each successful edit, `details.ptcValue.semanticSummary` classifies the change as:
+- `no-op`
+- `whitespace-only`
+- `semantic`
+- `mixed`
 
-After each successful edit, the result includes a `semanticSummary` in the structured output (`details.ptcValue.semanticSummary`) that classifies the change as `semantic`, `whitespace-only`, `mixed`, or `no-op`. This helps agents and reviewers quickly assess whether a change is substantive or cosmetic.
+When [difftastic](https://difftastic.wilfred.me/) (`difft`) is installed, classification uses AST-aware diffing for better formatting-only detection and moved-block summaries. When difftastic is unavailable or fails, the tool falls back silently to internal heuristics.
 
-When [difftastic](https://difftastic.wilfred.me/) (`difft`) is installed, classification uses AST-aware diffing for more accurate results — especially for detecting moved code blocks and formatting-only changes. Without difftastic, the tool falls back to internal line-level heuristics. Install with:
+The success text output stays unchanged. Semantic classification is additive metadata only.
 
-```bash
-brew install difftastic
-```
+## `grep`
+- hash-anchored matches ready for direct use with `edit`
+- context lines with deduped and merged windows
+- `summary: true` mode for per-file match counts
+- result truncation indicators
+- symbol-scoped results via `scope: "symbol"`
+- custom TUI rendering with match distribution and truncation badges
 
-### Less wasted context on noisy command output
+### Symbol-scoped grep
+With `scope: "symbol"`, matches are grouped by their enclosing function, method, class, or other mapped symbol when possible. Unsupported files and unmappable cases fall back gracefully to normal grep output.
 
-`bash` outputs from test runners, builds, git, linters, Docker, package managers, and more are compressed to the parts that matter.
+## `sg`
+- wraps [ast-grep](https://ast-grep.github.io/) for structural code search
+- returns merged, hash-anchored match blocks grouped by file
+- ideal for structure-aware search → edit workflows
+- custom TUI rendering
+- requires `ast-grep` installed locally
 
-### One package, no overlapping-tool fights
+## `bash` output compression
+The extension post-processes `bash` tool results to reduce noise while preserving the useful parts.
 
-A common pi problem is stacking multiple extensions that all want to own `read`, `grep`, or `edit` — leading to conflict and unpredictable behavior. This package unifies the overlapping improvements into one extension.
-
-## What you get
-
-### `read`
-
-- `LINE:HASH|content` output
-- Structural maps via `map: true` — supports **17 languages** (TypeScript, JavaScript, Python, Rust, Go, C, C++, Clojure, SQL, JSON, JSONL, Markdown, YAML, TOML, CSV)
-- Automatic maps on truncated reads
-- Symbol lookup via `symbol` param (dot notation for methods: `ClassName.methodName`)
-- `map` and `symbol` are mutually exclusive; `symbol` cannot combine with `offset`/`limit`
-- Image delegation, binary file detection, display-safe control character escaping
-- Custom TUI rendering with symbol/map/warning badges
-
-### `edit`
-
-- Hash-verified anchored edits using `LINE:HASH` anchors from `read`/`grep`/`sg`
-- Operations: `set_line`, `replace_lines`, `insert_after`, `replace`
-- Compact diff and full diff support
-- Mismatch diagnostics with context
-- Custom TUI rendering with diff preview
-
-### `grep`
-
-- Hash-anchored match output, ready to feed directly into `edit`
-- Context lines with deduped/merged windows
-- `summary: true` mode for file-level match counts
-- Truncation indicators when results hit the limit
-- Custom TUI rendering with match distribution and truncation badges
-
-### `sg`
-
-- Wraps [ast-grep](https://ast-grep.github.io/) for structural code search
-- Returns merged, hash-anchored match blocks grouped by file
-- Ideal for structural search → edit workflows
-- Custom TUI rendering
-- Requires `ast-grep` installed (`brew install ast-grep`)
-
-### `bash` output compression
-
-Eleven specialized compressors for common command output:
-
-| Compressor | What it handles |
-|---|---|
-| test-output | Test runner results (vitest, jest, pytest, etc.) |
-| build | Build tool output (tsc, esbuild, webpack, etc.) |
-| build-tools | Compiler/bundler noise |
-| git | Git command output |
-| linter | Linter results (eslint, shellcheck, etc.) |
-| docker | Docker build/run output |
-| package-manager | npm/yarn/pnpm install output |
-| http-client | curl/wget output |
-| transfer | rsync/scp output |
-| file-listing | ls/find/tree output |
-| truncate | Smart truncation for oversized output |
+Specialized compressors currently cover:
+- test runners
+- build tools
+- compiler / bundler noise
+- Git output
+- linter output
+- Docker output
+- package manager output
+- HTTP client output
+- transfer tools
+- file listing output
+- oversized generic output via smart truncation
 
 ANSI escape stripping runs on all bash output regardless.
 
-## Example workflows
+## Quick Start
 
-### Read → edit
+### Install from npm
+```bash
+pi install npm:pi-hashline-readmap
+```
 
+### Install from GitHub
+```bash
+pi install git:github.com/coctostan/pi-hashline-readmap
+```
+
+### Optional local tools
+```bash
+brew install ast-grep          # required for sg
+brew install difftastic        # optional, improves semantic edit summaries
+brew install shellcheck yq scc # optional, improves some bash output compression flows
+```
+
+After installation, use pi normally. The package registers the upgraded tools automatically.
+
+## Installation
+
+## Requirements
+- Node.js **>= 20**
+- [pi](https://github.com/mariozechner/pi-coding-agent) with extension support
+
+## Install methods
+
+### 1. npm package
+```bash
+pi install npm:pi-hashline-readmap
+```
+
+Use this if you want the published package.
+
+### 2. Git install
+```bash
+pi install git:github.com/coctostan/pi-hashline-readmap
+```
+
+Use this if you want to install directly from the repository without waiting for an npm publish.
+
+### 3. Local clone
+```bash
+git clone https://github.com/coctostan/pi-hashline-readmap.git
+cd pi-hashline-readmap
+npm install
+pi install .
+```
+
+Use this when developing locally or testing unreleased changes.
+
+## Usage
+
+## Typical workflow: read → edit
 ```text
 read({ path: "src/server.ts" })
 ```
 
+Example output:
 ```text
 45:e4|router.addRoute("/api", handler);
 ```
 
+Use the anchor directly in `edit`:
 ```text
 edit({
   path: "src/server.ts",
@@ -136,192 +211,207 @@ edit({
 })
 ```
 
-### Symbol read
-
+## Read a symbol directly
 ```text
 read({ path: "src/server.ts", symbol: "handleRequest" })
+read({ path: "src/router.ts", symbol: "Router.addRoute" })
 ```
 
-Returns only that symbol's body, already hashlined and ready for editing.
+This returns the symbol body only, already hashlined.
 
-### Read with a map
+## Read a symbol with local support
+```text
+read({ path: "src/server.ts", symbol: "handleRequest", bundle: "local" })
+```
 
+Use this when you want the requested symbol plus directly relevant same-file support code without opening the entire file.
+
+## Read a large file with a structural map
 ```text
 read({ path: "src/large-file.ts", map: true })
 ```
 
-Returns scoped hashlines plus a structural outline of the file.
+Use this when you need the shape of the file before choosing a symbol or line range.
 
-### Search → edit with grep
-
+## Search and edit directly with grep
 ```text
 grep({ pattern: "addRoute", path: "src", literal: true })
 ```
 
+Example output:
 ```text
 [3 matches in 2 files]
 --- src/server.ts (2 matches) ---
 src/server.ts:>>45:e4|router.addRoute("/api", handler);
 ```
 
-Use the anchor directly in `edit`.
+You can use the anchor from grep directly in `edit`.
 
-### Structural search with sg
+## Search within enclosing symbols
+```text
+grep({ pattern: "addRoute", path: "src", literal: true, scope: "symbol" })
+```
 
+Use this when the match location alone is not enough and you want the enclosing function or method block.
+
+## Structural code search with sg
 ```text
 sg({ pattern: "console.log($$$ARGS)", lang: "typescript", path: "src" })
 ```
 
-Returns hash-anchored AST matches grouped by file.
+Use this for AST-level search patterns instead of raw text matching.
 
-## Installation
+## Structured output (`details.ptcValue`)
+All tools provide machine-facing structured data alongside human-facing text output.
 
-### From npm
+### `read`
+Includes path, selected range, warnings, truncation info, symbol metadata, map status, and per-line anchors.
 
-```bash
-pi install npm:pi-hashline-readmap
-```
+### `grep`
+Includes total matches, per-record anchors, and additive symbol-scope metadata when `scope: "symbol"` is used.
 
-### From GitHub
+### `sg`
+Includes grouped match ranges and anchored lines.
 
-```bash
-pi install git:github.com/coctostan/pi-hashline-readmap
-```
+### `edit`
+Includes summary, diff, changed line, warnings, no-op metadata, and semantic edit classification.
 
-### From a local clone
-
-```bash
-git clone https://github.com/coctostan/pi-hashline-readmap.git
-cd pi-hashline-readmap
-npm install
-pi install .
-```
-
-## Requirements
-
-- Node.js **>= 20**
-- [pi](https://github.com/mariozechner/pi-coding-agent) with extension support
-
-Optional CLI tools for full functionality:
-
-```bash
-brew install ast-grep          # required for sg tool
-brew install difftastic        # semantic edit classification (optional)
-brew install shellcheck yq scc # used by some compressors
-```
-
-## PTC structured output
-
-All four tools expose machine-facing structured payloads at `details.ptcValue` alongside their human-facing `content[].text` output:
-
-- **`read`** — path, line range, warnings, truncation info, symbol metadata, map status, per-line anchors
-- **`grep`** — summary flag, total matches, per-match records with anchors
-- **`sg`** — per-file match ranges and anchored lines
-- **`edit`** — ok/fail, summary, diff, changed line, warnings, noop edits
-
-Hashes and anchors are tied to raw file content. `display` fields are escaped for safe rendering; `raw` fields preserve the underlying file text.
+Hashes and anchors are tied to raw file content. Display fields are escaped for safe rendering; raw fields preserve the underlying text.
 
 ### PTC tool policy contract
-
-The package exports a machine-readable policy contract via `HASHLINE_TOOL_PTC_POLICY` and `getHashlineToolPtcPolicy()`:
+The package exports a machine-readable tool policy contract. The primary export is `HASHLINE_TOOL_PTC_POLICY`, and the package also exports `getHashlineToolPtcPolicy()`.
 
 ```ts
 import { HASHLINE_TOOL_PTC_POLICY } from "pi-hashline-readmap";
 ```
 
-- `read` and `grep` are safe-by-default, read-only helpers.
-- `sg` is opt-in, read-only.
-- `edit` is not safe-by-default and is mutating/write-capable.
+Policy summary:
+- `read` and `grep` are safe-by-default and read-only
+- `sg` is opt-in and read-only
+- `edit` is not safe-by-default and is mutating
 
-`pi-prompt-assembler` may optionally consume this contract, but `pi-hashline-readmap` does not require it to function.
+`pi-prompt-assembler` may optionally consume this contract, but this package does not depend on it.
 
-### EventBus integration
-
-On load, the extension emits tool executor references for downstream PTC consumers:
+## EventBus integration
+On load, the extension emits tool executor references for downstream consumers:
 
 ```ts
 pi.events.emit("hashline:tool-executors", { read, edit, grep, sg });
 ```
 
-Also available at `globalThis.__hashlineToolExecutors`.
+The same executors are also exposed at `globalThis.__hashlineToolExecutors`.
+
+## Feature-by-feature reference
+
+## `read` parameters
+- `path` — file path
+- `offset` — 1-indexed start line
+- `limit` — max lines
+- `symbol` — direct symbol lookup
+- `map` — append structural map
+- `bundle: "local"` — include same-file local support for a symbol read
+
+## `grep` parameters
+- `pattern` — regex or literal pattern
+- `path` — file or directory
+- `glob` — file filter
+- `ignoreCase`
+- `literal`
+- `context`
+- `limit`
+- `summary`
+- `scope: "symbol"`
+
+## `edit` operations
+- `set_line`
+- `replace_lines`
+- `insert_after`
+- `replace`
+
+## `sg` parameters
+- `pattern`
+- `lang`
+- `path`
+
+## Project Structure
+```text
+index.ts                  # extension entry point
+src/
+  read.ts                 # read tool implementation
+  read-output.ts          # read output builder
+  read-local-bundle.ts    # local same-file support bundle builder
+  read-render-helpers.ts  # read TUI rendering helpers
+  edit.ts                 # edit tool implementation
+  edit-diff.ts            # diff computation and patch application
+  edit-output.ts          # edit output builder
+  edit-render-helpers.ts  # edit TUI rendering helpers
+  grep.ts                 # grep tool implementation
+  grep-output.ts          # grep output builder
+  grep-symbol-scope.ts    # symbol-scoped grep grouping
+  grep-render-helpers.ts  # grep TUI rendering helpers
+  sg.ts                   # ast-grep wrapper
+  sg-output.ts            # sg output builder
+  hashline.ts             # LINE:HASH generation
+  map-cache.ts            # mtime-keyed structural map cache
+  ptc-value.ts            # shared structured output builders
+  ptc-tool-policy.ts      # machine-readable tool policy contract
+  readmap/                # structural mapping and symbol lookup engine
+  rtk/                    # bash output compression pipeline
+prompts/                  # tool schema prompts
+tests/                    # Vitest test suite
+```
 
 ## Development
 
+### Install dependencies
 ```bash
 npm install
-npm test             # 483 tests across 92 files
-npm run typecheck    # tsc --noEmit
 ```
 
-### Project structure
+### Run tests
+```bash
+npm test
+npm run typecheck
+```
 
-```
-index.ts                  # Extension entry point — registers tools + bash filter
-src/
-  read.ts                 # read tool implementation
-  edit.ts                 # edit tool implementation
-  edit-diff.ts            # diff computation and patch application
-  grep.ts                 # grep tool implementation
-  sg.ts                   # ast-grep wrapper
-  hashline.ts             # LINE:HASH anchor generation (xxhash-wasm)
-  map-cache.ts            # mtime-keyed structural map cache
-  path-utils.ts           # path resolution helpers
-  runtime.ts              # AbortSignal helpers
-  binary-detect.ts        # binary file detection
-  ptc-value.ts            # structured PTC value builders
-  ptc-tool-policy.ts      # PTC tool policy contract
-  read-output.ts          # read output formatting
-  grep-output.ts          # grep output formatting
-  sg-output.ts            # sg output formatting
-  edit-output.ts          # edit output formatting
-  read-render-helpers.ts  # read TUI renderCall/renderResult
-  grep-render-helpers.ts  # grep TUI renderCall/renderResult
-  edit-render-helpers.ts  # edit TUI renderCall/renderResult
-  readmap/                # Structural map engine
-    mapper.ts             #   language dispatch + mapper registry
-    symbol-lookup.ts      #   symbol-addressable read
-    formatter.ts          #   FileMap → human-readable text
-    language-detect.ts    #   file extension → language mapping
-    types.ts              #   shared types
-    enums.ts              #   symbol kind enums
-    constants.ts          #   shared constants
-    mappers/              #   16 per-language mapper implementations
-  rtk/                    # Bash output compression
-    bash-filter.ts        #   command detection + routing
-    index.ts              #   technique registry
-    ansi.ts               #   ANSI escape stripping
-    test-output.ts        #   test runner summarizer
-    build.ts              #   build output extractor
-    build-tools.ts        #   compiler/bundler compressor
-    git.ts                #   git output compressor
-    linter.ts             #   linter result summarizer
-    docker.ts             #   Docker output compressor
-    package-manager.ts    #   npm/yarn/pnpm compressor
-    http-client.ts        #   curl/wget compressor
-    transfer.ts           #   rsync/scp compressor
-    file-listing.ts       #   ls/find/tree compressor
-    truncate.ts           #   smart truncation
-prompts/                  # Tool schema prompt files
-tests/                    # 92 vitest test files
-```
+As of the current repository state, the suite passes with:
+- **100** test files
+- **496** tests
+
+### Local development notes
+This repository is intended to be used as a pi extension workspace. In local development, changes can take effect immediately when the extension is installed from the local checkout.
+
+For project-specific development workflow details, see [AGENTS.md](AGENTS.md).
 
 ## Publishing
-
 ```bash
-npm pack --dry-run    # preview
-npm publish           # publish to npm
+npm pack --dry-run
+npm publish
 ```
 
-The published package includes: `index.ts`, `src/`, `prompts/`, `LICENSE`, `README.md`.
+The published package includes:
+- `index.ts`
+- `src/`
+- `prompts/`
+- `LICENSE`
+- `README.md`
+
+## When to choose this package
+Install `pi-hashline-readmap` if you want pi to be stronger at:
+- reliable local code editing
+- navigating large files by structure
+- symbol-oriented inspection instead of blind scrolling
+- search-to-edit workflows
+- structured code search
+- keeping shell output compact enough for model context windows
+
+Skip it if your main need is repo-wide dependency analysis, impact graphs, runtime traces, or broader workflow orchestration. This package is intentionally focused on local file and symbol workflows.
 
 ## Credits
-
 Combines and adapts ideas from:
-
 - [pi-hashline-edit](https://github.com/nicholasgasior/pi-hashline-edit) — hash-anchored editing
 - [pi-read-map](https://github.com/nicholasgasior/pi-read-map) — structural file maps
 - [pi-rtk](https://github.com/mcowger/pi-rtk) — bash output compression
 
 ## License
-
-MIT — see [LICENSE](LICENSE).
+This project is licensed under the MIT License — see [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ Cuts tokens and reduces exploratory round-trips.
 
 `grep` and `sg` output is hashline-anchored, so the agent can go straight from search to edit without a cleanup read in between.
 
+### Semantic edit classification
+
+After each successful edit, the result includes a `semanticSummary` in the structured output (`details.ptcValue.semanticSummary`) that classifies the change as `semantic`, `whitespace-only`, `mixed`, or `no-op`. This helps agents and reviewers quickly assess whether a change is substantive or cosmetic.
+
+When [difftastic](https://difftastic.wilfred.me/) (`difft`) is installed, classification uses AST-aware diffing for more accurate results — especially for detecting moved code blocks and formatting-only changes. Without difftastic, the tool falls back to internal line-level heuristics. Install with:
+
+```bash
+brew install difftastic
+```
+
 ### Less wasted context on noisy command output
 
 `bash` outputs from test runners, builds, git, linters, Docker, package managers, and more are compressed to the parts that matter.
@@ -196,7 +206,7 @@ Optional CLI tools for full functionality:
 
 ```bash
 brew install ast-grep          # required for sg tool
-brew install difftastic        # enhanced diffs
+brew install difftastic        # semantic edit classification (optional)
 brew install shellcheck yq scc # used by some compressors
 ```
 

--- a/src/edit-classify.ts
+++ b/src/edit-classify.ts
@@ -1,0 +1,190 @@
+import * as Diff from "diff";
+import { execFile } from "node:child_process";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+export type EditClassification = "no-op" | "whitespace-only" | "semantic" | "mixed";
+
+export interface EditClassifyResult {
+  classification: EditClassification;
+}
+
+export function classifyEdit(oldContent: string, newContent: string): EditClassifyResult {
+  if (oldContent === newContent) {
+    return { classification: "no-op" };
+  }
+
+  const oldLines = oldContent.split("\n");
+  const newLines = newContent.split("\n");
+
+  // When line counts match, do pairwise comparison
+  if (oldLines.length === newLines.length) {
+    let hasWhitespaceChange = false;
+    let hasSemanticChange = false;
+    for (let i = 0; i < oldLines.length; i++) {
+      if (oldLines[i] === newLines[i]) continue;
+      if (oldLines[i].trim() === newLines[i].trim()) {
+        hasWhitespaceChange = true;
+      } else {
+        hasSemanticChange = true;
+      }
+    }
+    if (hasSemanticChange && hasWhitespaceChange) return { classification: "mixed" };
+    if (hasWhitespaceChange) return { classification: "whitespace-only" };
+    return { classification: "semantic" };
+  }
+
+  // When line counts differ, use diff library to find changes
+  const parts = Diff.diffLines(oldContent, newContent);
+  let hasWhitespaceChange = false;
+  let hasSemanticChange = false;
+
+  for (const part of parts) {
+    if (!part.added && !part.removed) continue;
+
+    const lines = part.value.split("\n");
+    if (lines[lines.length - 1] === "") lines.pop();
+
+    for (const line of lines) {
+      if (line.trim() === "") {
+        hasWhitespaceChange = true;
+      } else {
+        hasSemanticChange = true;
+      }
+    }
+  }
+
+  if (hasSemanticChange && hasWhitespaceChange) return { classification: "mixed" };
+  if (hasWhitespaceChange) return { classification: "whitespace-only" };
+  return { classification: "semantic" };
+}
+
+let difftCachedResult: boolean | null = null;
+
+export function _resetDifftCache(): void {
+  difftCachedResult = null;
+}
+
+export async function isDifftAvailable(): Promise<boolean> {
+  if (difftCachedResult !== null) return difftCachedResult;
+
+  return new Promise<boolean>((resolve) => {
+    execFile("which", ["difft"], (err) => {
+      difftCachedResult = !err;
+      resolve(difftCachedResult);
+    });
+  });
+}
+
+export interface DifftClassifyResult {
+  classification: EditClassification;
+  movedBlocks: number;
+}
+
+function getChunkSideText(side: any): string {
+  if (!side || typeof side !== "object") return "";
+  if (!Array.isArray(side.changes)) return "";
+  return side.changes
+    .map((change: any) => (change && typeof change.content === "string" ? change.content : ""))
+    .join("");
+}
+
+function getChunkOnlySideSignature(chunk: any[]): { side: "lhs" | "rhs"; text: string } | null {
+  let hasLhs = false;
+  let hasRhs = false;
+  let text = "";
+
+  for (const entry of chunk) {
+    if (entry?.lhs) {
+      hasLhs = true;
+      text += getChunkSideText(entry.lhs);
+    }
+    if (entry?.rhs) {
+      hasRhs = true;
+      text += getChunkSideText(entry.rhs);
+    }
+  }
+
+  if (hasLhs === hasRhs) return null;
+  return { side: hasLhs ? "lhs" : "rhs", text };
+}
+
+export function parseDifftJson(json: any): DifftClassifyResult | null {
+  if (!json || typeof json !== "object" || !("status" in json)) return null;
+
+  if (json.status === "unchanged") {
+    return { classification: "whitespace-only", movedBlocks: 0 };
+  }
+
+  if (json.status !== "changed" || !Array.isArray(json.chunks)) {
+    return null;
+  }
+
+  const lhsOnlyChunkTexts: string[] = [];
+  const rhsOnlyChunkTexts: string[] = [];
+  for (const chunk of json.chunks) {
+    if (!Array.isArray(chunk)) continue;
+    const signature = getChunkOnlySideSignature(chunk);
+    if (!signature) continue;
+    if (signature.side === "lhs") lhsOnlyChunkTexts.push(signature.text);
+    if (signature.side === "rhs") rhsOnlyChunkTexts.push(signature.text);
+  }
+
+  const remainingRhs = new Map<string, number>();
+  for (const text of rhsOnlyChunkTexts) {
+    remainingRhs.set(text, (remainingRhs.get(text) ?? 0) + 1);
+  }
+
+  let movedBlocks = 0;
+  for (const text of lhsOnlyChunkTexts) {
+    const count = remainingRhs.get(text) ?? 0;
+    if (count <= 0) continue;
+    movedBlocks++;
+    if (count === 1) remainingRhs.delete(text);
+    else remainingRhs.set(text, count - 1);
+  }
+
+  return { classification: "semantic", movedBlocks };
+
+  return { classification: "semantic", movedBlocks };
+}
+
+export async function runDifftastic(
+  oldContent: string,
+  newContent: string,
+  fileExtension: string,
+): Promise<DifftClassifyResult | null> {
+  const available = await isDifftAvailable();
+  if (!available) return null;
+
+  let tempDir: string | null = null;
+  try {
+    tempDir = mkdtempSync(resolve(tmpdir(), "pi-difft-"));
+    const oldPath = resolve(tempDir, `old.${fileExtension}`);
+    const newPath = resolve(tempDir, `new.${fileExtension}`);
+    writeFileSync(oldPath, oldContent, "utf-8");
+    writeFileSync(newPath, newContent, "utf-8");
+
+    const stdout = await new Promise<string>((resolve, reject) => {
+      execFile(
+        "difft",
+        ["--display=json", oldPath, newPath],
+        { env: { ...process.env, DFT_UNSTABLE: "yes" }, timeout: 10_000 },
+        (err, stdout) => {
+          if (err) return reject(err);
+          resolve(stdout);
+        },
+      );
+    });
+
+    const json = JSON.parse(stdout);
+    return parseDifftJson(json);
+  } catch {
+    return null;
+  } finally {
+    if (tempDir) {
+      try { rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  }
+}

--- a/src/edit-output.ts
+++ b/src/edit-output.ts
@@ -1,4 +1,4 @@
-import { buildPtcEditResult } from "./ptc-value.js";
+import { buildPtcEditResult, type SemanticSummary } from "./ptc-value.js";
 
 export interface BuildEditOutputInput {
   path: string;
@@ -7,6 +7,7 @@ export interface BuildEditOutputInput {
   firstChangedLine: number | undefined;
   warnings: string[];
   noopEdits: unknown[];
+  semanticSummary?: SemanticSummary;
 }
 
 export interface EditOutputResult {
@@ -26,6 +27,7 @@ export function buildEditOutput(input: BuildEditOutputInput): EditOutputResult {
       firstChangedLine: input.firstChangedLine,
       warnings: input.warnings,
       noopEdits: input.noopEdits,
+      ...(input.semanticSummary ? { semanticSummary: input.semanticSummary } : {}),
     }),
   };
 }

--- a/src/edit-render-helpers.ts
+++ b/src/edit-render-helpers.ts
@@ -94,6 +94,7 @@ export interface EditResultTextInput {
   warnings: string[];
   noopEdits: unknown[];
   errorText: string;
+  semanticClassification?: "no-op" | "whitespace-only" | "semantic" | "mixed";
 }
 
 export interface EditResultTextOutput {
@@ -101,6 +102,7 @@ export interface EditResultTextOutput {
   noOp: boolean;
   warningsBadge: string | undefined;
   errorText: string | undefined;
+  semanticBadge: string | undefined;
 }
 
 export function formatEditResultText(input: EditResultTextInput): EditResultTextOutput {
@@ -128,10 +130,20 @@ export function formatEditResultText(input: EditResultTextInput): EditResultText
   // Error text (only for errors)
   const showErrorText = isError ? errorText : undefined;
 
+  // Semantic classification badge (success only)
+  let semanticBadge: string | undefined;
+  if (!isError && !isNoOp && input.semanticClassification) {
+    switch (input.semanticClassification) {
+      case "whitespace-only": semanticBadge = "ws-only"; break;
+      case "semantic": semanticBadge = "\u2713 semantic"; break;
+      case "mixed": semanticBadge = "mixed"; break;
+    }
+  }
   return {
     diffStats,
     noOp: isNoOp,
     warningsBadge,
     errorText: showErrorText,
+    semanticBadge,
   };
 }

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -8,6 +8,8 @@ import { applyHashlineEdits, computeLineHash, ensureHashInit, parseLineRef, type
 import { resolveToCwd } from "./path-utils";
 import { throwIfAborted } from "./runtime";
 import { buildEditOutput } from "./edit-output.js";
+import { classifyEdit, isDifftAvailable, runDifftastic } from "./edit-classify.js";
+import type { SemanticSummary } from "./ptc-value.js";
 import { Text } from "@mariozechner/pi-tui";
 import { formatEditCallText, formatEditResultText } from "./edit-render-helpers.js";
 
@@ -242,6 +244,25 @@ export function registerEditTool(pi: ExtensionAPI) {
 			const warnings: string[] = [];
 			if (anchorResult.warnings?.length) warnings.push(...anchorResult.warnings);
 			if (legacyNormalizationWarning) warnings.push(legacyNormalizationWarning);
+			// Semantic classification
+			const internalClassification = classifyEdit(originalNormalized, result);
+			const difftAvailable = await isDifftAvailable();
+			let semanticSummary: SemanticSummary = {
+				classification: internalClassification.classification,
+				difftasticAvailable: difftAvailable,
+			};
+
+			if (difftAvailable) {
+				const ext = path.split(".").pop() ?? "txt";
+				const difftResult = await runDifftastic(originalNormalized, result, ext);
+				if (difftResult) {
+					semanticSummary = {
+						classification: difftResult.classification,
+						difftasticAvailable: true,
+						...(difftResult.movedBlocks > 0 ? { movedBlocks: difftResult.movedBlocks } : {}),
+					};
+				}
+			}
 			const builtOutput = buildEditOutput({
 				path: absolutePath,
 				displayPath: path,
@@ -249,6 +270,7 @@ export function registerEditTool(pi: ExtensionAPI) {
 				firstChangedLine: anchorResult.firstChangedLine ?? diffResult.firstChangedLine,
 				warnings,
 				noopEdits: anchorResult.noopEdits ?? [],
+				semanticSummary,
 			});
 
 			const warn = warnings.length ? `\n\nWarnings:\n${warnings.join("\n")}` : "";
@@ -315,6 +337,7 @@ export function registerEditTool(pi: ExtensionAPI) {
 			} | undefined;
 			const warnings = ptcValue?.warnings ?? [];
 			const noopEdits = ptcValue?.noopEdits ?? [];
+			const semanticClassification = (ptcValue as any)?.semanticSummary?.classification as string | undefined;
 
 			const info = formatEditResultText({
 				isError: isError || !!result.isError,
@@ -322,6 +345,7 @@ export function registerEditTool(pi: ExtensionAPI) {
 				warnings,
 				noopEdits,
 				errorText: textContent,
+				semanticClassification: semanticClassification as any,
 			});
 
 			// Build display text
@@ -348,6 +372,9 @@ export function registerEditTool(pi: ExtensionAPI) {
 				}
 				if (info.warningsBadge) {
 					parts.push(theme.fg("warning", info.warningsBadge));
+				}
+				if (info.semanticBadge) {
+					parts.push(theme.fg("dim", info.semanticBadge));
 				}
 				text = parts.join("  ") || theme.fg("success", "\u2713");
 

--- a/src/ptc-value.ts
+++ b/src/ptc-value.ts
@@ -25,6 +25,11 @@ export interface PtcFileGroup {
   lines: PtcLine[];
 }
 
+export interface SemanticSummary {
+  classification: "no-op" | "whitespace-only" | "semantic" | "mixed";
+  difftasticAvailable: boolean;
+  movedBlocks?: number;
+}
 export interface PtcEditResult {
   tool: "edit";
   ok: boolean;
@@ -34,6 +39,7 @@ export interface PtcEditResult {
   firstChangedLine: number | undefined;
   warnings: string[];
   noopEdits: unknown[];
+  semanticSummary?: SemanticSummary;
 }
 
 export function buildPtcLine(line: number, raw: string): PtcLine {
@@ -83,6 +89,7 @@ export function buildPtcEditResult(input: {
   firstChangedLine: number | undefined;
   warnings: string[];
   noopEdits: unknown[];
+  semanticSummary?: SemanticSummary;
 }): PtcEditResult {
   return {
     tool: "edit",
@@ -93,5 +100,6 @@ export function buildPtcEditResult(input: {
     firstChangedLine: input.firstChangedLine,
     warnings: [...input.warnings],
     noopEdits: [...input.noopEdits],
+    ...(input.semanticSummary ? { semanticSummary: input.semanticSummary } : {}),
   };
 }

--- a/tests/edit-classify-difft-parse.test.ts
+++ b/tests/edit-classify-difft-parse.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { parseDifftJson } from "../src/edit-classify.js";
+
+describe("parseDifftJson", () => {
+  it("returns whitespace-only for status unchanged", () => {
+    const json = { language: "TypeScript", path: "/tmp/b.ts", status: "unchanged" };
+    const result = parseDifftJson(json);
+    expect(result!.classification).toBe("whitespace-only");
+    expect(result!.movedBlocks).toBe(0);
+  });
+
+  it("returns semantic for status changed with no moved blocks", () => {
+    const json = {
+      chunks: [[
+        {
+          lhs: { line_number: 1, changes: [{ start: 8, end: 9, content: "x", highlight: "normal" }] },
+          rhs: { line_number: 1, changes: [{ start: 8, end: 9, content: "y", highlight: "normal" }] },
+        },
+      ]],
+      language: "TypeScript",
+      path: "/tmp/b.ts",
+      status: "changed",
+    };
+    const result = parseDifftJson(json);
+    expect(result!.classification).toBe("semantic");
+    expect(result!.movedBlocks).toBe(0);
+  });
+
+  it("counts moved blocks when chunks have lhs-only and rhs-only pairs", () => {
+    const json = {
+      chunks: [
+        [{ rhs: { line_number: 0, changes: [{ start: 0, end: 8, content: "function", highlight: "keyword" }] } }],
+        [{ lhs: { line_number: 4, changes: [{ start: 0, end: 8, content: "function", highlight: "keyword" }] } }],
+      ],
+      language: "TypeScript",
+      path: "/tmp/b.ts",
+      status: "changed",
+    };
+    const result = parseDifftJson(json);
+    expect(result!.classification).toBe("semantic");
+    expect(result!.movedBlocks).toBe(1);
+  });
+
+  it("does not count moved blocks when lhs-only and rhs-only chunks have different content", () => {
+    const json = {
+      chunks: [
+        [{ rhs: { line_number: 0, changes: [{ start: 0, end: 3, content: "AAA", highlight: "normal" }] } }],
+        [{ lhs: { line_number: 4, changes: [{ start: 0, end: 3, content: "BBB", highlight: "normal" }] } }],
+      ],
+      language: "TypeScript",
+      path: "/tmp/b.ts",
+      status: "changed",
+    };
+    const result = parseDifftJson(json);
+    expect(result!.classification).toBe("semantic");
+    expect(result!.movedBlocks).toBe(0);
+  });
+
+  it("returns null for invalid JSON shape", () => {
+    const result = parseDifftJson({ garbage: true });
+    expect(result).toBeNull();
+  });
+});

--- a/tests/edit-classify-difft-run.test.ts
+++ b/tests/edit-classify-difft-run.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, execFile: vi.fn(actual.execFile) };
+});
+
+import { runDifftastic, _resetDifftCache } from "../src/edit-classify.js";
+import { execFile } from "node:child_process";
+
+const mockedExecFile = vi.mocked(execFile);
+
+describe("runDifftastic", () => {
+  beforeEach(() => {
+    _resetDifftCache();
+    mockedExecFile.mockRestore();
+  });
+
+  it("returns a DifftClassifyResult for whitespace-only changes when difft is available", async () => {
+    const old = "function hello() {\n  const x = 1;\n  return x;\n}\n";
+    const nw = "function hello() {\n    const x = 1;\n    return x;\n}\n";
+    const result = await runDifftastic(old, nw, "ts");
+    if (result !== null) {
+      expect(result.classification).toBe("whitespace-only");
+      expect(result.movedBlocks).toBe(0);
+    }
+  });
+
+  it("returns a DifftClassifyResult for semantic changes when difft is available", async () => {
+    const old = "const x = 1;\n";
+    const nw = "const y = 2;\n";
+    const result = await runDifftastic(old, nw, "ts");
+    if (result !== null) {
+      expect(result.classification).toBe("semantic");
+    }
+  });
+
+  it("returns null when difft subprocess fails", async () => {
+    mockedExecFile.mockImplementation((...args: any[]) => {
+      const cb = args[args.length - 1];
+      if (typeof cb === "function") {
+        const err = new Error("not found") as any;
+        err.code = "ENOENT";
+        cb(err, "", "");
+      }
+      return {} as any;
+    });
+    const result = await runDifftastic("a\n", "b\n", "ts");
+    expect(result).toBeNull();
+  });
+});

--- a/tests/edit-classify-difft.test.ts
+++ b/tests/edit-classify-difft.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock child_process before importing the module under test
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    execFile: vi.fn(actual.execFile),
+  };
+});
+
+import { isDifftAvailable, _resetDifftCache } from "../src/edit-classify.js";
+import { execFile } from "node:child_process";
+
+const mockedExecFile = vi.mocked(execFile);
+
+describe("difftastic availability detection", () => {
+  beforeEach(() => {
+    _resetDifftCache();
+    mockedExecFile.mockReset();
+    // Restore real implementation by default
+    mockedExecFile.mockImplementation(
+      ((...args: any[]) => {
+        const cb = args[args.length - 1];
+        if (typeof cb === "function") {
+          // Actually call which difft
+          const { execFile: realExecFile } = require("node:child_process");
+          return realExecFile(...args);
+        }
+      }) as any,
+    );
+  });
+
+  it("returns a boolean when checking difft availability", async () => {
+    mockedExecFile.mockRestore();
+    const result = await isDifftAvailable();
+    expect(typeof result).toBe("boolean");
+  });
+
+  it("caches the result across calls", async () => {
+    mockedExecFile.mockRestore();
+    const first = await isDifftAvailable();
+    const second = await isDifftAvailable();
+    expect(first).toBe(second);
+  });
+
+  it("returns false when the lookup fails", async () => {
+    mockedExecFile.mockImplementation((...args: any[]) => {
+      const cb = args[args.length - 1];
+      if (typeof cb === "function") {
+        const err = new Error("not found") as any;
+        err.code = "ENOENT";
+        cb(err, "", "");
+      }
+      return {} as any;
+    });
+    const result = await isDifftAvailable();
+    expect(result).toBe(false);
+  });
+});

--- a/tests/edit-classify.test.ts
+++ b/tests/edit-classify.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { classifyEdit } from "../src/edit-classify.js";
+
+describe("classifyEdit internal heuristics", () => {
+  it("classifies no-op when old and new content are identical", () => {
+    const result = classifyEdit("const x = 1;\n", "const x = 1;\n");
+    expect(result.classification).toBe("no-op");
+  });
+
+  it("classifies whitespace-only when all changes are whitespace", () => {
+    const old = "function hello() {\n  const x = 1;\n  return x;\n}\n";
+    const nw = "function hello() {\n    const x = 1;\n    return x;\n}\n";
+    const result = classifyEdit(old, nw);
+    expect(result.classification).toBe("whitespace-only");
+  });
+
+  it("classifies semantic when all changes are non-whitespace", () => {
+    const old = "const x = 1;\nconst y = 2;\n";
+    const nw = "const x = 10;\nconst y = 20;\n";
+    const result = classifyEdit(old, nw);
+    expect(result.classification).toBe("semantic");
+  });
+
+  it("classifies mixed when some changes are whitespace and some are semantic", () => {
+    const old = "const x = 1;\n  const y = 2;\n";
+    const nw = "const x = 10;\nconst y = 2;\n";
+    const result = classifyEdit(old, nw);
+    expect(result.classification).toBe("mixed");
+  });
+
+  it("classifies semantic for added lines", () => {
+    const old = "line1\nline2\n";
+    const nw = "line1\nnewline\nline2\n";
+    const result = classifyEdit(old, nw);
+    expect(result.classification).toBe("semantic");
+  });
+
+  it("classifies semantic for deleted lines", () => {
+    const old = "line1\nline2\nline3\n";
+    const nw = "line1\nline3\n";
+    const result = classifyEdit(old, nw);
+    expect(result.classification).toBe("semantic");
+  });
+});

--- a/tests/edit-output-semantic.test.ts
+++ b/tests/edit-output-semantic.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { ensureHashInit } from "../src/hashline.js";
+import { buildEditOutput } from "../src/edit-output.js";
+
+describe("buildEditOutput semanticSummary", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("includes semanticSummary in ptcValue when provided", () => {
+    const result = buildEditOutput({
+      path: "/tmp/test.ts",
+      displayPath: "test.ts",
+      diff: "+1 const x = 10;",
+      firstChangedLine: 1,
+      warnings: [],
+      noopEdits: [],
+      semanticSummary: {
+        classification: "semantic",
+        difftasticAvailable: true,
+        movedBlocks: 0,
+      },
+    });
+
+    expect(result.ptcValue.semanticSummary).toEqual({
+      classification: "semantic",
+      difftasticAvailable: true,
+      movedBlocks: 0,
+    });
+  });
+
+  it("omits semanticSummary from ptcValue when not provided", () => {
+    const result = buildEditOutput({
+      path: "/tmp/test.ts",
+      displayPath: "test.ts",
+      diff: "+1 const x = 10;",
+      firstChangedLine: 1,
+      warnings: [],
+      noopEdits: [],
+    });
+
+    expect(result.ptcValue.semanticSummary).toBeUndefined();
+  });
+
+  it("preserves existing ptcValue fields when semanticSummary is present", () => {
+    const result = buildEditOutput({
+      path: "/tmp/test.ts",
+      displayPath: "test.ts",
+      diff: "+1 const x = 10;",
+      firstChangedLine: 1,
+      warnings: ["some warning"],
+      noopEdits: [],
+      semanticSummary: {
+        classification: "whitespace-only",
+        difftasticAvailable: false,
+      },
+    });
+
+    expect(result.ptcValue.tool).toBe("edit");
+    expect(result.ptcValue.ok).toBe(true);
+    expect(result.ptcValue.path).toBe("/tmp/test.ts");
+    expect(result.ptcValue.warnings).toEqual(["some warning"]);
+    expect(result.ptcValue.semanticSummary).toEqual({
+      classification: "whitespace-only",
+      difftasticAvailable: false,
+    });
+  });
+});

--- a/tests/edit-render-semantic-badge.test.ts
+++ b/tests/edit-render-semantic-badge.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { formatEditResultText } from "../src/edit-render-helpers.js";
+
+describe("formatEditResultText semantic badge", () => {
+  it("includes ws-only badge for whitespace-only classification", () => {
+    const result = formatEditResultText({
+      isError: false,
+      diff: "+1 const x = 1;",
+      warnings: [],
+      noopEdits: [],
+      errorText: "",
+      semanticClassification: "whitespace-only",
+    });
+    expect(result.semanticBadge).toBe("ws-only");
+  });
+
+  it("includes ✓ semantic badge for semantic classification", () => {
+    const result = formatEditResultText({
+      isError: false,
+      diff: "+1 const x = 10;",
+      warnings: [],
+      noopEdits: [],
+      errorText: "",
+      semanticClassification: "semantic",
+    });
+    expect(result.semanticBadge).toBe("✓ semantic");
+  });
+
+  it("includes mixed badge for mixed classification", () => {
+    const result = formatEditResultText({
+      isError: false,
+      diff: "+1 const x = 10;",
+      warnings: [],
+      noopEdits: [],
+      errorText: "",
+      semanticClassification: "mixed",
+    });
+    expect(result.semanticBadge).toBe("mixed");
+  });
+
+  it("returns undefined badge when no classification provided", () => {
+    const result = formatEditResultText({
+      isError: false,
+      diff: "+1 const x = 10;",
+      warnings: [],
+      noopEdits: [],
+      errorText: "",
+    });
+    expect(result.semanticBadge).toBeUndefined();
+  });
+
+  it("returns undefined badge on error path", () => {
+    const result = formatEditResultText({
+      isError: true,
+      diff: "",
+      warnings: [],
+      noopEdits: [],
+      errorText: "File not found",
+      semanticClassification: "semantic",
+    });
+    expect(result.semanticBadge).toBeUndefined();
+  });
+});

--- a/tests/edit-semantic-integration.test.ts
+++ b/tests/edit-semantic-integration.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+import { registerEditTool } from "../src/edit.js";
+
+async function callEditTool(params: Record<string, unknown>) {
+  let capturedTool: any = null;
+  registerEditTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  if (!capturedTool) throw new Error("edit tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function makeFixture(content: string): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-cls-"));
+  const filePath = resolve(dir, "test.ts");
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+describe("edit semantic classification integration", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("includes semanticSummary with classification 'semantic' after a real code change", async () => {
+    const filePath = makeFixture("const x = 1;\nconst y = 2;\n");
+    const lines = readFileSync(filePath, "utf-8").split("\n");
+    const anchor = `1:${computeLineHash(1, lines[0])}`;
+
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ set_line: { anchor, new_text: "const x = 999;" } }],
+    });
+
+    const ptc = result.details?.ptcValue;
+    expect(ptc.semanticSummary).toBeDefined();
+    expect(ptc.semanticSummary.classification).toBe("semantic");
+    expect(typeof ptc.semanticSummary.difftasticAvailable).toBe("boolean");
+  });
+
+  it("includes semanticSummary with classification 'whitespace-only' after an indent change", async () => {
+    const filePath = makeFixture("  const x = 1;\n");
+    const lines = readFileSync(filePath, "utf-8").split("\n");
+    const anchor = `1:${computeLineHash(1, lines[0])}`;
+
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ set_line: { anchor, new_text: "    const x = 1;" } }],
+    });
+
+    const ptc = result.details?.ptcValue;
+    expect(ptc.semanticSummary).toBeDefined();
+    expect(ptc.semanticSummary.classification).toBe("whitespace-only");
+  });
+
+  it("preserves existing text output unchanged when semanticSummary is added", async () => {
+    const filePath = makeFixture("const a = 1;\n");
+    const lines = readFileSync(filePath, "utf-8").split("\n");
+    const anchor = `1:${computeLineHash(1, lines[0])}`;
+
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ set_line: { anchor, new_text: "const a = 2;" } }],
+    });
+
+    const text = result.content.find((c: any) => c.type === "text")?.text ?? "";
+    expect(text).toContain("Updated");
+    expect(text).not.toContain("semantic");
+    expect(text).not.toContain("whitespace");
+  });
+});


### PR DESCRIPTION
## Summary
- add semanticSummary metadata to edit results
- classify edits with internal heuristics and optional difftastic refinement
- surface semantic badges in edit TUI and document optional difftastic support
- perform a full README audit so installation, usage, feature coverage, benefits, and use cases are clear
- clean tracked local/internal repo metadata and bump the package to `0.4.0`

## Details
- adds `src/edit-classify.ts` for no-op / whitespace-only / semantic / mixed classification
- uses difftastic JSON output when available, including matching-content moved block counting
- falls back silently when difftastic is unavailable or fails
- keeps existing edit text output unchanged and additive-only in `details.ptcValue`
- closes source issues #063 and #064 as already shipped
- rewrites `README.md` to better explain:
  - installation from npm, GitHub, and a local clone
  - typical `read`, `edit`, `grep`, `scope: "symbol"`, `bundle: "local"`, and `sg` workflows
  - the full feature set of the package
  - the practical benefits and best-fit use cases
- removes tracked local/internal files that should not be on GitHub, including `.megapowers/*`, `.npmrc`, `.zellij_bookmarks.yaml`, and local planning docs
- bumps `package.json` and `package-lock.json` from `0.3.0` to `0.4.0`

## Verification
- npm test
- npm run typecheck
- npx vitest run tests/edit-classify.test.ts tests/edit-classify-difft.test.ts tests/edit-classify-difft-parse.test.ts tests/edit-classify-difft-run.test.ts tests/edit-semantic-integration.test.ts tests/edit-output-semantic.test.ts tests/edit-render-semantic-badge.test.ts --reporter=verbose
