### PR TITLE
feat: rename sg tool to ast_search for agent discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Repo-local guide for working on `pi-hashline-readmap`.
 - `read` — hashlined reads, structural maps, symbol-addressable reads
 - `edit` — hash-anchored edits with semantic diff summaries
 - `grep` — hashlined search results
-- `sg` — ast-grep wrapper with hashlined output
+- `ast_search` — ast-grep wrapper with hashlined output
 - `bash` filtering — command-aware output compression
 
 The extension is symlinked from `~/.pi/agent/extensions/pi-hashline-readmap` to this workspace, so local edits take effect immediately.
@@ -98,7 +98,7 @@ npm run typecheck
 
 ### Tool output contract change
 
-When changing `read`, `edit`, `grep`, or `sg` output:
+When changing `read`, `edit`, `grep`, or `ast_search` output:
 
 1. Update the relevant `*-output.ts` / render helper modules
 2. Update `prompts/` docs if the contract changed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A drop-in [pi](https://github.com/mariozechner/pi-coding-agent) extension that upgrades the agent’s local coding workflow with hash-anchored reads and edits, structural file maps, symbol-aware navigation, structural search, and compressed `bash` output.
 
-It replaces the stock `read`, `edit`, and `grep` tools, provides an enhanced `sg` tool, and post-processes `bash` output so more context budget goes to useful information instead of noise.
+It replaces the stock `read`, `edit`, and `grep` tools, provides an enhanced `ast_search` tool, and post-processes `bash` output so more context budget goes to useful information instead of noise.
 
 ## Why install this?
 
@@ -23,7 +23,7 @@ If you use pi for real code changes, the stock toolchain has a few recurring pro
 ## Benefits
 
 ### Safer edits
-`read`, `grep`, and `sg` return `LINE:HASH|content` anchors. Those anchors can be fed directly into `edit`, which means the model edits exactly the line it read.
+`read`, `grep`, and `ast_search` return `LINE:HASH|content` anchors. Those anchors can be fed directly into `edit`, which means the model edits exactly the line it read.
 
 ```text
 45:e4|router.addRoute("/api", handler);
@@ -39,7 +39,7 @@ This package stays focused on local file and symbol work:
 - symbol lookup in `read`
 - symbol-scoped grep with enclosing symbol blocks
 - local same-file support bundles for `read(symbol=...)`
-- structural code search via `sg`
+- structural code search via `ast_search`
 
 That gives agents more context without turning this package into a repo-wide code graph tool.
 
@@ -79,7 +79,7 @@ This package is a good fit when you want pi to:
 - `bundle: "local"` requires `symbol` and cannot be combined with `map` or `offset`.
 
 ## `edit`
-- hash-verified anchored edits using `LINE:HASH` anchors from `read`, `grep`, or `sg`
+- hash-verified anchored edits using `LINE:HASH` anchors from `read`, `grep`, or `ast_search`
 - operations: `set_line`, `replace_lines`, `insert_after`, `replace`
 - compact diff and full diff support
 - mismatch diagnostics with context
@@ -108,7 +108,7 @@ The success text output stays unchanged. Semantic classification is additive met
 ### Symbol-scoped grep
 With `scope: "symbol"`, matches are grouped by their enclosing function, method, class, or other mapped symbol when possible. Unsupported files and unmappable cases fall back gracefully to normal grep output.
 
-## `sg`
+## `ast_search`
 - wraps [ast-grep](https://ast-grep.github.io/) for structural code search
 - returns merged, hash-anchored match blocks grouped by file
 - ideal for structure-aware search → edit workflows
@@ -147,7 +147,7 @@ pi install git:github.com/coctostan/pi-hashline-readmap
 
 ### Optional local tools
 ```bash
-brew install ast-grep          # required for sg
+brew install ast-grep          # required for ast_search
 brew install difftastic        # optional, improves semantic edit summaries
 brew install shellcheck yq scc # optional, improves some bash output compression flows
 ```
@@ -256,9 +256,9 @@ grep({ pattern: "addRoute", path: "src", literal: true, scope: "symbol" })
 
 Use this when the match location alone is not enough and you want the enclosing function or method block.
 
-## Structural code search with sg
+## Structural code search with ast_search
 ```text
-sg({ pattern: "console.log($$$ARGS)", lang: "typescript", path: "src" })
+ast_search({ pattern: "console.log($$$ARGS)", lang: "typescript", path: "src" })
 ```
 
 Use this for AST-level search patterns instead of raw text matching.
@@ -272,7 +272,7 @@ Includes path, selected range, warnings, truncation info, symbol metadata, map s
 ### `grep`
 Includes total matches, per-record anchors, and additive symbol-scope metadata when `scope: "symbol"` is used.
 
-### `sg`
+### `ast_search`
 Includes grouped match ranges and anchored lines.
 
 ### `edit`
@@ -289,7 +289,7 @@ import { HASHLINE_TOOL_PTC_POLICY } from "pi-hashline-readmap";
 
 Policy summary:
 - `read` and `grep` are safe-by-default and read-only
-- `sg` is opt-in and read-only
+- `ast_search` is opt-in and read-only
 - `edit` is not safe-by-default and is mutating
 
 `pi-prompt-assembler` may optionally consume this contract, but this package does not depend on it.
@@ -298,7 +298,7 @@ Policy summary:
 On load, the extension emits tool executor references for downstream consumers:
 
 ```ts
-pi.events.emit("hashline:tool-executors", { read, edit, grep, sg });
+pi.events.emit("hashline:tool-executors", { read, edit, grep, ast_search });
 ```
 
 The same executors are also exposed at `globalThis.__hashlineToolExecutors`.
@@ -330,7 +330,7 @@ The same executors are also exposed at `globalThis.__hashlineToolExecutors`.
 - `insert_after`
 - `replace`
 
-## `sg` parameters
+## `ast_search` parameters
 - `pattern`
 - `lang`
 - `path`

--- a/docs/exploratory-functional-testing.md
+++ b/docs/exploratory-functional-testing.md
@@ -46,7 +46,7 @@ Practical expectation:
 
 Expected behavior:
 
-- applies anchor-verified edits using anchors from `read`, `grep`, or `sg`
+- applies anchor-verified edits using anchors from `read`, `grep`, or `ast_search`
 - supports `set_line`, `replace_lines`, `insert_after`, and `replace`
 - rejects stale anchors with useful mismatch diagnostics
 - returns diff-oriented result metadata in structured output
@@ -72,7 +72,7 @@ Practical expectation:
 
 - a user should be able to search, understand the enclosing code region, and edit from the search result directly
 
-### `sg`
+### `ast_search`
 
 Expected behavior:
 
@@ -107,7 +107,7 @@ The present test suite covers, at minimum:
 - `read` output shape, truncation, maps, symbol lookup, local bundles, and rendering helpers
 - `edit` output, diff generation, semantic classification, difftastic integration/fallbacks, and anchor safety
 - `grep` output, summary mode, symbol-scoped grouping, truncation indicators, and rendering helpers
-- `sg` formatting, schema handling, execution behavior, no-match behavior, and path handling
+- `ast_search` formatting, schema handling, execution behavior, no-match behavior, and path handling
 - binary / control-character handling regressions
 - map cache behavior
 - RTK / bash filter routing and compressor-specific behavior
@@ -121,7 +121,7 @@ When doing manual validation beyond the automated suite, the highest-value check
 1. `read` on a large source file with `map: true`
 2. `read(symbol=...)` on an ambiguous and an unambiguous symbol
 3. `grep(..., scope: "symbol")` on a mapped TypeScript or Python file
-4. `sg(...)` with both a match and a deliberate no-match query
+4. `ast_search(...)` with both a match and a deliberate no-match query
 5. `edit` using a fresh anchor, then repeating with a stale anchor to confirm mismatch handling
 6. representative `bash` commands such as `npm test`, `tsc --noEmit`, `git diff`, `docker build`, `curl`, and `find`
 

--- a/index.ts
+++ b/index.ts
@@ -45,7 +45,7 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
     read: readTool,
     edit: editTool,
     grep: grepTool,
-    sg: sgTool,
+    ast_search: sgTool,
   };
 
   (globalThis as any).__hashlineToolExecutors = toolExecutors;

--- a/prompts/sg.md
+++ b/prompts/sg.md
@@ -1,4 +1,6 @@
-Structural code search using **ast-grep** (`sg`). This tool finds code by **AST structure** (not raw text) and returns **hashline-anchored** results ready for the `edit` tool.
+AST-aware structural code search. Use this when grep is too brittle and you need to match code shape rather than raw text. Prefer over grep for finding function calls, imports, JSX elements, or syntax patterns. Returns anchored matches suitable for edit.
+
+Use for AST-aware code pattern search when text search is too brittle.
 
 ## Pattern Syntax (metavariables)
 
@@ -22,7 +24,7 @@ Structural code search using **ast-grep** (`sg`). This tool finds code by **AST 
 
 ## Workflow: search → edit
 
-1. Run `sg({ pattern: "console.log($$$ARGS)" })`
+1. Run `ast_search({ pattern: "console.log($$$ARGS)" })`
 2. Review output grouped by file (`--- path ---`) with anchors (`>>LINE:HASH|...`)
 3. Use anchors directly with `edit({ path: "file.ts", edits: [{ set_line: { anchor: "42:ab", new_text: "..." } }] })`
 

--- a/src/ptc-tool-policy.ts
+++ b/src/ptc-tool-policy.ts
@@ -1,4 +1,4 @@
-export type HashlineToolName = "read" | "grep" | "sg" | "edit";
+export type HashlineToolName = "read" | "grep" | "ast_search" | "edit";
 
 export type HashlineToolMutability = "read-only" | "mutating";
 
@@ -37,9 +37,9 @@ export const HASHLINE_TOOL_PTC_POLICY: HashlineToolPtcPolicy = {
       mutability: "read-only",
       defaultExposure: "safe-by-default",
     },
-    sg: {
-      toolName: "sg",
-      helperName: "sg",
+    ast_search: {
+      toolName: "ast_search",
+      helperName: "ast_search",
       overridesBuiltin: false,
       mutability: "read-only",
       defaultExposure: "opt-in",

--- a/src/sg-output.ts
+++ b/src/sg-output.ts
@@ -15,7 +15,7 @@ export interface BuildSgOutputInput {
 export interface SgOutputResult {
   text: string;
   ptcValue: {
-    tool: "sg";
+    tool: "ast_search";
     files: Array<{
       path: string;
       ranges: PtcRange[];
@@ -29,7 +29,7 @@ export function buildSgOutput(input: BuildSgOutputInput): SgOutputResult {
     return {
       text: `No matches found for pattern: ${input.pattern}`,
       ptcValue: {
-        tool: "sg",
+        tool: "ast_search",
         files: [],
       },
     };
@@ -46,7 +46,7 @@ export function buildSgOutput(input: BuildSgOutputInput): SgOutputResult {
   return {
     text: blocks.join("\n"),
     ptcValue: {
-      tool: "sg",
+      tool: "ast_search",
       files: input.files.map((file) => ({
         path: file.path,
         ranges: file.ranges.map((range) => ({ ...range })),

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -44,7 +44,8 @@ export function mergeRanges(ranges: SgRange[]): SgRange[] {
   return merged;
 }
 
-const SG_DESC = readFileSync(new URL("../prompts/sg.md", import.meta.url), "utf-8").trim();
+const SG_PROMPT = readFileSync(new URL("../prompts/sg.md", import.meta.url), "utf-8").trim();
+const SG_DESC = SG_PROMPT.split(/\n\s*\n/, 1)[0]?.trim() ?? SG_PROMPT;
 
 function execFileText(
   cmd: string,
@@ -74,13 +75,13 @@ export function registerSgTool(pi: ExtensionAPI) {
     enabled: true,
     policy: "read-only" as const,
     readOnly: true,
-    pythonName: "sg",
+    pythonName: "ast_search",
     defaultExposure: "opt-in" as const,
   };
 
   const tool = {
-    name: "sg",
-    label: "AST Grep",
+    name: "ast_search",
+    label: "AST Search",
     description: SG_DESC,
     parameters: Type.Object({
       pattern: Type.String({ description: "AST pattern to search for" }),
@@ -215,7 +216,7 @@ export function registerSgTool(pi: ExtensionAPI) {
     },
     renderCall(args: any, theme: any, ...rest: any[]) {
       const _context = rest[0];
-      let text = theme.fg("toolTitle", theme.bold("sg "));
+      let text = theme.fg("toolTitle", theme.bold("ast_search "));
       text += theme.fg("accent", args.pattern);
       if (args.lang) {
         text += theme.fg("dim", ` (${args.lang})`);
@@ -244,7 +245,7 @@ export function registerSgTool(pi: ExtensionAPI) {
         return new Text(theme.fg("error", firstLine), 0, 0);
       }
       const ptcValue = (result.details as any)?.ptcValue as
-        | { tool: "sg"; files: Array<{ path: string; lines: any[] }> }
+        | { tool: "ast_search"; files: Array<{ path: string; lines: any[] }> }
         | undefined;
       const files = ptcValue?.files ?? [];
       if (files.length === 0) {

--- a/tests/bash-filter-integration.test.ts
+++ b/tests/bash-filter-integration.test.ts
@@ -33,15 +33,13 @@ describe("bash filter integration", () => {
 
     expect(handlers["tool_result"]).toBeDefined();
 
-    // Non-bash tools must be untouched (AC17: read, grep, edit, sg)
     const hashlineText = "1:ab|some hashline content";
 
     expect(await handlers["tool_result"](makeEvent("read", "t-read", { path: "foo.ts" }, hashlineText))).toBeUndefined();
     expect(await handlers["tool_result"](makeEvent("grep", "t-grep", { pattern: "x" }, hashlineText))).toBeUndefined();
     expect(await handlers["tool_result"](makeEvent("edit", "t-edit", { path: "foo.ts" }, hashlineText))).toBeUndefined();
-    expect(await handlers["tool_result"](makeEvent("sg", "t-sg", { pattern: "$X" }, hashlineText))).toBeUndefined();
+    expect(await handlers["tool_result"](makeEvent("ast_search", "t-ast", { pattern: "$X" }, hashlineText))).toBeUndefined();
 
-    // Bash is compressed (at least ANSI-stripped)
     const bashEvent = makeEvent("bash", "t-bash", { command: "echo hello" }, "\x1b[32mhello\x1b[0m");
 
     const result = await handlers["tool_result"](bashEvent);

--- a/tests/entry-point.test.ts
+++ b/tests/entry-point.test.ts
@@ -19,7 +19,7 @@ describe("extension entry point (AC8)", () => {
     expect(source).toContain('import { registerEditTool } from "./src/edit.js";');
     expect(source).toContain('import { registerGrepTool } from "./src/grep.js";');
   });
-  it("registers sg tool", async () => {
+  it("registers ast_search tool", async () => {
     const mod = await import(pathToFileURL(resolve(root, "index.ts")).href);
     const tools: string[] = [];
     const mockPi = {
@@ -30,6 +30,6 @@ describe("extension entry point (AC8)", () => {
       events: { emit() {}, on() {} },
     };
     mod.default(mockPi as any);
-    expect(tools).toContain("sg");
+    expect(tools).toContain("ast_search");
   });
 });

--- a/tests/hashline-runtime-ptc-sg-edit.test.ts
+++ b/tests/hashline-runtime-ptc-sg-edit.test.ts
@@ -14,15 +14,15 @@ async function captureTools() {
   return tools;
 }
 
-describe("hashline runtime ptc metadata — sg and edit", () => {
-  it("registers opt-in metadata for sg and mutating metadata for edit", async () => {
+describe("hashline runtime ptc metadata — ast_search and edit", () => {
+  it("registers opt-in metadata for ast_search and mutating metadata for edit", async () => {
     const tools = await captureTools();
-    expect(tools.sg.ptc).toEqual({
+    expect(tools.ast_search.ptc).toEqual({
       callable: true,
       enabled: true,
       policy: "read-only",
       readOnly: true,
-      pythonName: "sg",
+      pythonName: "ast_search",
       defaultExposure: "opt-in",
     });
     expect(tools.edit.ptc).toEqual({

--- a/tests/prompts-files.test.ts
+++ b/tests/prompts-files.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest"; // AC15
+import { describe, it, expect } from "vitest";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
@@ -31,7 +31,7 @@ describe("prompts directory (AC15)", () => {
     expect(readPrompt).toContain("Images");
   });
 
-  it("sg prompt exists and documents metavariables and workflow", () => {
+  it("sg prompt exists and documents metavariables, workflow, and the ast_search snippet", () => {
     const sgPromptPath = resolve(root, "prompts/sg.md");
     expect(existsSync(sgPromptPath)).toBe(true);
 
@@ -39,6 +39,7 @@ describe("prompts directory (AC15)", () => {
     expect(content).toContain("$NAME");
     expect(content).toContain("$$$ARGS");
     expect(content).toContain("$_");
+    expect(content).toContain("Use for AST-aware code pattern search when text search is too brittle.");
     expect(content.toLowerCase()).toContain("workflow");
     expect(content.toLowerCase()).toContain("edit");
   });

--- a/tests/ptc-tool-policy.test.ts
+++ b/tests/ptc-tool-policy.test.ts
@@ -40,9 +40,9 @@ describe("hashline tool ptc policy contract", () => {
           mutability: "read-only",
           defaultExposure: "safe-by-default",
         },
-        sg: {
-          toolName: "sg",
-          helperName: "sg",
+        ast_search: {
+          toolName: "ast_search",
+          helperName: "ast_search",
           overridesBuiltin: false,
           mutability: "read-only",
           defaultExposure: "opt-in",
@@ -58,15 +58,15 @@ describe("hashline tool ptc policy contract", () => {
     });
     expect(HASHLINE_TOOL_PTC_POLICY.tools.read.helperName).toBe(tools.read.ptc.pythonName);
     expect(HASHLINE_TOOL_PTC_POLICY.tools.grep.helperName).toBe(tools.grep.ptc.pythonName);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.sg.helperName).toBe(tools.sg.ptc.pythonName);
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.ast_search.helperName).toBe(tools.ast_search.ptc.pythonName);
     expect(HASHLINE_TOOL_PTC_POLICY.tools.edit.helperName).toBe(tools.edit.ptc.pythonName);
     expect(HASHLINE_TOOL_PTC_POLICY.tools.read.mutability).toBe(tools.read.ptc.policy);
     expect(HASHLINE_TOOL_PTC_POLICY.tools.grep.mutability).toBe(tools.grep.ptc.policy);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.sg.mutability).toBe(tools.sg.ptc.policy);
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.ast_search.mutability).toBe(tools.ast_search.ptc.policy);
     expect(HASHLINE_TOOL_PTC_POLICY.tools.edit.mutability).toBe(tools.edit.ptc.policy);
     expect(HASHLINE_TOOL_PTC_POLICY.tools.read.defaultExposure).toBe(tools.read.ptc.defaultExposure);
     expect(HASHLINE_TOOL_PTC_POLICY.tools.grep.defaultExposure).toBe(tools.grep.ptc.defaultExposure);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.sg.defaultExposure).toBe(tools.sg.ptc.defaultExposure);
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.ast_search.defaultExposure).toBe(tools.ast_search.ptc.defaultExposure);
     expect(HASHLINE_TOOL_PTC_POLICY.tools.edit.defaultExposure).toBe(tools.edit.ptc.defaultExposure);
   });
 });

--- a/tests/public-api-ptc-policy.test.ts
+++ b/tests/public-api-ptc-policy.test.ts
@@ -19,7 +19,7 @@ describe("public API ptc policy export", () => {
     expect(typeof mod.default).toBe("function");
     expect(mod.HASHLINE_TOOL_PTC_POLICY).toEqual(mod.getHashlineToolPtcPolicy());
     expect(mod.HASHLINE_TOOL_PTC_POLICY.tools.read.defaultExposure).toBe("safe-by-default");
-    expect(mod.HASHLINE_TOOL_PTC_POLICY.tools.sg.defaultExposure).toBe("opt-in");
+    expect(mod.HASHLINE_TOOL_PTC_POLICY.tools.ast_search.defaultExposure).toBe("opt-in");
     expect(mod.HASHLINE_TOOL_PTC_POLICY.tools.edit.defaultExposure).toBe("not-safe-by-default");
   });
 });

--- a/tests/readme-ptc-policy.test.ts
+++ b/tests/readme-ptc-policy.test.ts
@@ -13,7 +13,7 @@ describe("README.md ptc policy docs", () => {
     expect(readme).toContain("### PTC tool policy contract");
     expect(readme).toContain("`HASHLINE_TOOL_PTC_POLICY`");
     expect(readme).toContain("`read` and `grep` are safe-by-default");
-    expect(readme).toContain("`sg` is opt-in");
+    expect(readme).toContain("`ast_search` is opt-in");
     expect(readme).toContain("`edit` is not safe-by-default");
     expect(readme).toContain("`pi-prompt-assembler` may optionally consume this contract");
   });

--- a/tests/sg-output.test.ts
+++ b/tests/sg-output.test.ts
@@ -35,7 +35,7 @@ describe("buildSgOutput", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders grouped sg matches through one shared builder", async () => {
+  it("renders grouped ast_search matches through one shared builder", async () => {
     const spy = vi.spyOn(sgOutputModule, "buildSgOutput");
     const tool = await getSgTool();
     const filePath = resolve(fixturesDir, "small.ts");
@@ -69,6 +69,7 @@ describe("buildSgOutput", () => {
     ].join("\n");
 
     expect(built.text).toBe(expectedText);
+    expect(built.ptcValue.tool).toBe("ast_search");
     expect(getTextContent(result)).toBe(built.text);
     expect(result.details?.ptcValue).toEqual(built.ptcValue);
   });
@@ -94,6 +95,7 @@ describe("buildSgOutput", () => {
     );
 
     const built = spy.mock.results.at(-1)?.value;
+    expect(built.ptcValue.tool).toBe("ast_search");
     expect(getTextContent(result)).toBe(built.text);
     expect(result.details?.ptcValue).toEqual(built.ptcValue);
   });

--- a/tests/sg-ptc-value.test.ts
+++ b/tests/sg-ptc-value.test.ts
@@ -32,7 +32,7 @@ describe("sg ptcValue", () => {
 
   afterEach(() => vi.restoreAllMocks());
 
-  it("returns grouped structured results with merged ranges and anchored lines while keeping sg text unchanged", async () => {
+  it("returns grouped structured results with merged ranges and anchored lines while keeping ast_search text unchanged", async () => {
     const tool = await getSgTool();
     const filePath = resolve(fixturesDir, "small.ts");
     const sourceLines = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n").split("\n");
@@ -58,7 +58,7 @@ describe("sg ptcValue", () => {
 
     expect(ptc).toBeDefined();
     expect(ptc).toEqual({
-      tool: "sg",
+      tool: "ast_search",
       files: [
         {
           path: filePath,

--- a/tests/sg.prompt-loading.test.ts
+++ b/tests/sg.prompt-loading.test.ts
@@ -1,4 +1,10 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
 
 async function getSgTool() {
   const { registerSgTool } = await import("../src/sg.js");
@@ -10,9 +16,15 @@ async function getSgTool() {
 }
 
 describe("sg prompt loading", () => {
-  it("uses prompts/sg.md as tool description", async () => {
+  it("uses the first prompt paragraph as the exact ast_search description", async () => {
     const tool = await getSgTool();
-    expect(tool.description).toContain("ast-grep");
-    expect(tool.description).toContain("$NAME");
+    expect(tool.description).toBe(
+      "AST-aware structural code search. Use this when grep is too brittle and you need to match code shape rather than raw text. Prefer over grep for finding function calls, imports, JSX elements, or syntax patterns. Returns anchored matches suitable for edit.",
+    );
+  });
+
+  it("keeps the prompt snippet in prompts/sg.md", () => {
+    const content = readFileSync(resolve(root, "prompts/sg.md"), "utf8");
+    expect(content).toContain("Use for AST-aware code pattern search when text search is too brittle.");
   });
 });

--- a/tests/sg.schema.test.ts
+++ b/tests/sg.schema.test.ts
@@ -14,10 +14,11 @@ async function getSgTool() {
 }
 
 describe("sg tool schema", () => {
-  it("registers name=sg and requires pattern only", async () => {
+  it("registers name=ast_search and requires pattern only", async () => {
     const tool = await getSgTool();
 
-    expect(tool.name).toBe("sg");
+    expect(tool.name).toBe("ast_search");
+    expect(tool.ptc.pythonName).toBe("ast_search");
     expect(tool.parameters).toBeTruthy();
 
     expect(tool.parameters.properties.pattern.type).toBe("string");

--- a/tests/tool-executor-emit.test.ts
+++ b/tests/tool-executor-emit.test.ts
@@ -19,7 +19,7 @@ describe("index.ts emits and stashes tool executors (task 2)", () => {
     init(pi as any);
     const stash = (globalThis as any).__hashlineToolExecutors;
     expect(stash).toBeDefined();
-    expect(Object.keys(stash).sort()).toEqual(["edit", "grep", "read", "sg"]);
+    expect(Object.keys(stash).sort()).toEqual(["ast_search", "edit", "grep", "read"]);
   });
 
   it("emit channel is exactly 'hashline:tool-executors'", async () => {
@@ -30,7 +30,6 @@ describe("index.ts emits and stashes tool executors (task 2)", () => {
       (c: any[]) => c[0] === "hashline:tool-executors"
     );
     expect(emitCall).toBeDefined();
-    // Payload should be the SAME object reference as globalThis stash
     expect(emitCall![1]).toBe((globalThis as any).__hashlineToolExecutors);
   });
 });

--- a/tests/tool-executors.test.ts
+++ b/tests/tool-executors.test.ts
@@ -47,7 +47,7 @@ describe("register functions return tool definitions", () => {
     const pi = createMockPi();
     const tool = registerSgTool(pi as any);
     expect(tool).toBeDefined();
-    expect(tool.name).toBe("sg");
+    expect(tool.name).toBe("ast_search");
     expect(typeof tool.execute).toBe("function");
     expect(typeof tool.description).toBe("string");
     expect(tool.parameters).toBeDefined();
@@ -84,7 +84,7 @@ describe("index.ts emits and stashes tool executors", () => {
     expect(stash.read).toBeDefined();
     expect(stash.edit).toBeDefined();
     expect(stash.grep).toBeDefined();
-    expect(stash.sg).toBeDefined();
+    expect(stash.ast_search).toBeDefined();
   });
 
   it("emits on hashline:tool-executors channel", async () => {
@@ -97,7 +97,7 @@ describe("index.ts emits and stashes tool executors", () => {
         read: expect.objectContaining({ name: "read" }),
         edit: expect.objectContaining({ name: "edit" }),
         grep: expect.objectContaining({ name: "grep" }),
-        sg: expect.objectContaining({ name: "sg" }),
+        ast_search: expect.objectContaining({ name: "ast_search" }),
       })
     );
   });
@@ -107,7 +107,7 @@ describe("index.ts emits and stashes tool executors", () => {
     const { default: init } = await import("../index.js");
     init(pi as any);
     const stash = (globalThis as any).__hashlineToolExecutors;
-    for (const key of ["read", "edit", "grep", "sg"]) {
+    for (const key of ["read", "edit", "grep", "ast_search"]) {
       expect(typeof stash[key].execute).toBe("function");
     }
   });
@@ -120,10 +120,8 @@ describe("index.ts emits and stashes tool executors", () => {
     });
     const { default: init } = await import("../index.js");
     init(pi as any);
-    // globalThis should have been set BEFORE emit was called
     expect(stashAtEmitTime).toBeDefined();
     expect(stashAtEmitTime.read).toBeDefined();
-    // This assertion will fail until emit ordering is verified
     expect(stashAtEmitTime).toBe((globalThis as any).__hashlineToolExecutors);
   });
 
@@ -135,7 +133,7 @@ describe("index.ts emits and stashes tool executors", () => {
       (c: any[]) => c[0] === "hashline:tool-executors"
     )?.[1] as Record<string, any>;
     expect(payload).toBeDefined();
-    for (const key of ["read", "edit", "grep", "sg"]) {
+    for (const key of ["read", "edit", "grep", "ast_search"]) {
       expect(typeof payload[key].description).toBe("string");
       expect(payload[key].parameters).toBeDefined();
       expect(typeof payload[key].execute).toBe("function");


### PR DESCRIPTION
## Summary

Renames the public structural search tool from `sg` to `ast_search` and updates its description to improve agent discoverability.

## Why

Agents were under-selecting the `sg` tool because the name was terse and non-descriptive. The new name `ast_search` and explicit description ("AST-aware structural code search. Use this when grep is too brittle...") make it clear when to prefer this tool over `grep`.

## What changed

- **Tool registration** (`src/sg.ts`): public name `sg` → `ast_search`, label `AST Grep` → `AST Search`, pythonName updated
- **Description loading** (`src/sg.ts`, `prompts/sg.md`): description is now the first paragraph of the prompt file; prompt snippet added as second paragraph
- **Structured output** (`src/sg-output.ts`): `tool` discriminator `"sg"` → `"ast_search"`
- **PTC policy** (`src/ptc-tool-policy.ts`): type union and policy object key renamed
- **Executor map** (`index.ts`): key `sg` → `ast_search`
- **Documentation**: README, AGENTS.md, exploratory testing docs updated
- **Tests** (13 files): all assertions updated to expect `ast_search`

## What did NOT change

- Backend still invokes the `sg` CLI binary (`ast-grep`)
- Source filenames (`sg.ts`, `sg-output.ts`) kept as internal implementation details
- Anchored output format and search→edit workflow unchanged
- Bash filter: zero changes

## Verification

- 107 test files, 525 tests pass
- TypeScript typecheck clean
- All 6 acceptance criteria verified with direct evidence

Closes #67