### PR TITLE
feat: add Nushell (nu) tool for structured exploration alongside bash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ npm run typecheck
 ## Source map
 
 - `index.ts` — extension entry point
-- `src/read.ts`, `src/edit.ts`, `src/grep.ts`, `src/sg.ts` — core tool implementations
+- `src/read.ts`, `src/edit.ts`, `src/grep.ts`, `src/sg.ts`, `src/nu.ts` — core tool implementations
 - `src/*-output.ts`, `src/*-render-helpers.ts` — tool result shaping / rendering
 - `src/readmap/` — structural mapping, symbol lookup, language detection, per-language mappers
 - `src/rtk/` — bash output routing and compression techniques

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import { registerReadTool } from "./src/read.js";
 import { registerEditTool } from "./src/edit.js";
 import { registerGrepTool } from "./src/grep.js";
 import { registerSgTool } from "./src/sg.js";
+import { registerNuTool } from "./src/nu.js";
 import { filterBashOutput } from "./src/rtk/bash-filter.js";
 import { stripAnsi } from "./src/rtk/ansi.js";
 
@@ -40,6 +41,7 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
   const editTool = registerEditTool(pi);
   const grepTool = registerGrepTool(pi);
   const sgTool = registerSgTool(pi);
+  registerNuTool(pi);
 
   const toolExecutors = {
     read: readTool,

--- a/prompts/nu.md
+++ b/prompts/nu.md
@@ -1,0 +1,1 @@
+Explore files, structured data (JSON/CSV/TOML/YAML), and system state using Nushell pipelines. Returns structured output ideal for inspection and analysis. Use for exploration and investigation — for running project commands, build tools, scripts, or git operations, use `bash` instead.

--- a/src/nu.ts
+++ b/src/nu.ts
@@ -1,0 +1,323 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { Type } from "@sinclair/typebox";
+import { execFileSync, spawn } from "node:child_process";
+import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { stripAnsi } from "./rtk/ansi.js";
+
+const MAX_LINES = 2000;
+const MAX_BYTES = 50 * 1024; // 50 KB
+
+/**
+ * Check if the `nu` (Nushell) binary is available in PATH.
+ * Runs `nu --version` synchronously with a 3-second timeout.
+ */
+export function isNuAvailable(): boolean {
+  try {
+    execFileSync("nu", ["--version"], { timeout: 3000, stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Truncate output to match bash tool limits: 2000 lines or 50KB.
+ * Line truncation is applied before byte truncation.
+ */
+export function truncateNuOutput(text: string): string {
+  const lines = text.split("\n");
+  if (lines.length > MAX_LINES) {
+    text =
+      lines.slice(0, MAX_LINES).join("\n") +
+      `\n[… ${lines.length - MAX_LINES} more lines truncated]`;
+  }
+  const bytes = Buffer.byteLength(text, "utf8");
+  if (bytes > MAX_BYTES) {
+    text =
+      Buffer.from(text, "utf8").subarray(0, MAX_BYTES).toString("utf8") +
+      "\n[… truncated at 50 KB]";
+  }
+  return text;
+}
+
+export interface NuExecuteOptions {
+  command: string;
+  cwd: string;
+  timeoutSeconds?: number;
+  signal?: AbortSignal;
+  onUpdate?: (output: string) => void;
+}
+
+export interface NuExecuteResult {
+  output: string;
+  exitCode: number | null;
+  timedOut: boolean;
+}
+
+/**
+ * Execute a Nushell script via a temp file.
+ * Streams partial output, handles timeout/abort, strips ANSI, truncates.
+ */
+export async function executeNuScript(opts: NuExecuteOptions): Promise<NuExecuteResult> {
+  const { command, cwd, timeoutSeconds = 30, signal, onUpdate } = opts;
+  const timeoutMs = timeoutSeconds * 1000;
+
+  // Short-circuit if already aborted
+  if (signal?.aborted) {
+    return { output: "(aborted)", exitCode: -1, timedOut: false };
+  }
+
+  const tmpFile = join(tmpdir(), `pi-nu-${randomBytes(8).toString("hex")}.nu`);
+
+  const cleanup = () => {
+    try {
+      unlinkSync(tmpFile);
+    } catch {
+      // best-effort
+    }
+  };
+
+  // Safely write temp file with restrictive permissions
+  try {
+    writeFileSync(tmpFile, command, { encoding: "utf8", mode: 0o600 });
+  } catch (err: unknown) {
+    cleanup(); // remove partial temp file if any
+    const msg = err instanceof Error ? err.message : String(err);
+    return { output: `Error writing temp file: ${msg}`, exitCode: -1, timedOut: false };
+  }
+
+  const args = process.env.PI_NUSHELL_CONFIG
+    ? ["--config", process.env.PI_NUSHELL_CONFIG, tmpFile]
+    : ["--no-config-file", tmpFile];
+
+  return new Promise<NuExecuteResult>((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let settled = false;
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const settle = (result: NuExecuteResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (killTimer) clearTimeout(killTimer);
+      signal?.removeEventListener("abort", abort);
+      cleanup();
+      resolve(result);
+    };
+
+    // Wrap spawn in try/catch for sync failures (e.g. invalid cwd)
+    let proc;
+    try {
+      proc = spawn("nu", args, { cwd, env: { ...process.env } });
+    } catch (err: unknown) {
+      cleanup();
+      const msg = err instanceof Error ? err.message : String(err);
+      resolve({ output: `Error spawning nushell: ${msg}`, exitCode: -1, timedOut: false });
+      return;
+    }
+
+    // SIGTERM → 2s grace → SIGKILL escalation to prevent hanging
+    const forceKill = () => {
+      killTimer = setTimeout(() => {
+        try {
+          proc.kill("SIGKILL");
+        } catch {
+          // process may already be dead
+        }
+      }, 2000);
+    };
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill("SIGTERM");
+      forceKill();
+    }, timeoutMs);
+
+    const abort = () => {
+      clearTimeout(timer);
+      proc.kill("SIGTERM");
+      forceKill();
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+
+    proc.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+      onUpdate?.(truncateNuOutput(stdout));
+    });
+
+    proc.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    proc.on("close", (code) => {
+      let output = stdout;
+      if (stderr) {
+        output += (output ? "\n\nstderr:\n" : "") + stderr;
+      }
+      if (timedOut) {
+        output = `[timed out after ${timeoutSeconds}s]\n` + output;
+      }
+
+      output = truncateNuOutput(stripAnsi(output.trim())) || "(no output)";
+
+      settle({ output, exitCode: timedOut ? -1 : code, timedOut });
+    });
+
+    proc.on("error", (err: NodeJS.ErrnoException) => {
+      const hint =
+        err.code === "ENOENT"
+          ? "\n\nHint: 'nu' was not found in PATH. Install nushell: https://www.nushell.sh/"
+          : "";
+      settle({
+        output: `Error spawning nushell: ${err.message}${hint}`,
+        exitCode: -1,
+        timedOut: false,
+      });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Prompt & registration
+// ---------------------------------------------------------------------------
+
+const NU_PROMPT = readFileSync(new URL("../prompts/nu.md", import.meta.url), "utf-8").trim();
+const NU_DESC = NU_PROMPT.split(/\n\s*\n/, 1)[0]?.trim() ?? NU_PROMPT;
+
+const NU_SNIPPET =
+  "Structured exploration shell — file inspection, data wrangling, system queries via Nushell pipelines. Use bash for project commands.";
+
+export const NU_GUIDELINES: string[] = [
+  `Use \`nu\` for exploring, inspecting, and analyzing. Use \`bash\` for executing project commands.
+
+| Task | Tool |
+|------|------|
+| Find large files in src/ | nu |
+| Run tests | bash |
+| Read fields from package.json | nu |
+| Install dependencies | bash |
+| Parse and filter a CSV | nu |
+| Run git diff | bash |
+| Check disk space or memory | nu |
+| Build Docker image | bash |
+| Explore an API response | nu |
+| Run a Makefile target | bash |`,
+
+  `## File exploration
+ls **/*.ts | where size > 10kb | sort-by size | reverse | first 10
+ls src/ | where type == "dir"
+glob **/*.test.ts | length`,
+
+  `## Structured data access
+open package.json | get scripts
+open tsconfig.json | get compilerOptions.strict
+open Cargo.toml | get dependencies | transpose key value`,
+
+  `## Filtering and transforming
+open data.csv | where status == "active" | group-by region
+open results.json | get items | where score > 90 | select name score`,
+
+  `## System inspection
+ps | where cpu > 5 | sort-by cpu | reverse | first 10
+sys mem`,
+
+  `## HTTP (exploring APIs)
+http get https://api.example.com/data | get results | first 5`,
+
+  `## Quick calculations
+1400 * 300
+(open data.csv | get revenue | math sum) / (open data.csv | length)`,
+
+  `## Key syntax
+- Filter rows: | where column > value or | where name =~ "pattern"
+- Select columns: | select col1 col2
+- Sort: | sort-by column (add | reverse for descending)
+- Count: | length
+- Aggregate: | math sum, | math avg, | math max
+- First/last N: | first 5, | last 3
+- Group: | group-by column
+- Convert: | to json, | to csv
+- Strings in filters must be quoted: | where name == "value"`,
+];
+
+export const NU_PTC = {
+  callable: true,
+  enabled: true,
+  policy: "read-only" as const,
+  readOnly: true,
+  pythonName: "nu",
+  defaultExposure: "opt-in" as const,
+};
+
+/**
+ * Register the `nu` tool with pi. Returns true if registered, false if nu is not available.
+ */
+export function registerNuTool(pi: ExtensionAPI): boolean {
+  if (!isNuAvailable()) {
+    return false;
+  }
+
+  const tool = {
+    name: "nu",
+    label: "nushell",
+    description: NU_DESC,
+    promptSnippet: NU_SNIPPET,
+    promptGuidelines: NU_GUIDELINES,
+    ptc: NU_PTC,
+    parameters: Type.Object({
+      command: Type.String({ description: "Nushell script to run. May be multi-line." }),
+      timeout: Type.Optional(
+        Type.Number({ description: "Maximum run time in seconds. Defaults to 30." }),
+      ),
+    }),
+
+    async execute(toolCallId, params: { command: string; timeout?: number }, signal, onUpdate, ctx) {
+      const result = await executeNuScript({
+        command: params.command,
+        cwd: ctx.cwd,
+        timeoutSeconds: params.timeout ?? 30,
+        signal: signal ?? undefined,
+        onUpdate: onUpdate
+          ? (text) => onUpdate({ content: [{ type: "text", text }], details: {} })
+          : undefined,
+      });
+
+      return {
+        content: [{ type: "text" as const, text: result.output }],
+        details: {
+          exitCode: result.exitCode,
+          timedOut: result.timedOut,
+          shell: "nushell",
+        },
+      };
+    },
+
+    renderCall(args: any, theme: any) {
+      const { command } = args as { command: string };
+      const label = theme.fg("toolTitle", "🐚 nushell");
+      const firstLine = command.split("\n")[0];
+      const preview = firstLine + (command.includes("\n") ? " …" : "");
+      const full = command.includes("\n")
+        ? "\n" + theme.fg("muted", command)
+        : "";
+      return new Text(`${label} ${theme.fg("muted", preview)}${full}`, 0, 0);
+    },
+
+    renderResult(result, _options, theme) {
+      const output =
+        result.content[0]?.type === "text"
+          ? (result.content[0] as { type: "text"; text: string }).text
+          : "";
+      return new Text(theme.fg("toolOutput", output), 0, 0);
+    },
+  } satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof NU_PTC };
+
+  pi.registerTool(tool);
+  return true;
+}

--- a/tests/nu-execute.test.ts
+++ b/tests/nu-execute.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+// Check if nu is installed for integration tests
+const nuAvailable = (() => {
+  try {
+    execFileSync("nu", ["--version"], { timeout: 3000, stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+const describeNu = nuAvailable ? describe : describe.skip;
+
+describeNu("executeNuScript (integration)", () => {
+  it("executes a simple expression and returns result", async () => {
+    const { executeNuScript } = await import("../src/nu.js");
+    const result = await executeNuScript({
+      command: "[1 2 3] | math sum",
+      cwd: process.cwd(),
+    });
+    expect(result.output.trim()).toBe("6");
+    expect(result.exitCode).toBe(0);
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("captures stderr on error command", async () => {
+    const { executeNuScript } = await import("../src/nu.js");
+    const result = await executeNuScript({
+      command: "nonexistent_command_xyz_123",
+      cwd: process.cwd(),
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.output.toLowerCase()).toMatch(/not found|not_found|error|external/i);
+  });
+
+  it("respects timeout", async () => {
+    const { executeNuScript } = await import("../src/nu.js");
+    const result = await executeNuScript({
+      command: "sleep 10sec",
+      cwd: process.cwd(),
+      timeoutSeconds: 1,
+    });
+    expect(result.timedOut).toBe(true);
+    expect(result.output).toContain("timed out");
+  });
+
+  it("cleans up temp files after execution", async () => {
+    const { executeNuScript } = await import("../src/nu.js");
+    await executeNuScript({ command: "echo hello", cwd: process.cwd() });
+    const tmpFiles = readdirSync(tmpdir()).filter(
+      (f: string) => f.startsWith("pi-nu-") && f.endsWith(".nu"),
+    );
+    expect(tmpFiles.length).toBe(0);
+  });
+
+  it("strips ANSI codes from output", async () => {
+    const { executeNuScript } = await import("../src/nu.js");
+    const result = await executeNuScript({
+      command: 'echo "hello"',
+      cwd: process.cwd(),
+    });
+    expect(result.output).not.toMatch(/\x1b\[/);
+  });
+
+  it("handles multi-line scripts", async () => {
+    const { executeNuScript } = await import("../src/nu.js");
+    const result = await executeNuScript({
+      command: "let x = 5\nlet y = 10\n$x + $y",
+      cwd: process.cwd(),
+    });
+    expect(result.output.trim()).toBe("15");
+  });
+});
+
+describe("executeNuScript (error handling)", () => {
+  it("short-circuits when signal is already aborted", async () => {
+    const { executeNuScript } = await import("../src/nu.js");
+    const controller = new AbortController();
+    controller.abort();
+    const result = await executeNuScript({
+      command: "echo should-not-run",
+      cwd: process.cwd(),
+      signal: controller.signal,
+    });
+    expect(result.output).toContain("aborted");
+    expect(result.exitCode).toBe(-1);
+  });
+
+  it("returns error for spawn failure with invalid binary", async () => {
+    // Temporarily test with a deliberately broken PATH to verify ENOENT handling
+    const { executeNuScript } = await import("../src/nu.js");
+    // We can't easily force ENOENT without mocking, but we verify the function
+    // handles the error event path by checking the contract
+    const result = await executeNuScript({
+      command: "echo test",
+      cwd: "/nonexistent-directory-xyz-12345",
+    });
+    // spawn with invalid cwd should produce an error
+    expect(result.exitCode).toBe(-1);
+    expect(result.output.length).toBeGreaterThan(0);
+  });
+
+  it("returns structured result shape on all paths", async () => {
+    const { executeNuScript } = await import("../src/nu.js");
+    const controller = new AbortController();
+    controller.abort();
+    const result = await executeNuScript({
+      command: "echo test",
+      cwd: process.cwd(),
+      signal: controller.signal,
+    });
+    // Verify the result always has the expected shape
+    expect(result).toHaveProperty("output");
+    expect(result).toHaveProperty("exitCode");
+    expect(result).toHaveProperty("timedOut");
+    expect(typeof result.output).toBe("string");
+    expect(typeof result.timedOut).toBe("boolean");
+  });
+});

--- a/tests/nu-index.test.ts
+++ b/tests/nu-index.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("index.ts nu integration", () => {
+  const content = readFileSync(resolve(__dirname, "../index.ts"), "utf-8");
+
+  it("imports registerNuTool", () => {
+    expect(content).toContain("registerNuTool");
+    expect(content).toContain("./src/nu.js");
+  });
+
+  it("calls registerNuTool(pi)", () => {
+    expect(content).toContain("registerNuTool(pi)");
+  });
+});

--- a/tests/nu-prompt.test.ts
+++ b/tests/nu-prompt.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("prompts/nu.md", () => {
+  it("exists and contains structured exploration description", () => {
+    const content = readFileSync(resolve(__dirname, "../prompts/nu.md"), "utf-8");
+    expect(content).toContain("Nushell");
+    expect(content).toContain("structured");
+    expect(content).toContain("bash");
+  });
+
+  it("mentions exploration and investigation use case", () => {
+    const content = readFileSync(resolve(__dirname, "../prompts/nu.md"), "utf-8");
+    expect(content).toContain("exploration");
+  });
+});

--- a/tests/nu-register.test.ts
+++ b/tests/nu-register.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { NU_GUIDELINES, NU_PTC } from "../src/nu.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("NU_GUIDELINES", () => {
+  const allText = NU_GUIDELINES.join("\n");
+
+  it("contains routing guidance for both nu and bash", () => {
+    expect(allText).toContain("bash");
+    expect(allText).toContain("nu");
+  });
+
+  it("includes file exploration patterns", () => {
+    expect(allText).toContain("ls");
+    expect(allText).toContain("where");
+    expect(allText).toContain("sort-by");
+  });
+
+  it("includes structured data access patterns", () => {
+    expect(allText).toContain("open");
+    expect(allText).toContain("get");
+  });
+
+  it("includes system inspection patterns", () => {
+    expect(allText).toContain("ps");
+    expect(allText).toContain("sys mem");
+  });
+
+  it("includes key syntax reference", () => {
+    expect(allText).toContain("length");
+    expect(allText).toContain("math sum");
+    expect(allText).toContain("group-by");
+    expect(allText).toContain("first");
+  });
+
+  it("includes routing table with task-to-tool mappings", () => {
+    expect(allText).toContain("Run tests");
+    expect(allText).toContain("package.json");
+  });
+});
+
+describe("NU_PTC", () => {
+  it("is callable and read-only", () => {
+    expect(NU_PTC.callable).toBe(true);
+    expect(NU_PTC.readOnly).toBe(true);
+  });
+
+  it("has pythonName 'nu'", () => {
+    expect(NU_PTC.pythonName).toBe("nu");
+  });
+
+  it("has read-only policy", () => {
+    expect(NU_PTC.policy).toBe("read-only");
+  });
+
+  it("is opt-in by default", () => {
+    expect(NU_PTC.defaultExposure).toBe("opt-in");
+  });
+});
+
+describe("registerNuTool", () => {
+  it("is exported as a function", async () => {
+    const { registerNuTool } = await import("../src/nu.js");
+    expect(typeof registerNuTool).toBe("function");
+  });
+});
+
+describe("tool registration includes PTC metadata", () => {
+  it("tool definition includes ptc: NU_PTC", () => {
+    const src = readFileSync(resolve(__dirname, "../src/nu.ts"), "utf-8");
+    expect(src).toMatch(/ptc:\s*NU_PTC/);
+    expect(src).toContain("pi.registerTool(tool)");
+  });
+});

--- a/tests/nu-utils.test.ts
+++ b/tests/nu-utils.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { isNuAvailable, truncateNuOutput } from "../src/nu.js";
+
+describe("isNuAvailable", () => {
+  it("returns a boolean", () => {
+    const result = isNuAvailable();
+    expect(typeof result).toBe("boolean");
+  });
+});
+
+describe("truncateNuOutput", () => {
+  it("passes through short output unchanged", () => {
+    expect(truncateNuOutput("hello")).toBe("hello");
+  });
+
+  it("passes through empty string unchanged", () => {
+    expect(truncateNuOutput("")).toBe("");
+  });
+
+  it("truncates output exceeding 2000 lines", () => {
+    const lines = Array.from({ length: 2500 }, (_, i) => `line ${i}`);
+    const result = truncateNuOutput(lines.join("\n"));
+    const resultLines = result.split("\n");
+    // 2000 content lines + 1 truncation message line
+    expect(resultLines.length).toBeLessThanOrEqual(2001);
+    expect(result).toContain("500 more lines truncated");
+  });
+
+  it("truncates output exceeding 50KB", () => {
+    const big = "x".repeat(60 * 1024);
+    const result = truncateNuOutput(big);
+    expect(Buffer.byteLength(result, "utf8")).toBeLessThanOrEqual(52 * 1024);
+    expect(result).toContain("truncated at 50 KB");
+  });
+
+  it("applies line truncation before byte truncation when lines are short", () => {
+    // Short lines (4 chars each) so 3000 lines = ~15KB (under 50KB)
+    // This ensures line truncation fires, not byte truncation
+    const lines = Array.from({ length: 3000 }, (_, i) => `L${i}`);
+    const result = truncateNuOutput(lines.join("\n"));
+    expect(result).toContain("more lines truncated");
+    // Should NOT have byte truncation since total is well under 50KB
+    expect(result).not.toContain("truncated at 50 KB");
+  });
+
+  it("handles exactly 2000 lines without truncation", () => {
+    const lines = Array.from({ length: 2000 }, (_, i) => `line ${i}`);
+    const input = lines.join("\n");
+    const result = truncateNuOutput(input);
+    expect(result).toBe(input);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `nu` tool that executes Nushell scripts for structured exploration tasks alongside the existing `bash` tool.

**Division of labor:**
- `nu` → file exploration, structured data access (JSON/CSV/TOML/YAML), system inspection, data transformation, quick calculations
- `bash` → project commands, git, docker, package managers, build tools, scripts

**Key features:**
- Opt-in by detection: only registered when `nu` binary is in PATH
- Prompt-driven routing with explicit task→tool mapping table
- Pattern library with ~15 recipes the agent can use immediately
- Robust execution: temp files with 0o600 perms, SIGTERM→SIGKILL escalation, pre-abort short-circuit
- ANSI stripping + truncation (2000 lines / 50KB)
- PTC exposure (callable, read-only)
- Streaming TUI output

**Files:**
- `src/nu.ts` — 322 lines: detection, truncation, execution engine, prompt guidelines, tool registration
- `prompts/nu.md` — tool description
- `index.ts` — 2 lines added (import + register)
- 5 test files, 26 tests + 6 integration tests (skipped when nu not installed)

All 112 test files pass, typecheck clean.

Closes #68