### PR TITLE
feat(nu): advertise nushell plugins and add config resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A drop-in [pi](https://github.com/mariozechner/pi-coding-agent) extension that upgrades the agent’s local coding workflow with hash-anchored reads and edits, structural file maps, symbol-aware navigation, structural search, and compressed `bash` output.
 
-It replaces the stock `read`, `edit`, and `grep` tools, provides an enhanced `ast_search` tool, and post-processes `bash` output so more context budget goes to useful information instead of noise.
+It replaces the stock `read`, `edit`, and `grep` tools, provides an enhanced `ast_search` tool, adds a `nu` tool for structured exploration via Nushell, and post-processes `bash` output so more context budget goes to useful information instead of noise.
 
 ## Why install this?
 
@@ -133,6 +133,21 @@ Specialized compressors currently cover:
 
 ANSI escape stripping runs on all bash output regardless.
 
+## `nu`
+When [Nushell](https://www.nushell.sh/) is installed, the extension registers a `nu` tool for structured exploration — file inspection, data wrangling, and system queries via Nushell pipelines.
+
+The `nu` tool's prompt advertises several optional Nushell plugins that enhance agentic coding workflows when installed:
+
+| Plugin | Commands | What it does |
+|--------|----------|--------------|
+| `nu_plugin_gstat` | `gstat` | Structured git status — branch, ahead/behind, staged/unstaged counts, conflicts |
+| `nu_plugin_query` | `query json`, `query xml`, `query web` | JSONPath, XPath, and CSS selector queries on structured data |
+| `nu_plugin_formats` | `from ini`, `from plist` | Parse INI and plist config file formats into structured records |
+| `nu_plugin_semver` | `into semver`, `semver bump` | Parse, compare, sort, and bump SemVer versions |
+| `nu_plugin_file` | `file` | Detect file type from magic bytes instead of extension |
+
+These plugins are **not bundled** — they must be installed separately. See [Optional Nushell plugins](#optional-nushell-plugins) below.
+
 ## Quick Start
 
 ### Install from npm
@@ -147,10 +162,46 @@ pi install git:github.com/coctostan/pi-hashline-readmap
 
 ### Optional local tools
 ```bash
+brew install nushell           # required for nu tool
 brew install ast-grep          # required for ast_search
 brew install difftastic        # optional, improves semantic edit summaries
 brew install shellcheck yq scc # optional, improves some bash output compression flows
 ```
+
+### Optional Nushell plugins
+If Nushell is installed, these plugins add capabilities to the `nu` tool. Install with `cargo install` and register with `plugin add` inside Nushell:
+```bash
+# Install plugins (requires Rust toolchain)
+cargo install nu_plugin_gstat nu_plugin_query nu_plugin_formats --locked
+cargo install nu_plugin_semver nu_plugin_file --locked
+
+# Register them inside nushell
+nu -c 'plugin add ~/.cargo/bin/nu_plugin_gstat'
+nu -c 'plugin add ~/.cargo/bin/nu_plugin_query'
+nu -c 'plugin add ~/.cargo/bin/nu_plugin_formats'
+nu -c 'plugin add ~/.cargo/bin/nu_plugin_semver'
+nu -c 'plugin add ~/.cargo/bin/nu_plugin_file'
+```
+
+After installing and registering plugins, create a pi-specific nushell config to load them:
+
+```bash
+mkdir -p ~/.config/pi/nushell
+cat > ~/.config/pi/nushell/config.nu << 'EOF'
+# Minimal nushell config for pi — only loads plugins
+plugin use gstat
+plugin use query
+plugin use formats
+plugin use semver
+plugin use file
+EOF
+```
+
+The `nu` tool resolves its config with this priority:
+1. `PI_NUSHELL_CONFIG` environment variable → uses that config path
+2. `~/.config/pi/nushell/config.nu` → uses the pi-specific config if it exists
+3. `--no-config-file` → fast, clean, no plugins (default when no config exists)
+The `nu` tool will advertise available plugin commands to the agent regardless of whether they are installed. If a plugin is missing, the agent will see a "command not found" error and fall back to other approaches.
 
 After installation, use pi normally. The package registers the upgraded tools automatically.
 

--- a/src/nu.ts
+++ b/src/nu.ts
@@ -2,8 +2,8 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { execFileSync, spawn } from "node:child_process";
-import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 import { stripAnsi } from "./rtk/ansi.js";
@@ -59,6 +59,29 @@ export interface NuExecuteResult {
 }
 
 /**
+ * Resolve nushell CLI arguments for config and plugin loading.
+ *
+ * Priority:
+ *   1. PI_NUSHELL_CONFIG env var → --config <path>
+ *   2. ~/.config/pi/nushell/config.nu if it exists → --config <path>
+ *   3. --no-config-file (clean, no plugins)
+ */
+export function resolveNuArgs(): string[] {
+  // Priority 1: Explicit env var override
+  if (process.env.PI_NUSHELL_CONFIG) {
+    return ["--config", process.env.PI_NUSHELL_CONFIG];
+  }
+
+  // Priority 2: Pi-specific config at well-known path
+  const piConfig = join(homedir(), ".config", "pi", "nushell", "config.nu");
+  if (existsSync(piConfig)) {
+    return ["--config", piConfig];
+  }
+
+  // Priority 3: Clean slate — fast, predictable, no plugins
+  return ["--no-config-file"];
+}
+/**
  * Execute a Nushell script via a temp file.
  * Streams partial output, handles timeout/abort, strips ANSI, truncates.
  */
@@ -90,9 +113,7 @@ export async function executeNuScript(opts: NuExecuteOptions): Promise<NuExecute
     return { output: `Error writing temp file: ${msg}`, exitCode: -1, timedOut: false };
   }
 
-  const args = process.env.PI_NUSHELL_CONFIG
-    ? ["--config", process.env.PI_NUSHELL_CONFIG, tmpFile]
-    : ["--no-config-file", tmpFile];
+  const args = [...resolveNuArgs(), tmpFile];
 
   return new Promise<NuExecuteResult>((resolve) => {
     let stdout = "";
@@ -244,6 +265,16 @@ http get https://api.example.com/data | get results | first 5`,
 - Group: | group-by column
 - Convert: | to json, | to csv
 - Strings in filters must be quoted: | where name == "value"`,
+  `## Nushell plugins (install separately)
+If installed, these plugins are available in nu pipelines:
+- \`gstat\` — structured git status: branch, ahead/behind, staged/unstaged counts, conflicts
+- \`query json <jsonpath>\` — JSONPath queries on structured data
+- \`query xml <xpath>\` — XPath queries on XML documents
+- \`query web <css-selector>\` — CSS selector queries on HTML
+- \`from ini\` / \`from plist\` — parse INI and plist config formats (via formats plugin)
+- \`into semver\` / \`semver bump <level>\` — parse and manipulate SemVer versions
+- \`file\` — detect file type from magic bytes, not extension
+Install: \`cargo install nu_plugin_gstat nu_plugin_query nu_plugin_formats\` then \`plugin add <path>\` inside nushell.`,
 ];
 
 export const NU_PTC = {

--- a/tests/nu-utils.test.ts
+++ b/tests/nu-utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { isNuAvailable, truncateNuOutput } from "../src/nu.js";
+import { describe, it, expect, afterEach } from "vitest";
+import { isNuAvailable, truncateNuOutput, resolveNuArgs } from "../src/nu.js";
 
 describe("isNuAvailable", () => {
   it("returns a boolean", () => {
@@ -48,5 +48,38 @@ describe("truncateNuOutput", () => {
     const input = lines.join("\n");
     const result = truncateNuOutput(input);
     expect(result).toBe(input);
+  });
+});
+
+describe("resolveNuArgs", () => {
+  const origEnv = process.env.PI_NUSHELL_CONFIG;
+
+  afterEach(() => {
+    if (origEnv === undefined) {
+      delete process.env.PI_NUSHELL_CONFIG;
+    } else {
+      process.env.PI_NUSHELL_CONFIG = origEnv;
+    }
+  });
+
+  it("uses PI_NUSHELL_CONFIG when set", () => {
+    process.env.PI_NUSHELL_CONFIG = "/custom/config.nu";
+    const args = resolveNuArgs();
+    expect(args).toEqual(["--config", "/custom/config.nu"]);
+  });
+
+  it("falls back to --no-config-file when no env var and no pi config file", () => {
+    delete process.env.PI_NUSHELL_CONFIG;
+    // Unless ~/.config/pi/nushell/config.nu exists, should get --no-config-file
+    const args = resolveNuArgs();
+    // Either uses pi config if it exists, or falls back
+    expect(args[0]).toMatch(/^--config$|^--no-config-file$/);
+  });
+
+  it("returns an array suitable for spreading into spawn args", () => {
+    delete process.env.PI_NUSHELL_CONFIG;
+    const args = resolveNuArgs();
+    expect(Array.isArray(args)).toBe(true);
+    expect(args.length).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## What

Adds nushell plugin awareness to the `nu` tool so agents know about and can use installed nushell plugins for common agentic coding tasks.

## Changes

### `src/nu.ts`
- **`resolveNuArgs()`** — 3-tier config resolution:
  1. `PI_NUSHELL_CONFIG` env var → explicit config path
  2. `~/.config/pi/nushell/config.nu` → auto-detected pi-specific config
  3. `--no-config-file` → clean fallback (no plugins)
- **Plugin guidelines** added to `NU_GUIDELINES` — advertises `gstat`, `query json/xml/web`, `from ini/plist`, `into semver`, `file` with install hint

### `README.md`
- Added `## nu` section with plugin capability table
- Added `nushell` to optional local tools
- Added `### Optional Nushell plugins` with install + registration steps
- Documented pi-specific config creation (`~/.config/pi/nushell/config.nu`)
- Documented the 3-tier config resolution priority

### `tests/nu-utils.test.ts`
- 3 new tests for `resolveNuArgs` — env override, fallback, array shape

## Why

The `nu` tool already works well for structured data exploration, but agents had no way to know about nushell plugins like `gstat` (structured git status) or `query` (JSONPath/XPath/CSS selectors). These plugins add real capabilities — not just convenience wrappers — that make agentic coding more efficient.

The config resolution ensures plugins actually load when installed, while keeping the default behavior fast and clean for users without plugins.