### PR TITLE
feat: sharpen agentic tooling — 3-char hashes, adaptive relocation, fuzzy recovery, write tool, Swift/Shell mappers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,8 +2,9 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { registerReadTool } from "./src/read.js";
 import { registerEditTool } from "./src/edit.js";
 import { registerGrepTool } from "./src/grep.js";
-import { registerSgTool } from "./src/sg.js";
+import { registerSgTool, isSgAvailable } from "./src/sg.js";
 import { registerNuTool } from "./src/nu.js";
+import { registerWriteTool } from "./src/write.js";
 import { filterBashOutput } from "./src/rtk/bash-filter.js";
 import { stripAnsi } from "./src/rtk/ansi.js";
 
@@ -39,15 +40,22 @@ const BASH_FILTER_ENABLED = true;
 export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
   const readTool = registerReadTool(pi);
   const editTool = registerEditTool(pi);
-  const grepTool = registerGrepTool(pi);
+  const sgAvailable = isSgAvailable();
+  const astSearchGuideline = sgAvailable
+    ? 'Use `ast_search` for structural code patterns (function calls, imports, JSX). Use `grep` for text matching.'
+    : 'For AST-aware structural code search (function calls, imports, JSX elements), install ast-grep: `brew install ast-grep`';
+
+  const grepTool = registerGrepTool(pi, { astSearchGuideline });
   const sgTool = registerSgTool(pi);
   registerNuTool(pi);
+  const writeTool = registerWriteTool(pi);
 
   const toolExecutors = {
     read: readTool,
     edit: editTool,
     grep: grepTool,
     ast_search: sgTool,
+    write: writeTool,
   };
 
   (globalThis as any).__hashlineToolExecutors = toolExecutors;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, and bash output compression",
   "type": "module",
   "exports": {

--- a/prompts/grep.md
+++ b/prompts/grep.md
@@ -1,0 +1,54 @@
+Search file contents for a pattern. Returns matching lines with `LINE:HASH` anchors for hashline edit workflows.
+
+## Search Modes
+
+### Default mode
+Returns matching lines prefixed with `LINE:HASH|content` anchors. Use `>>` markers to identify match lines vs context lines.
+
+### Context mode (`context: N`)
+Includes N surrounding lines before and after each match. Nearby matches are merged and deduplicated automatically. Use when you need to see the code around a match, not just the matching line.
+
+### Summary mode (`summary: true`)
+Returns per-file match counts only — no line content, no anchors. Use this first to scope a broad search across many files, then drill into specific files with a targeted search.
+
+### Symbol-scoped mode (`scope: "symbol"`)
+Groups matches by their enclosing function, method, or class. Shows the full symbol block containing each match, not just the matching line. Falls back gracefully for files without structural maps. Ignored when `summary: true`.
+
+## Parameters
+
+- `pattern` — Search pattern (regex by default, or literal string with `literal: true`)
+- `path` — Directory or file to search (default: current directory)
+- `glob` — Filter files by glob pattern, e.g. `'*.ts'` or `'**/*.test.ts'`
+- `ignoreCase` — Case-insensitive search (default: false)
+- `literal` — Treat pattern as literal string instead of regex (default: false). Use for exact matches to avoid regex escaping issues.
+- `context` — Number of lines to show before and after each match (default: 0)
+- `limit` — Maximum number of matches to return (default: 100)
+- `summary` — Return per-file match counts only (no hashline anchors)
+- `scope` — Set to `"symbol"` to group matches by enclosing symbol block
+
+## Usage Guidance
+
+- Use `summary: true` first to scope a broad search, then drill into specific files with `path` or `glob`
+- Use `scope: "symbol"` when you need to understand the context of matches, not just find them
+- Use `literal: true` for exact string matches (e.g., searching for `$variable` or `array[0]`) to avoid regex escaping issues
+- Anchors from grep can be used directly in `edit` — no intermediate `read` needed
+- For structural code patterns (function calls, imports, JSX), prefer `ast_search` if available
+
+## Workflow: grep → edit
+
+1. Search: `grep({ pattern: "oldFunction", glob: "*.ts" })`
+2. Review output — each match has a `LINE:HASH` anchor
+3. Use anchors directly: `edit({ path: "file.ts", edits: [{ set_line: { anchor: "45:a3f", new_text: "newFunction();" } }] })`
+
+## Output Format
+
+```
+[3 matches in 2 files]
+--- src/server.ts (2 matches) ---
+src/server.ts:>>45:a3f|router.addRoute("/api", handler);
+src/server.ts:  46:b12|router.addRoute("/health", healthCheck);
+--- src/client.ts (1 match) ---
+src/client.ts:>>12:c7e|const api = new ApiClient();
+```
+
+Lines with `>>` are matches; lines with `  ` (two spaces) are context lines.

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -3,6 +3,7 @@ import { createGrepTool } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { readFile as fsReadFile, stat as fsStat } from "fs/promises";
 import path from "path";
+import { readFileSync } from "node:fs";
 import { normalizeToLF, stripBom, hasBareCarriageReturn } from "./edit-diff";
 import { looksLikeBinary } from "./binary-detect";
 import { ensureHashInit, formatHashlineDisplay } from "./hashline";
@@ -15,8 +16,8 @@ import { throwIfAborted } from "./runtime";
 import { Text } from "@mariozechner/pi-tui";
 import { formatGrepCallText, formatGrepResultText } from "./grep-render-helpers.js";
 
-const GREP_DESC =
-	"Search file contents for a pattern. Returns matching lines with LINE:HASH anchors for hashline edit workflows.";
+const GREP_PROMPT = readFileSync(new URL("../prompts/grep.md", import.meta.url), "utf-8").trim();
+const GREP_DESC = GREP_PROMPT.split(/\n\s*\n/, 1)[0]?.trim() ?? GREP_PROMPT;
 
 const grepSchema = Type.Object({
 	pattern: Type.String({ description: "Search pattern (regex or literal string)" }),
@@ -256,7 +257,7 @@ function escapeForRegex(s: string): string {
 	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-export function registerGrepTool(pi: ExtensionAPI) {
+export function registerGrepTool(pi: ExtensionAPI, options?: { astSearchGuideline?: string }) {
 	const ptc = {
 		callable: true,
 		enabled: true,
@@ -272,6 +273,7 @@ export function registerGrepTool(pi: ExtensionAPI) {
 		description: GREP_DESC,
 		parameters: grepSchema,
 		ptc,
+		promptGuidelines: options?.astSearchGuideline ? [options.astSearchGuideline] : undefined,
 		async execute(toolCallId, params, signal, onUpdate, ctx) {
 			await ensureHashInit();
 			const p = params as GrepParams;

--- a/src/hashline.ts
+++ b/src/hashline.ts
@@ -43,7 +43,7 @@ interface NoopEdit {
 
 // ─── Hash computation ───────────────────────────────────────────────────
 
-const HASH_LEN = 2;
+const HASH_LEN = 3;
 const RADIX = 16;
 const HASH_MOD = RADIX ** HASH_LEN;
 const DICT = Array.from({ length: HASH_MOD }, (_, i) => i.toString(RADIX).padStart(HASH_LEN, "0"));
@@ -51,7 +51,8 @@ const DICT = Array.from({ length: HASH_MOD }, (_, i) => i.toString(RADIX).padSta
 const HASHLINE_PREFIX_RE = /^\d+:[0-9a-zA-Z]{1,16}\|/;
 const DIFF_PLUS_RE = /^\+(?!\+)/;
 const CONFUSABLE_HYPHENS_RE = /[\u2010\u2011\u2012\u2013\u2014\u2212\uFE63\uFF0D]/g;
-const HASH_RELOCATION_WINDOW = 20;
+const HASH_RELOCATION_WINDOW_BASE = 20;
+const HASH_RELOCATION_WINDOW_CAP = 100;
 
 let h32Fn: ((input: string, seed?: number) => number) | null = null;
 let initPromise: Promise<void> | null = null;
@@ -155,7 +156,7 @@ function findSimilarLines(
 		return `  ${c.line}:${hash}|${escapeControlCharsForDisplay(c.content)}`;
 	});
 }
-function formatMismatchError(mismatches: HashMismatch[], fileLines: string[]): string {
+function formatMismatchError(mismatches: HashMismatch[], fileLines: string[], relocationWindow: number): string {
 	const mismatchSet = new Map<number, HashMismatch>();
 	for (const m of mismatches) mismatchSet.set(m.line, m);
 
@@ -168,7 +169,7 @@ function formatMismatchError(mismatches: HashMismatch[], fileLines: string[]): s
 
 	const sorted = [...displayLines].sort((a, b) => a - b);
 	const out: string[] = [
-		`${mismatches.length} line${mismatches.length > 1 ? "s have" : " has"} changed since last read. Auto-relocation checks only within ±${HASH_RELOCATION_WINDOW} lines of each anchor. Use the updated LINE:HASH references shown below (>>> marks changed lines).`,
+		`${mismatches.length} line${mismatches.length > 1 ? "s have" : " has"} changed since last read. Auto-relocation checks only within ±${relocationWindow} lines of each anchor. Use the updated LINE:HASH references shown below (>>> marks changed lines).`,
 		"",
 	];
 
@@ -368,6 +369,9 @@ export function applyHashlineEdits(
 	throwIfAborted(signal);
 	if (!edits.length) return { content, firstChangedLine: undefined };
 
+	// Compute adaptive relocation window based on edit batch size
+	const relocationWindow = Math.min(Math.max(HASH_RELOCATION_WINDOW_BASE, edits.length * 5), HASH_RELOCATION_WINDOW_CAP);
+
 	const fileLines = content.split("\n");
 	const origLines = [...fileLines];
 	let firstChanged: number | undefined;
@@ -404,14 +408,13 @@ export function applyHashlineEdits(
 
 	const relocationNotes = new Set<string>();
 
-	function findRelocationLine(expectedHash: string, hintLine: number): number | undefined {
+	function findRelocationLine(expectedHash: string, hintLine: number, relocationWindow: number): number | undefined {
 		const candidates = hashToLines.get(expectedHash);
 		if (!candidates?.length) return undefined;
 
-		const minLine = Math.max(1, hintLine - HASH_RELOCATION_WINDOW);
-		const maxLine = Math.min(fileLines.length, hintLine + HASH_RELOCATION_WINDOW);
+		const minLine = Math.max(1, hintLine - relocationWindow);
+		const maxLine = Math.min(fileLines.length, hintLine + relocationWindow);
 		let match: number | undefined;
-
 		for (const candidate of candidates) {
 			if (candidate < minLine || candidate > maxLine) continue;
 			if (match !== undefined) return undefined; // ambiguous within window
@@ -430,13 +433,40 @@ export function applyHashlineEdits(
 		const originalLine = ref.line;
 		const actual = lineHashes[originalLine - 1];
 		if (actual === expected) return true;
-		const relocated = findRelocationLine(expected, originalLine);
+		const relocated = findRelocationLine(expected, originalLine, relocationWindow);
 		if (relocated !== undefined) {
 			ref.line = relocated;
 			relocationNotes.add(
-				`Auto-relocated anchor ${originalLine}:${ref.hash} -> ${relocated}:${ref.hash} (window ±${HASH_RELOCATION_WINDOW}).`,
+				`Auto-relocated anchor ${originalLine}:${ref.hash} -> ${relocated}:${ref.hash} (window ±${relocationWindow}).`,
 			);
 			return true;
+		}
+		// Fuzzy content-based recovery: if anchor includes content after pipe,
+		// look for a nearby line with high token similarity
+		if (ref.content) {
+			const FUZZY_THRESHOLD = 0.8;
+			const FUZZY_SCAN = 50;
+			const scanStart = Math.max(0, originalLine - 1 - FUZZY_SCAN);
+			const scanEnd = Math.min(fileLines.length, originalLine - 1 + FUZZY_SCAN + 1);
+			const fuzzyHits: { line: number; score: number }[] = [];
+			for (let i = scanStart; i < scanEnd; i++) {
+				const lineContent = fileLines[i];
+				if (!lineContent.trim()) continue;
+				const score = tokenSimilarity(ref.content, lineContent);
+				if (score > FUZZY_THRESHOLD) {
+					fuzzyHits.push({ line: i + 1, score });
+				}
+			}
+			if (fuzzyHits.length === 1) {
+				const hit = fuzzyHits[0];
+				const newHash = computeLineHash(hit.line, fileLines[hit.line - 1]);
+				ref.line = hit.line;
+				ref.hash = newHash;
+				relocationNotes.add(
+					`Fuzzy-relocated anchor ${originalLine}:${expected} \u2192 ${hit.line}:${newHash} (similarity: ${hit.score.toFixed(2)})`,
+				);
+				return true;
+			}
 		}
 		mismatches.push({ line: originalLine, expected: ref.hash, actual, expectedContent: ref.content });
 		return false;
@@ -477,7 +507,7 @@ export function applyHashlineEdits(
 			}
 		}
 	}
-	if (mismatches.length) throw new Error(formatMismatchError(mismatches, fileLines));
+	if (mismatches.length) throw new Error(formatMismatchError(mismatches, fileLines, relocationWindow));
 
 	// Recompute after potential relocation
 	explicitlyTouchedLines = collectExplicitlyTouchedLines();

--- a/src/readmap/language-detect.ts
+++ b/src/readmap/language-detect.ts
@@ -26,6 +26,14 @@ const EXTENSION_MAP: Record<string, LanguageInfo> = {
   // Go
   ".go": { id: "go", name: "Go" },
 
+  // Swift
+  ".swift": { id: "swift", name: "Swift" },
+
+  // Shell/Bash
+  ".sh": { id: "shell", name: "Shell" },
+  ".bash": { id: "shell", name: "Shell" },
+  ".zsh": { id: "shell", name: "Shell" },
+
   // Rust
   ".rs": { id: "rust", name: "Rust" },
 

--- a/src/readmap/mapper.ts
+++ b/src/readmap/mapper.ts
@@ -18,6 +18,8 @@ import { sqlMapper } from "./mappers/sql.js";
 import { tomlMapper } from "./mappers/toml.js";
 import { typescriptMapper } from "./mappers/typescript.js";
 import { yamlMapper } from "./mappers/yaml.js";
+import { swiftMapper } from "./mappers/swift.js";
+import { shellMapper } from "./mappers/shell.js";
 
 type MapperFn = (
   filePath: string,
@@ -61,6 +63,12 @@ const MAPPERS: Record<string, MapperFn> = {
 
   // Phase 5: Clojure tree-sitter
   clojure: clojureMapper,
+
+  // Phase 6: Swift regex mapper
+  swift: swiftMapper,
+
+  // Phase 7: Shell/Bash regex mapper
+  shell: shellMapper,
 };
 
 /**

--- a/src/readmap/mappers/shell.ts
+++ b/src/readmap/mappers/shell.ts
@@ -1,0 +1,213 @@
+/**
+ * Shell/Bash mapper using regex-based extraction.
+ *
+ * Extracts functions (both styles), aliases, and exported variables.
+ * Handles heredocs gracefully — content inside heredocs is not parsed.
+ * No external dependencies — pure regex with brace-depth tracking.
+ */
+import { readFile, stat } from "node:fs/promises";
+
+import type { FileMap, FileSymbol } from "../types.js";
+
+import { DetailLevel, SymbolKind } from "../enums.js";
+
+// function name() { ... } or function name { ... }
+const FUNC_KEYWORD_RE = /^\s*function\s+(\w+)\s*(?:\(\s*\))?\s*\{?\s*$/;
+
+// name() { ... }
+const FUNC_PARENS_RE = /^\s*(\w+)\s*\(\s*\)\s*\{?\s*$/;
+
+// alias name='...' or alias name="..."
+const ALIAS_RE = /^\s*alias\s+(\w[\w-]*)=/;
+
+// export NAME=... (uppercase convention for exported vars)
+const EXPORT_RE = /^\s*export\s+([A-Za-z_]\w*)=/;
+
+// Heredoc start: <<EOF, <<'EOF', <<"EOF", <<-EOF
+const HEREDOC_START_RE = /<<-?\s*['"]?(\w+)['"]?\s*$/;
+
+function countChar(s: string, ch: string): number {
+  let n = 0;
+  for (const c of s) if (c === ch) n++;
+  return n;
+}
+
+/**
+ * Generate a file map for a Shell/Bash file.
+ */
+export async function shellMapper(
+  filePath: string,
+  signal?: AbortSignal,
+): Promise<FileMap | null> {
+  try {
+    const stats = await stat(filePath);
+    const totalBytes = stats.size;
+
+    const content = await readFile(filePath, "utf8");
+
+    if (signal?.aborted) return null;
+
+    const lines = content.split(/\r?\n/);
+    const totalLines = lines.length;
+    const symbols: FileSymbol[] = [];
+
+    let braceDepth = 0;
+    const declStack: { symbol: FileSymbol; startDepth: number }[] = [];
+    let heredocDelimiter: string | null = null;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const lineNum = i + 1;
+      const trimmed = line.trim();
+
+      // Handle heredoc: skip lines until we find the closing delimiter
+      if (heredocDelimiter !== null) {
+        if (trimmed === heredocDelimiter) {
+          heredocDelimiter = null;
+        }
+        continue;
+      }
+
+      // Skip comments and empty lines for symbol detection
+      if (trimmed.startsWith("#") || trimmed === "") {
+        continue;
+      }
+
+      // Check for heredoc start (on any line, including inside functions)
+      const heredocMatch = line.match(HEREDOC_START_RE);
+      if (heredocMatch) {
+        heredocDelimiter = heredocMatch[1];
+        // Still process this line for function detection before entering heredoc mode
+      }
+
+      // Try function with 'function' keyword: function name() { or function name {
+      let funcMatch = trimmed.match(FUNC_KEYWORD_RE);
+      if (funcMatch) {
+        const name = funcMatch[1];
+        const sym: FileSymbol = {
+          name,
+          kind: SymbolKind.Function,
+          startLine: lineNum,
+          endLine: lineNum,
+          signature: trimmed.replace(/\{.*$/, "").trim(),
+        };
+
+        const openBraces = countChar(line, "{");
+        const closeBraces = countChar(line, "}");
+
+        if (openBraces > closeBraces) {
+          declStack.push({ symbol: sym, startDepth: braceDepth });
+        } else {
+          sym.endLine = lineNum;
+        }
+
+        symbols.push(sym);
+        braceDepth += openBraces - closeBraces;
+        continue;
+      }
+
+      // Try name() { style function
+      funcMatch = trimmed.match(FUNC_PARENS_RE);
+      if (funcMatch) {
+        // Exclude shell builtins and common keywords that could match
+        const name = funcMatch[1];
+        if (!isShellKeyword(name)) {
+          const sym: FileSymbol = {
+            name,
+            kind: SymbolKind.Function,
+            startLine: lineNum,
+            endLine: lineNum,
+            signature: trimmed.replace(/\{.*$/, "").trim(),
+          };
+
+          const openBraces = countChar(line, "{");
+          const closeBraces = countChar(line, "}");
+
+          if (openBraces > closeBraces) {
+            declStack.push({ symbol: sym, startDepth: braceDepth });
+          } else {
+            sym.endLine = lineNum;
+          }
+
+          symbols.push(sym);
+          braceDepth += openBraces - closeBraces;
+          continue;
+        }
+      }
+
+      // Try alias
+      const aliasMatch = trimmed.match(ALIAS_RE);
+      if (aliasMatch) {
+        symbols.push({
+          name: aliasMatch[1],
+          kind: SymbolKind.Variable,
+          startLine: lineNum,
+          endLine: lineNum,
+          signature: trimmed,
+        });
+        continue;
+      }
+
+      // Try export
+      const exportMatch = trimmed.match(EXPORT_RE);
+      if (exportMatch) {
+        symbols.push({
+          name: exportMatch[1],
+          kind: SymbolKind.Variable,
+          startLine: lineNum,
+          endLine: lineNum,
+          signature: trimmed,
+        });
+        continue;
+      }
+
+      // Track braces for non-declaration lines
+      const openBraces = countChar(line, "{");
+      const closeBraces = countChar(line, "}");
+      braceDepth += openBraces - closeBraces;
+
+      // Pop closed declarations
+      while (declStack.length > 0) {
+        const top = declStack[declStack.length - 1];
+        if (braceDepth <= top.startDepth) {
+          top.symbol.endLine = lineNum;
+          declStack.pop();
+        } else {
+          break;
+        }
+      }
+    }
+
+    // Close any remaining open declarations
+    for (const item of declStack) {
+      item.symbol.endLine = totalLines;
+    }
+
+    if (symbols.length === 0) return null;
+
+    return {
+      path: filePath,
+      totalLines,
+      totalBytes,
+      language: "Shell",
+      symbols,
+      imports: [],
+      detailLevel: DetailLevel.Full,
+    };
+  } catch (error) {
+    if (signal?.aborted) return null;
+    console.error(`Shell mapper failed: ${error}`);
+    return null;
+  }
+}
+
+/** Shell keywords that look like function names but aren't */
+function isShellKeyword(name: string): boolean {
+  const keywords = new Set([
+    "if", "then", "else", "elif", "fi",
+    "for", "while", "until", "do", "done",
+    "case", "esac", "select", "in",
+    "time", "coproc",
+  ]);
+  return keywords.has(name);
+}

--- a/src/readmap/mappers/swift.ts
+++ b/src/readmap/mappers/swift.ts
@@ -1,0 +1,147 @@
+/**
+ * Swift mapper using regex-based extraction.
+ *
+ * Extracts classes, structs, enums, protocols, extensions, and functions.
+ * No external dependencies — pure regex with brace-depth tracking.
+ */
+import { readFile, stat } from "node:fs/promises";
+
+import type { FileMap, FileSymbol } from "../types.js";
+
+import { DetailLevel, SymbolKind } from "../enums.js";
+
+// Regex for Swift declarations (handles access modifiers and attributes)
+const SWIFT_DECL_RE =
+  /^(?:\s*)(?:@\w+\s+)*(?:(?:public|private|internal|open|fileprivate)\s+)?(?:(?:final|static|override|class|mutating|nonmutating)\s+)*(class|struct|enum|protocol|extension|func)\s+(\w+)/;
+
+function countChar(s: string, ch: string): number {
+  let n = 0;
+  for (const c of s) if (c === ch) n++;
+  return n;
+}
+
+/**
+ * Generate a file map for a Swift file.
+ */
+export async function swiftMapper(
+  filePath: string,
+  signal?: AbortSignal,
+): Promise<FileMap | null> {
+  try {
+    const stats = await stat(filePath);
+    const totalBytes = stats.size;
+
+    const content = await readFile(filePath, "utf8");
+
+    if (signal?.aborted) return null;
+
+    const lines = content.split(/\r?\n/);
+    const totalLines = lines.length;
+    const symbols: FileSymbol[] = [];
+
+    let braceDepth = 0;
+    const declStack: { symbol: FileSymbol; startDepth: number }[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const lineNum = i + 1;
+      const trimmed = line.trim();
+
+      if (trimmed.startsWith("//")) continue;
+
+      const match = trimmed.match(SWIFT_DECL_RE);
+      if (match) {
+        const keyword = match[1];
+        const name = match[2];
+
+        let kind: SymbolKind;
+        switch (keyword) {
+          case "class":
+          case "struct":
+          case "extension":
+            kind = SymbolKind.Class;
+            break;
+          case "enum":
+            kind = SymbolKind.Enum;
+            break;
+          case "protocol":
+            kind = SymbolKind.Interface;
+            break;
+          case "func":
+            kind = braceDepth > 0 ? SymbolKind.Method : SymbolKind.Function;
+            break;
+          default:
+            kind = SymbolKind.Unknown;
+        }
+
+        const sym: FileSymbol = {
+          name,
+          kind,
+          startLine: lineNum,
+          endLine: lineNum,
+          signature: trimmed.replace(/\{.*$/, "").trim(),
+        };
+
+        // Determine parent BEFORE pushing this symbol
+        const isChild = declStack.length > 0 && keyword === "func";
+        const parentEntry = isChild ? declStack[declStack.length - 1] : null;
+
+        const openBraces = countChar(line, "{");
+        const closeBraces = countChar(line, "}");
+
+        if (openBraces > closeBraces) {
+          declStack.push({ symbol: sym, startDepth: braceDepth });
+        } else {
+          sym.endLine = lineNum;
+        }
+
+        if (isChild && parentEntry) {
+          if (!parentEntry.symbol.children) parentEntry.symbol.children = [];
+          parentEntry.symbol.children.push(sym);
+        } else {
+          symbols.push(sym);
+        }
+
+        braceDepth += openBraces - closeBraces;
+        continue;
+      }
+
+      // Track braces for non-declaration lines
+      const openBraces = countChar(line, "{");
+      const closeBraces = countChar(line, "}");
+      braceDepth += openBraces - closeBraces;
+
+      // Pop closed declarations
+      while (declStack.length > 0) {
+        const top = declStack[declStack.length - 1];
+        if (braceDepth <= top.startDepth) {
+          top.symbol.endLine = lineNum;
+          declStack.pop();
+        } else {
+          break;
+        }
+      }
+    }
+
+    // Close any remaining open declarations
+    for (const item of declStack) {
+      item.symbol.endLine = totalLines;
+    }
+
+    if (symbols.length === 0) return null;
+
+    return {
+      path: filePath,
+      totalLines,
+      totalBytes,
+      language: "Swift",
+      symbols,
+      imports: [],
+      detailLevel: DetailLevel.Full,
+    };
+  } catch (error) {
+    if (signal?.aborted) return null;
+    console.error(`Swift mapper failed: ${error}`);
+    return null;
+  }
+}

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -69,6 +69,19 @@ function execFileText(
   });
 }
 
+/**
+ * Check if the `sg` (ast-grep) binary is available in PATH.
+ * Runs `sg --version` synchronously with a 3-second timeout.
+ */
+export function isSgAvailable(): boolean {
+  try {
+    cp.execFileSync("sg", ["--version"], { timeout: 3000, stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function registerSgTool(pi: ExtensionAPI) {
   const ptc = {
     callable: true,

--- a/src/write.ts
+++ b/src/write.ts
@@ -1,0 +1,165 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { Type } from "@sinclair/typebox";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, relative } from "node:path";
+import { ensureHashInit, formatHashlineDisplay } from "./hashline.js";
+import { buildPtcLine, buildPtcWarning, type PtcLine, type PtcWarning } from "./ptc-value.js";
+import { looksLikeBinary } from "./binary-detect.js";
+import { getOrGenerateMap } from "./map-cache.js";
+import { formatFileMapWithBudget } from "./readmap/formatter.js";
+
+const MAX_LINES = 2000;
+const MAX_BYTES = 50 * 1024;
+
+export interface WriteResult {
+  text: string;
+  warnings: string[];
+  ptcValue: {
+    tool: "write";
+    path: string;
+    lines: PtcLine[];
+    warnings: PtcWarning[];
+    map?: { appended: boolean };
+  };
+}
+
+export async function executeWrite(opts: {
+  path: string;
+  content: string;
+  map?: boolean;
+  cwd?: string;
+}): Promise<WriteResult> {
+  await ensureHashInit();
+
+  const { path: filePath, content, map: requestMap, cwd } = opts;
+
+  // Create parent directories
+  mkdirSync(dirname(filePath), { recursive: true });
+
+  // Write file
+  writeFileSync(filePath, content, "utf-8");
+
+  const warnings: string[] = [];
+  const ptcWarnings: PtcWarning[] = [];
+
+  // Binary detection
+  if (looksLikeBinary(Buffer.from(content, "utf-8"))) {
+    warnings.push("File content appears to be binary.");
+    ptcWarnings.push(buildPtcWarning("binary", "File content appears to be binary."));
+    return {
+      text: `Wrote ${filePath}\n⚠️ File content appears to be binary — hashlines not generated.`,
+      warnings,
+      ptcValue: {
+        tool: "write",
+        path: filePath,
+        lines: [],
+        warnings: ptcWarnings,
+      },
+    };
+  }
+
+  // Compute hashlines
+  const rawLines = content.split("\n");
+  const ptcLines: PtcLine[] = [];
+  const displayLines: string[] = [];
+
+  for (let i = 0; i < rawLines.length; i++) {
+    const lineNum = i + 1;
+    const ptcLine = buildPtcLine(lineNum, rawLines[i]);
+    ptcLines.push(ptcLine);
+    displayLines.push(formatHashlineDisplay(lineNum, rawLines[i]));
+  }
+
+  let text = displayLines.join("\n");
+
+  // Truncation
+  if (rawLines.length > MAX_LINES) {
+    text = displayLines.slice(0, MAX_LINES).join("\n");
+    text += `\n[… ${rawLines.length - MAX_LINES} more lines truncated]`;
+  }
+  const bytes = Buffer.byteLength(text, "utf8");
+  if (bytes > MAX_BYTES) {
+    text = Buffer.from(text, "utf8").subarray(0, MAX_BYTES).toString("utf8");
+    text += "\n[… truncated at 50 KB]";
+  }
+
+  // Optional structural map
+  let mapAppended = false;
+  if (requestMap) {
+    try {
+      const fileMap = await getOrGenerateMap(filePath);
+      if (fileMap) {
+        const mapText = formatFileMapWithBudget(fileMap);
+        if (mapText) {
+          text += "\n\n" + mapText;
+          mapAppended = true;
+        }
+      }
+    } catch {
+      // Map generation failure is non-fatal
+    }
+  }
+
+  const displayPath = cwd ? relative(cwd, filePath) || filePath : filePath;
+
+  return {
+    text,
+    warnings,
+    ptcValue: {
+      tool: "write",
+      path: displayPath,
+      lines: ptcLines,
+      warnings: ptcWarnings,
+      ...(requestMap !== undefined ? { map: { appended: mapAppended } } : {}),
+    },
+  };
+}
+
+export function registerWriteTool(pi: ExtensionAPI) {
+  const tool = {
+    name: "write",
+    label: "write",
+    description: "Write content to a file. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories. Returns hashlined content with LINE:HASH anchors for immediate use with edit.",
+    parameters: Type.Object({
+      path: Type.String({ description: "Path to the file to write (relative or absolute)" }),
+      content: Type.String({ description: "Content to write to the file" }),
+      map: Type.Optional(Type.Boolean({ description: "Append structural map to output" })),
+    }),
+
+    async execute(_toolCallId: string, params: { path: string; content: string; map?: boolean }, _signal: AbortSignal | undefined, _onUpdate: any, ctx: any) {
+      const result = await executeWrite({
+        path: params.path,
+        content: params.content,
+        map: params.map,
+        cwd: ctx?.cwd,
+      });
+
+      return {
+        content: [{ type: "text" as const, text: result.text }],
+        details: {
+          ptcValue: result.ptcValue,
+          warnings: result.warnings,
+        },
+      };
+    },
+
+    renderCall(args: any, theme: any) {
+      const { path } = args as { path: string };
+      const label = theme.fg("toolTitle", "✏️ write");
+      return new Text(`${label} ${theme.fg("muted", path)}`, 0, 0);
+    },
+
+    renderResult(result: any, _options: any, theme: any) {
+      const output = result.content[0]?.type === "text"
+        ? (result.content[0] as { type: "text"; text: string }).text
+        : "";
+      const lineCount = output.split("\n").filter((l: string) => /^\d+:[0-9a-f]{3}\|/.test(l)).length;
+      const summary = lineCount > 0 ? `${lineCount} lines written` : "written";
+      return new Text(theme.fg("toolOutput", summary), 0, 0);
+    },
+  };
+
+  pi.registerTool(tool);
+  return tool;
+}

--- a/tests/adaptive-relocation-window.test.ts
+++ b/tests/adaptive-relocation-window.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { ensureHashInit, computeLineHash, applyHashlineEdits } from "../src/hashline.js";
+
+describe("adaptive relocation window", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("single edit uses base window of ±20 — relocation at 21 lines fails", () => {
+    // Build a 60-line file where line 30 has unique content
+    const lines: string[] = [];
+    for (let i = 0; i < 60; i++) {
+      lines.push(`line ${i + 1} content`);
+    }
+
+    // Compute hash for line 30
+    const hash30 = computeLineHash(30, lines[29]);
+
+    // Try to use anchor 30:hash but content is actually at line 51 (21 lines away)
+    // This should FAIL for single edit — base window is 20
+    const movedLines = [...lines];
+    // Move line 30's content to line 51
+    movedLines[29] = "replaced line 30";
+    movedLines[50] = lines[29]; // put original at line 51
+    const movedContent = movedLines.join("\n");
+
+    expect(() =>
+      applyHashlineEdits(movedContent, [
+        { set_line: { anchor: `30:${hash30}`, new_text: "edited" } },
+      ])
+    ).toThrow(/changed since last read/);
+  });
+
+  it("multi-edit batch expands window — relocation at 25 lines succeeds with 5 edits", () => {
+    // Build a 100-line file
+    const lines: string[] = [];
+    for (let i = 0; i < 100; i++) {
+      lines.push(`unique line ${i + 1} with distinct content ${i * 7}`);
+    }
+
+    // Compute hash for line 50
+    const hash50 = computeLineHash(50, lines[49]);
+
+    // Move line 50's content to line 75 (25 lines away)
+    const movedLines = [...lines];
+    movedLines[49] = "replaced line 50";
+    movedLines[74] = lines[49]; // put original at line 75
+    const movedContent = movedLines.join("\n");
+
+    // With 5 edits: window = max(20, 5*5) = 25, which should reach line 75
+    const result = applyHashlineEdits(movedContent, [
+      { set_line: { anchor: `50:${hash50}`, new_text: "edited line 50" } },
+      { set_line: { anchor: `1:${computeLineHash(1, lines[0])}`, new_text: lines[0] } }, // noop
+      { set_line: { anchor: `2:${computeLineHash(2, lines[1])}`, new_text: lines[1] } }, // noop
+      { set_line: { anchor: `3:${computeLineHash(3, lines[2])}`, new_text: lines[2] } }, // noop
+      { set_line: { anchor: `4:${computeLineHash(4, lines[3])}`, new_text: lines[3] } }, // noop
+    ]);
+
+    // The edit should succeed — line 50's content was found at line 75 within the expanded window
+    expect(result.content).toContain("edited line 50");
+    // Should have a relocation warning
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some(w => w.includes("Auto-relocated"))).toBe(true);
+  });
+
+  it("adaptive window is capped at 100", () => {
+    // Build a 300-line file
+    const lines: string[] = [];
+    for (let i = 0; i < 300; i++) {
+      lines.push(`unique line ${i + 1} with distinct content ${i * 13}`);
+    }
+
+    // Compute hash for line 100
+    const hash100 = computeLineHash(100, lines[99]);
+
+    // Move line 100's content to line 210 (110 lines away — beyond cap of 100)
+    const movedLines = [...lines];
+    movedLines[99] = "replaced line 100";
+    movedLines[209] = lines[99]; // put original at line 210
+    const movedContent = movedLines.join("\n");
+
+    // Even with 25 edits (window = max(20, 25*5) = min(125, 100) = 100), 110 lines is beyond cap
+    const edits: any[] = [
+      { set_line: { anchor: `100:${hash100}`, new_text: "edited" } },
+    ];
+    for (let i = 0; i < 24; i++) {
+      const ln = i + 1;
+      edits.push({ set_line: { anchor: `${ln}:${computeLineHash(ln, lines[ln - 1])}`, new_text: lines[ln - 1] } });
+    }
+
+    expect(() => applyHashlineEdits(movedContent, edits)).toThrow(/changed since last read/);
+  });
+
+  it("mismatch error reports the actual window size", () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 60; i++) {
+      lines.push(`line ${i + 1}`);
+    }
+
+    const hash30 = computeLineHash(30, lines[29]);
+    const movedLines = [...lines];
+    movedLines[29] = "replaced";
+    const movedContent = movedLines.join("\n");
+
+    // 5 edits → window = 25
+    const edits: any[] = [
+      { set_line: { anchor: `30:${hash30}`, new_text: "edited" } },
+    ];
+    for (let i = 0; i < 4; i++) {
+      const ln = i + 1;
+      edits.push({ set_line: { anchor: `${ln}:${computeLineHash(ln, lines[ln - 1])}`, new_text: lines[ln - 1] } });
+    }
+
+    try {
+      applyHashlineEdits(movedContent, edits);
+      expect.unreachable("should have thrown");
+    } catch (err: any) {
+      expect(err.message).toContain("±25");
+    }
+  });
+});

--- a/tests/edit-compact-diff.test.ts
+++ b/tests/edit-compact-diff.test.ts
@@ -11,7 +11,7 @@ describe("edit compact diffs", () => {
 		const oldContent = "line one\nline two\nline three";
 		const newContent = "line one\nline TWO\nline three";
 		const result = generateCompactOrFullDiff(oldContent, newContent);
-		expect(result.diff).toMatch(/^\d+:[0-9a-f]{2}\|line two → \d+:[0-9a-f]{2}\|line TWO$/);
+		expect(result.diff).toMatch(/^\d+:[0-9a-f]{3}\|line two → \d+:[0-9a-f]{3}\|line TWO$/);
 		expect(result.firstChangedLine).toBe(2);
 	});
 
@@ -19,7 +19,7 @@ describe("edit compact diffs", () => {
 		const oldContent = "line one\nline two\nline three";
 		const newContent = "line one\nline three";
 		const result = generateCompactOrFullDiff(oldContent, newContent);
-		expect(result.diff).toMatch(/^\d+:[0-9a-f]{2}\|line two → \[deleted\]$/);
+		expect(result.diff).toMatch(/^\d+:[0-9a-f]{3}\|line two → \[deleted\]$/);
 		expect(result.firstChangedLine).toBe(2);
 	});
 
@@ -27,7 +27,7 @@ describe("edit compact diffs", () => {
 		const oldContent = "aaa\nbbb\nccc";
 		const newContent = "aaa\nBBB\nccc";
 		const result = generateCompactOrFullDiff(oldContent, newContent);
-		expect(result.diff).toMatch(/2:[0-9a-f]{2}\|bbb → 2:[0-9a-f]{2}\|BBB/);
+		expect(result.diff).toMatch(/2:[0-9a-f]{3}\|bbb → 2:[0-9a-f]{3}\|BBB/);
 	});
 
 	it("multi-line change preserves full unified diff format", () => {

--- a/tests/fixtures/sample.sh
+++ b/tests/fixtures/sample.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Sample shell script for readmap mapper testing
+
+export APP_NAME="myapp"
+export VERSION="1.0.0"
+
+alias ll='ls -la'
+alias gs='git status'
+
+function deploy() {
+    echo "Deploying $APP_NAME v$VERSION"
+    docker build -t "$APP_NAME:$VERSION" .
+    docker push "$APP_NAME:$VERSION"
+}
+
+build_image() {
+    local tag="${1:-latest}"
+    echo "Building image with tag: $tag"
+    docker build -t "$APP_NAME:$tag" .
+}
+
+function cleanup {
+    echo "Cleaning up..."
+    rm -rf /tmp/build-*
+    docker system prune -f
+}
+
+# A function with a heredoc inside
+function generate_config() {
+    cat <<EOF
+server:
+  host: localhost
+  port: 8080
+  name: $APP_NAME
+EOF
+}
+
+run_tests() {
+    echo "Running tests..."
+    npm test
+    local exit_code=$?
+    if [ $exit_code -ne 0 ]; then
+        echo "Tests failed!"
+        return 1
+    fi
+    echo "Tests passed!"
+}
+
+export PATH="/usr/local/bin:$PATH"

--- a/tests/fixtures/sample.swift
+++ b/tests/fixtures/sample.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+protocol Drawable {
+    func draw()
+    var area: Double { get }
+}
+
+public class Shape: Drawable {
+    var name: String
+    
+    init(name: String) {
+        self.name = name
+    }
+    
+    func draw() {
+        print("Drawing \(name)")
+    }
+    
+    var area: Double {
+        return 0.0
+    }
+}
+
+struct Point {
+    var x: Double
+    var y: Double
+    
+    func distance(to other: Point) -> Double {
+        let dx = x - other.x
+        let dy = y - other.y
+        return (dx * dx + dy * dy).squareRoot()
+    }
+}
+
+enum Direction {
+    case north
+    case south
+    case east
+    case west
+    
+    func opposite() -> Direction {
+        switch self {
+        case .north: return .south
+        case .south: return .north
+        case .east: return .west
+        case .west: return .east
+        }
+    }
+}
+
+extension Shape {
+    func describe() -> String {
+        return "Shape: \(name)"
+    }
+}
+
+func globalHelper(value: Int) -> Bool {
+    return value > 0
+}

--- a/tests/fuzzy-recovery.test.ts
+++ b/tests/fuzzy-recovery.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { ensureHashInit, computeLineHash, applyHashlineEdits } from "../src/hashline.js";
+
+describe("fuzzy content-based recovery", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("auto-relocates when one candidate has similarity > 0.8", () => {
+    // File with a line that was slightly modified (trailing comma added)
+    const originalLine = "const result = processData(input, options, config)";
+    const modifiedLine = "const result = processData(input, options, config),";
+    // High similarity — same tokens except trailing comma
+
+    const lines = [
+      "line 1",
+      "line 2",
+      originalLine, // line 3
+      "line 4",
+      "line 5",
+    ];
+
+    // Compute hash for original line 3
+    const hash3 = computeLineHash(3, originalLine);
+
+    // Modify the file — line 3 now has modified content
+    const modifiedLines = [...lines];
+    modifiedLines[2] = modifiedLine;
+    const modifiedContent = modifiedLines.join("\n");
+
+    // Use anchor with content: "3:HASH|original content"
+    // Hash won't match, but content is similar enough for fuzzy recovery
+    const result = applyHashlineEdits(modifiedContent, [
+      { set_line: { anchor: `3:${hash3}|${originalLine}`, new_text: "edited line" } },
+    ]);
+
+    expect(result.content).toContain("edited line");
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some(w => w.includes("Fuzzy-relocated"))).toBe(true);
+  });
+
+  it("throws standard error when two candidates exceed 0.8 similarity", () => {
+    // Two very similar lines — fuzzy recovery should refuse (ambiguous)
+    const targetLine = "const value = compute(alpha, beta, gamma)";
+    const similarLine1 = "const value = compute(alpha, beta, delta)";
+    const similarLine2 = "const value = compute(alpha, beta, epsilon)";
+
+    const lines = [
+      "line 1",
+      targetLine, // line 2
+      "line 3",
+      similarLine1, // line 4 — similar
+      similarLine2, // line 5 — also similar
+    ];
+    const hash2 = computeLineHash(2, targetLine);
+
+    // Modify file — remove original from line 2, similar lines remain at 4 and 5
+    const modifiedLines = [...lines];
+    modifiedLines[1] = "completely different content here";
+    const modifiedContent = modifiedLines.join("\n");
+
+    expect(() =>
+      applyHashlineEdits(modifiedContent, [
+        { set_line: { anchor: `2:${hash2}|${targetLine}`, new_text: "edited" } },
+      ])
+    ).toThrow(/changed since last read/);
+  });
+
+  it("throws standard error when similarity is below 0.8", () => {
+    const originalLine = "function processData(input) { return transform(input); }";
+    const lowSimilarityLine = "class DataProcessor { constructor() {} }";
+
+    const lines = [
+      "line 1",
+      originalLine, // line 2
+      "line 3",
+    ];
+    const hash2 = computeLineHash(2, originalLine);
+
+    const modifiedLines = [...lines];
+    modifiedLines[1] = lowSimilarityLine;
+    const modifiedContent = modifiedLines.join("\n");
+
+    expect(() =>
+      applyHashlineEdits(modifiedContent, [
+        { set_line: { anchor: `2:${hash2}|${originalLine}`, new_text: "edited" } },
+      ])
+    ).toThrow(/changed since last read/);
+  });
+
+  it("fuzzy relocation warning includes similarity score", () => {
+    const originalLine = "export const myData = await loadConfig(alpha, beta, gamma, delta, epsilon)";
+    const modifiedLine = "export const myData = await loadConfig(alpha, beta, gamma, delta, epsilon, zeta)";
+
+    const hash2 = computeLineHash(2, originalLine);
+
+    const modifiedLines = ["line 1", modifiedLine, "line 3"];
+    const modifiedContent = modifiedLines.join("\n");
+
+    const result = applyHashlineEdits(modifiedContent, [
+      { set_line: { anchor: `2:${hash2}|${originalLine}`, new_text: "edited" } },
+    ]);
+
+    expect(result.warnings).toBeDefined();
+    const fuzzyWarning = result.warnings!.find(w => w.includes("Fuzzy-relocated"));
+    expect(fuzzyWarning).toBeDefined();
+    expect(fuzzyWarning).toMatch(/similarity: 0\.\d+/);
+  });
+
+  it("falls through to standard error when anchor has no content after pipe", () => {
+    const originalLine = "const x = 42;";
+    const hash2 = computeLineHash(2, originalLine);
+
+    const modifiedLines = ["line 1", "const y = 99;", "line 3"];
+    const modifiedContent = modifiedLines.join("\n");
+
+    // Anchor WITHOUT content after pipe — no fuzzy recovery possible
+    expect(() =>
+      applyHashlineEdits(modifiedContent, [
+        { set_line: { anchor: `2:${hash2}`, new_text: "edited" } },
+      ])
+    ).toThrow(/changed since last read/);
+  });
+});

--- a/tests/grep-ast-guideline.test.ts
+++ b/tests/grep-ast-guideline.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { registerGrepTool } from "../src/grep.js";
+
+// Minimal mock for ExtensionAPI
+function createMockPi() {
+  const tools: any[] = [];
+  return {
+    registerTool(tool: any) {
+      tools.push(tool);
+    },
+    get tools() {
+      return tools;
+    },
+    events: { emit: vi.fn(), on: vi.fn() },
+    on: vi.fn(),
+  } as any;
+}
+
+describe("registerGrepTool with astSearchGuideline", () => {
+  it("includes astSearchGuideline in promptGuidelines when provided", () => {
+    const pi = createMockPi();
+    const guideline = "Use `ast_search` for structural code patterns.";
+    const tool = registerGrepTool(pi, { astSearchGuideline: guideline });
+    expect((tool as any).promptGuidelines).toBeDefined();
+    expect((tool as any).promptGuidelines).toContain(guideline);
+  });
+
+  it("does not include ast_search guideline when option is not provided", () => {
+    const pi = createMockPi();
+    const tool = registerGrepTool(pi);
+    const guidelines = (tool as any).promptGuidelines;
+    // Should either be undefined or not contain ast_search text
+    if (guidelines) {
+      for (const g of guidelines) {
+        expect(g).not.toContain("ast_search");
+      }
+    }
+  });
+});

--- a/tests/grep-prompt.test.ts
+++ b/tests/grep-prompt.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROMPTS_DIR = resolve(__dirname, "../prompts");
+const GREP_PROMPT_PATH = resolve(PROMPTS_DIR, "grep.md");
+
+describe("prompts/grep.md", () => {
+  it("exists and is non-empty", () => {
+    expect(existsSync(GREP_PROMPT_PATH)).toBe(true);
+    const content = readFileSync(GREP_PROMPT_PATH, "utf-8");
+    expect(content.trim().length).toBeGreaterThan(0);
+  });
+
+  it("contains scope and symbol documentation", () => {
+    const content = readFileSync(GREP_PROMPT_PATH, "utf-8");
+    expect(content).toContain("scope");
+    expect(content).toContain("symbol");
+  });
+
+  it("contains summary mode documentation", () => {
+    const content = readFileSync(GREP_PROMPT_PATH, "utf-8");
+    expect(content).toContain("summary");
+    expect(content).toContain("per-file");
+  });
+
+  it("first paragraph serves as tool description (matches loaded GREP_DESC)", () => {
+    const content = readFileSync(GREP_PROMPT_PATH, "utf-8").trim();
+    const firstParagraph = content.split(/\n\s*\n/, 1)[0]?.trim() ?? content;
+    // The first paragraph should describe what grep does and mention LINE:HASH anchors
+    expect(firstParagraph).toContain("LINE:HASH");
+    expect(firstParagraph.length).toBeGreaterThan(50);
+    expect(firstParagraph.length).toBeLessThan(500);
+  });
+
+  it("documents all search modes", () => {
+    const content = readFileSync(GREP_PROMPT_PATH, "utf-8");
+    expect(content).toContain("context");
+    expect(content).toContain("summary");
+    expect(content).toContain("scope");
+    expect(content).toContain("literal");
+  });
+
+  it("documents the grep → edit workflow", () => {
+    const content = readFileSync(GREP_PROMPT_PATH, "utf-8");
+    expect(content).toContain("edit");
+    expect(content).toContain("anchor");
+  });
+
+  it("shows output format with >> markers", () => {
+    const content = readFileSync(GREP_PROMPT_PATH, "utf-8");
+    expect(content).toContain(">>");
+  });
+});

--- a/tests/grep-summary.test.ts
+++ b/tests/grep-summary.test.ts
@@ -43,7 +43,7 @@ describe("grep summary mode", () => {
 		expect(lines[2]).toBe("src/bar.ts: 2 matches");
 		// No hashline anchors anywhere
 		expect(output).not.toContain(">>");
-		expect(output).not.toMatch(/\d+:[0-9a-f]{2}\|/);
+		expect(output).not.toMatch(/\d+:[0-9a-f]{3}\|/);
 	});
 });
 
@@ -97,6 +97,6 @@ describe("grep summary schema and integration", () => {
 		const text = getTextContent(result);
 		expect(text).toMatch(/^\[\d+ matches in \d+ files\]/);
 		expect(text).toContain(`${filePath}: `);
-		expect(text).not.toMatch(/\d+:[0-9a-f]{2}\|/);
+		expect(text).not.toMatch(/\d+:[0-9a-f]{3}\|/);
 	});
 });

--- a/tests/grep-truncation-indicator.test.ts
+++ b/tests/grep-truncation-indicator.test.ts
@@ -78,7 +78,7 @@ describe("grep truncation indicator", () => {
 		// Truncation indicator also appears
 		expect(output).toContain("[Results truncated at 5 matches — refine pattern or increase limit]");
 		// No hashline anchors in summary mode
-		expect(output).not.toMatch(/\d+:[0-9a-f]{2}\|/);
+		expect(output).not.toMatch(/\d+:[0-9a-f]{3}\|/);
 	});
 });
 

--- a/tests/hash-length-3.test.ts
+++ b/tests/hash-length-3.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { ensureHashInit, computeLineHash, parseLineRef } from "../src/hashline.js";
+
+describe("HASH_LEN = 3", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("produces 3-character hashes", () => {
+    const hash = computeLineHash(1, "hello world");
+    expect(hash).toHaveLength(3);
+    expect(hash).toMatch(/^[0-9a-f]{3}$/);
+  });
+
+  it("parseLineRef accepts 3-character hashes", () => {
+    const hash = computeLineHash(1, "hello world");
+    const ref = parseLineRef(`1:${hash}|hello world`);
+    expect(ref.line).toBe(1);
+    expect(ref.hash).toBe(hash);
+  });
+
+  it("parseLineRef rejects 2-character hashes", () => {
+    expect(() => parseLineRef("1:ab|content")).toThrow(/Invalid line reference/);
+  });
+});

--- a/tests/read-integration.test.ts
+++ b/tests/read-integration.test.ts
@@ -37,7 +37,7 @@ function getTextContent(result: any): string {
 function parseHashlineRows(text: string): HashlineRow[] {
 	const rows: HashlineRow[] = [];
 	for (const line of text.split("\n")) {
-		const match = line.match(/^(\d+):([0-9a-f]{2})\|(.*)$/);
+		const match = line.match(/^(\d+):([0-9a-f]{3})\|(.*)$/);
 		if (!match) continue;
 		rows.push({
 			line: Number(match[1]),
@@ -57,7 +57,7 @@ describe("read integration — combined output", () => {
 		const result = await callReadTool({ path: resolve(fixturesDir, "small.ts") });
 		const text = getTextContent(result);
 
-		expect(text).toMatch(/^\d+:[0-9a-f]{2}\|/m);
+		expect(text).toMatch(/^\d+:[0-9a-f]{3}\|/m);
 		expect(text).not.toContain("File Map:");
 		expect(text).not.toContain("[Output truncated:");
 	});
@@ -66,7 +66,7 @@ describe("read integration — combined output", () => {
 		const result = await callReadTool({ path: resolve(fixturesDir, "large.ts") });
 		const text = getTextContent(result);
 
-		expect(text).toMatch(/^\d+:[0-9a-f]{2}\|/m);
+		expect(text).toMatch(/^\d+:[0-9a-f]{3}\|/m);
 		expect(text).toContain("[Output truncated:");
 		expect(text).toContain("File Map:");
 		expect(text).toContain("EventEmitter");
@@ -84,7 +84,7 @@ describe("read integration — combined output", () => {
 		});
 		const text = getTextContent(result);
 
-		expect(text).toMatch(/^\d+:[0-9a-f]{2}\|/m);
+		expect(text).toMatch(/^\d+:[0-9a-f]{3}\|/m);
 		expect(text).not.toContain("File Map:");
 	});
 
@@ -95,7 +95,7 @@ describe("read integration — combined output", () => {
 		});
 		const text = getTextContent(result);
 
-		expect(text).toMatch(/^\d+:[0-9a-f]{2}\|/m);
+		expect(text).toMatch(/^\d+:[0-9a-f]{3}\|/m);
 		expect(text).not.toContain("File Map:");
 	});
 
@@ -103,7 +103,7 @@ describe("read integration — combined output", () => {
 		const result = await callReadTool({ path: resolve(fixturesDir, "small.py") });
 		const text = getTextContent(result);
 
-		expect(text).toMatch(/^\d+:[0-9a-f]{2}\|/m);
+		expect(text).toMatch(/^\d+:[0-9a-f]{3}\|/m);
 		expect(text).not.toContain("File Map:");
 		expect(text).not.toContain("[Output truncated:");
 	});
@@ -112,7 +112,7 @@ describe("read integration — combined output", () => {
 		const result = await callReadTool({ path: resolve(fixturesDir, "plain.txt") });
 		const text = getTextContent(result);
 
-		expect(text).toMatch(/^\d+:[0-9a-f]{2}\|/m);
+		expect(text).toMatch(/^\d+:[0-9a-f]{3}\|/m);
 		expect(text).not.toContain("File Map:");
 		expect(text).not.toContain("[Output truncated:");
 	});
@@ -127,7 +127,7 @@ describe("read integration — combined output", () => {
 		const text = getTextContent(result);
 
 		expect(result.isError).not.toBe(true);
-		expect(text).toMatch(/^\d+:[0-9a-f]{2}\|/m);
+		expect(text).toMatch(/^\d+:[0-9a-f]{3}\|/m);
 		expect(text).not.toContain("File Map:");
 	});
 });
@@ -141,7 +141,7 @@ describe("read integration — hashline format", () => {
 
 		expect(rows.length).toBeGreaterThan(0);
 		for (const row of rows) {
-			expect(`${row.line}:${row.hash}|${row.content}`).toMatch(/^\d+:[0-9a-f]{2}\|/);
+			expect(`${row.line}:${row.hash}|${row.content}`).toMatch(/^\d+:[0-9a-f]{3}\|/);
 		}
 		for (let i = 0; i < rows.length; i++) {
 			expect(rows[i].line).toBe(i + 1);
@@ -167,8 +167,8 @@ describe("read integration — hashline format", () => {
 	});
 
 	it("parsed rows expose reusable LINE:HASH anchors", () => {
-		const [row] = parseHashlineRows("12:ab|hello world");
-		expect((row as any).anchor).toBe("12:ab");
+		const [row] = parseHashlineRows("12:abc|hello world");
+		expect((row as any).anchor).toBe("12:abc");
 	});
 });
 describe("read integration — edit after read", () => {

--- a/tests/read-map-on-demand.test.ts
+++ b/tests/read-map-on-demand.test.ts
@@ -48,7 +48,7 @@ describe("read map on demand", () => {
 		});
 		const text = result.content[0].text;
 		// Should have hashlines
-		expect(text).toMatch(/^\d+:[0-9a-f]{2}\|/m);
+		expect(text).toMatch(/^\d+:[0-9a-f]{3}\|/m);
 		// Should NOT have truncation message (file is small)
 		expect(text).not.toContain("[Output truncated:");
 		// Should have structural map appended
@@ -81,9 +81,9 @@ describe("read map on demand", () => {
 		});
 		const text = result.content[0].text;
 		// Should have hashlines starting at line 1
-		expect(text).toMatch(/^1:[0-9a-f]{2}\|/m);
+		expect(text).toMatch(/^1:[0-9a-f]{3}\|/m);
 		// Should have only 5 hashlined content lines (offset=1, limit=5)
-		const hashlineRows = text.split("\n").filter((l: string) => /^\d+:[0-9a-f]{2}\|/.test(l));
+		const hashlineRows = text.split("\n").filter((l: string) => /^\d+:[0-9a-f]{3}\|/.test(l));
 		expect(hashlineRows.length).toBe(5);
 		// Should still have the structural map appended
 		expect(text).toContain("File Map:");
@@ -97,7 +97,7 @@ describe("read map on demand", () => {
 		});
 		const text = result.content[0].text;
 		// Should have hashlines
-		expect(text).toMatch(/^\d+:[0-9a-f]{2}\|/m);
+		expect(text).toMatch(/^\d+:[0-9a-f]{3}\|/m);
 		// Should NOT have a map (plain.txt is unmappable)
 		expect(text).not.toContain("File Map:");
 		// Should NOT be an error
@@ -110,7 +110,7 @@ describe("read map on demand", () => {
 		});
 		const text = result.content[0].text;
 		// Should have hashlines
-		expect(text).toMatch(/^\d+:[0-9a-f]{2}\|/m);
+		expect(text).toMatch(/^\d+:[0-9a-f]{3}\|/m);
 		// Should NOT have structural map (file is small, map not requested)
 		expect(text).not.toContain("File Map:");
 	});
@@ -121,7 +121,7 @@ describe("read map on demand", () => {
 			map: false,
 		});
 		const text = result.content[0].text;
-		expect(text).toMatch(/^\d+:[0-9a-f]{2}\|/m);
+		expect(text).toMatch(/^\d+:[0-9a-f]{3}\|/m);
 		expect(text).not.toContain("File Map:");
 	});
 });

--- a/tests/repro-021-binary-warning.test.ts
+++ b/tests/repro-021-binary-warning.test.ts
@@ -98,6 +98,6 @@ describe("Bug #021: binary files read/grepped without warning", () => {
 
     const readOutput = text(readResult);
     expect(hasBinaryWarning(readOutput)).toBe(false);
-    expect(readOutput).toMatch(/^1:[0-9a-f]{2}\|/m);
+    expect(readOutput).toMatch(/^1:[0-9a-f]{3}\|/m);
   });
 });

--- a/tests/repro-030b-did-you-mean.test.ts
+++ b/tests/repro-030b-did-you-mean.test.ts
@@ -32,7 +32,7 @@ describe("Feature #030b: Did you mean? suggestions on anchor mismatch", () => {
       // Must contain "Did you mean?" section
       expect(err.message).toContain("Did you mean");
       // Must suggest line(s) with LINE:HASH|content format
-      expect(err.message).toMatch(/\d+:[0-9a-f]{2}\|/);
+      expect(err.message).toMatch(/\d+:[0-9a-f]{3}\|/);
       // Should suggest line 3 which has similar content "const c = 3; // modified"
       expect(err.message).toContain("const c = 3;");
     }
@@ -94,7 +94,7 @@ describe("Feature #030b: Did you mean? suggestions on anchor mismatch", () => {
       const afterSection = err.message.slice(didYouMeanIdx);
       const suggestionLines = afterSection
         .split("\n")
-        .filter((l: string) => /^\s+\d+:[0-9a-f]{2}\|/.test(l));
+        .filter((l: string) => /^\s+\d+:[0-9a-f]{3}\|/.test(l));
       expect(suggestionLines.length).toBeLessThanOrEqual(3);
       expect(suggestionLines.length).toBeGreaterThanOrEqual(1);
     }

--- a/tests/repro-052-control-chars.test.ts
+++ b/tests/repro-052-control-chars.test.ts
@@ -147,9 +147,9 @@ describe("Bug #052: control characters in read/grep output", () => {
     const grepText = getTextContent(grepResult);
 
     // Extract anchor for line 2 from read output (format: "2:xx|display text")
-    const readAnchor = readText.match(/^2:[0-9a-f]{2}\|/m)?.[0].replace(/\|$/, "");
+    const readAnchor = readText.match(/^2:[0-9a-f]{3}\|/m)?.[0].replace(/\|$/, "");
     // Extract anchor for line 5 from grep output (format: "path:>>5:xx|display text")
-    const grepAnchor = grepText.match(/>>5:([0-9a-f]{2})\|/m)?.[0].replace(/^>>/, "").replace(/\|$/, "");
+    const grepAnchor = grepText.match(/>>5:([0-9a-f]{3})\|/m)?.[0].replace(/^>>/, "").replace(/\|$/, "");
 
     expect(readAnchor, "read output should contain a LINE:HASH anchor for line 2").toBeTruthy();
     expect(grepAnchor, "grep output should contain a LINE:HASH anchor for line 5").toBeTruthy();

--- a/tests/rtk-git.test.ts
+++ b/tests/rtk-git.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import {
+  isGitCommand,
+  compactDiff,
+  compactStatus,
+  compactLog,
+  compactGitOutput,
+} from "../src/rtk/git.js";
+
+describe("isGitCommand", () => {
+  it("matches git diff", () => {
+    expect(isGitCommand("git diff")).toBe(true);
+  });
+
+  it("matches git status", () => {
+    expect(isGitCommand("git status")).toBe(true);
+  });
+
+  it("matches git log", () => {
+    expect(isGitCommand("git log --oneline")).toBe(true);
+  });
+
+  it("matches git show", () => {
+    expect(isGitCommand("git show HEAD")).toBe(true);
+  });
+
+  it("matches git stash", () => {
+    expect(isGitCommand("git stash list")).toBe(true);
+  });
+
+  it("rejects npm install", () => {
+    expect(isGitCommand("npm install")).toBe(false);
+  });
+
+  it("rejects cargo test", () => {
+    expect(isGitCommand("cargo test")).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isGitCommand(undefined)).toBe(false);
+  });
+
+  it("rejects null", () => {
+    expect(isGitCommand(null)).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isGitCommand("")).toBe(false);
+  });
+});
+
+describe("compactDiff", () => {
+  it("preserves diff content with file headers", () => {
+    const output = [
+      "diff --git a/src/foo.ts b/src/foo.ts",
+      "--- a/src/foo.ts",
+      "+++ b/src/foo.ts",
+      "@@ -1,3 +1,3 @@",
+      " line1",
+      "-old line",
+      "+new line",
+      " line3",
+    ].join("\n");
+
+    const result = compactDiff(output);
+    expect(result).toContain("src/foo.ts");
+    expect(result).toContain("+new line");
+    expect(result).toContain("-old line");
+  });
+
+  it("truncates large diffs significantly", () => {
+    const lines: string[] = ["diff --git a/big.ts b/big.ts", "--- a/big.ts", "+++ b/big.ts", "@@ -1,200 +1,200 @@"];
+    for (let i = 0; i < 200; i++) {
+      lines.push(`+added line ${i}`);
+    }
+    const output = lines.join("\n");
+
+    const result = compactDiff(output, 20);
+    const resultLines = result.split("\n");
+    // Should be dramatically smaller than the 200+ input lines
+    expect(resultLines.length).toBeLessThan(30);
+    expect(result).toContain("more changes");
+  });
+
+  it("returns output unchanged when under maxLines", () => {
+    const output = [
+      "diff --git a/a.ts b/a.ts",
+      "--- a/a.ts",
+      "+++ b/a.ts",
+      "@@ -1,1 +1,1 @@",
+      "-old",
+      "+new",
+    ].join("\n");
+
+    const result = compactDiff(output, 100);
+    expect(result).toContain("+new");
+    expect(result).toContain("-old");
+  });
+});
+
+describe("compactStatus", () => {
+  it("returns clean for empty output", () => {
+    expect(compactStatus("")).toBe("Clean working tree");
+  });
+
+  it("shows branch name and staged files", () => {
+    const output = [
+      "## main...origin/main",
+      "M  src/foo.ts",
+      "A  src/bar.ts",
+    ].join("\n");
+
+    const result = compactStatus(output);
+    expect(result).toContain("main");
+    expect(result).toContain("Staged");
+    expect(result).toContain("2 files");
+  });
+
+  it("shows modified files", () => {
+    const output = [
+      "## feature",
+      " M src/changed.ts",
+    ].join("\n");
+
+    const result = compactStatus(output);
+    expect(result).toContain("Modified");
+    expect(result).toContain("src/changed.ts");
+  });
+
+  it("shows untracked files", () => {
+    const output = [
+      "## main",
+      "?? newfile.ts",
+    ].join("\n");
+
+    const result = compactStatus(output);
+    expect(result).toContain("Untracked");
+    expect(result).toContain("newfile.ts");
+  });
+});
+
+describe("compactLog", () => {
+  it("limits log entries to default 20", () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 50; i++) {
+      lines.push(`abc${i}def commit message ${i}`);
+    }
+    const output = lines.join("\n");
+
+    const result = compactLog(output);
+    expect(result).toContain("and 30 more commits");
+  });
+
+  it("limits log entries to custom limit", () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 20; i++) {
+      lines.push(`commit ${i}`);
+    }
+    const output = lines.join("\n");
+
+    const result = compactLog(output, 5);
+    expect(result).toContain("and 15 more commits");
+  });
+
+  it("returns all entries when under limit", () => {
+    const output = "commit 1\ncommit 2\ncommit 3";
+    const result = compactLog(output, 10);
+    expect(result).not.toContain("more commits");
+    expect(result).toContain("commit 1");
+    expect(result).toContain("commit 3");
+  });
+
+  it("truncates long lines to 80 chars", () => {
+    const longLine = "a".repeat(100);
+    const result = compactLog(longLine);
+    expect(result.length).toBeLessThanOrEqual(80);
+    expect(result).toContain("...");
+  });
+});
+
+describe("compactGitOutput", () => {
+  it("dispatches git diff to compactDiff", () => {
+    const output = [
+      "diff --git a/f.ts b/f.ts",
+      "--- a/f.ts",
+      "+++ b/f.ts",
+      "@@ -1,1 +1,1 @@",
+      "-old",
+      "+new",
+    ].join("\n");
+
+    const result = compactGitOutput(output, "git diff");
+    expect(result).not.toBeNull();
+    expect(result).toContain("f.ts");
+  });
+
+  it("dispatches git status to compactStatus", () => {
+    const result = compactGitOutput("## main\n?? new.ts", "git status --short");
+    expect(result).not.toBeNull();
+    expect(result).toContain("main");
+  });
+
+  it("dispatches git log to compactLog", () => {
+    const result = compactGitOutput("commit 1\ncommit 2", "git log --oneline");
+    expect(result).not.toBeNull();
+    expect(result).toContain("commit 1");
+  });
+
+  it("returns null for non-git commands", () => {
+    expect(compactGitOutput("output", "npm test")).toBeNull();
+  });
+
+  it("returns null for unrecognized git subcommands", () => {
+    expect(compactGitOutput("output", "git push origin main")).toBeNull();
+  });
+});

--- a/tests/rtk-linter.test.ts
+++ b/tests/rtk-linter.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { isLinterCommand, aggregateLinterOutput } from "../src/rtk/linter.js";
+
+describe("isLinterCommand", () => {
+  it("matches eslint", () => {
+    expect(isLinterCommand("npx eslint src/")).toBe(true);
+  });
+
+  it("matches prettier", () => {
+    expect(isLinterCommand("prettier --check .")).toBe(true);
+  });
+
+  it("matches ruff", () => {
+    expect(isLinterCommand("ruff check .")).toBe(true);
+  });
+
+  it("matches clippy", () => {
+    expect(isLinterCommand("cargo clippy")).toBe(true);
+  });
+
+  it("matches mypy", () => {
+    expect(isLinterCommand("mypy src/")).toBe(true);
+  });
+
+  it("matches flake8", () => {
+    expect(isLinterCommand("flake8 .")).toBe(true);
+  });
+
+  it("matches black", () => {
+    expect(isLinterCommand("black --check .")).toBe(true);
+  });
+
+  it("matches golangci-lint", () => {
+    expect(isLinterCommand("golangci-lint run")).toBe(true);
+  });
+
+  it("matches pylint", () => {
+    expect(isLinterCommand("pylint src/")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isLinterCommand("ESLint src/")).toBe(true);
+  });
+
+  it("rejects npm test", () => {
+    expect(isLinterCommand("npm test")).toBe(false);
+  });
+
+  it("rejects cargo build", () => {
+    expect(isLinterCommand("cargo build")).toBe(false);
+  });
+
+  it("rejects git status", () => {
+    expect(isLinterCommand("git status")).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isLinterCommand(undefined)).toBe(false);
+  });
+
+  it("rejects null", () => {
+    expect(isLinterCommand(null)).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isLinterCommand("")).toBe(false);
+  });
+});
+
+describe("aggregateLinterOutput", () => {
+  it("returns null for non-linter commands", () => {
+    expect(aggregateLinterOutput("some output", "npm test")).toBeNull();
+  });
+
+  it("reports no issues for empty parseable output", () => {
+    const result = aggregateLinterOutput("", "eslint src/");
+    expect(result).toContain("No issues found");
+  });
+
+  it("aggregates eslint error output", () => {
+    const output = [
+      "src/foo.ts:10:5: Missing semicolon [semi]",
+      "src/foo.ts:20:3: Unexpected var [no-var]",
+      "src/bar.ts:5:1: Missing return [consistent-return]",
+    ].join("\n");
+
+    const result = aggregateLinterOutput(output, "eslint src/");
+    expect(result).not.toBeNull();
+    expect(result).toContain("ESLint");
+    expect(result).toContain("3 errors");
+    expect(result).toContain("2 files");
+  });
+
+  it("aggregates ruff output", () => {
+    const output = [
+      "src/main.py:10:5: E501 Line too long [E501]",
+      "src/main.py:20:1: F401 Unused import [F401]",
+    ].join("\n");
+
+    const result = aggregateLinterOutput(output, "ruff check .");
+    expect(result).not.toBeNull();
+    expect(result).toContain("Ruff");
+    expect(result).toContain("errors");
+  });
+
+  it("aggregates clippy output", () => {
+    const output = "error: unused variable at src/main.rs:10:5";
+    const result = aggregateLinterOutput(output, "cargo clippy");
+    expect(result).not.toBeNull();
+    expect(result).toContain("Clippy");
+  });
+
+  it("shows top rules breakdown", () => {
+    const output = [
+      "src/a.ts:1:1: msg [semi]",
+      "src/a.ts:2:1: msg [semi]",
+      "src/a.ts:3:1: msg [no-var]",
+    ].join("\n");
+
+    const result = aggregateLinterOutput(output, "eslint .");
+    expect(result).not.toBeNull();
+    expect(result).toContain("semi");
+    expect(result).toContain("2x");
+  });
+
+  it("shows top files breakdown", () => {
+    const output = [
+      "src/a.ts:1:1: msg [rule1]",
+      "src/a.ts:2:1: msg [rule1]",
+      "src/b.ts:1:1: msg [rule1]",
+    ].join("\n");
+
+    const result = aggregateLinterOutput(output, "eslint .");
+    expect(result).not.toBeNull();
+    expect(result).toContain("src/a.ts");
+    expect(result).toContain("2 issues");
+  });
+
+  it("returns null for undefined command", () => {
+    expect(aggregateLinterOutput("output", undefined)).toBeNull();
+  });
+});

--- a/tests/rtk-truncate.test.ts
+++ b/tests/rtk-truncate.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { truncate, truncateLines } from "../src/rtk/truncate.js";
+
+describe("truncate", () => {
+  it("returns text unchanged when shorter than maxLength", () => {
+    expect(truncate("hello", 10)).toBe("hello");
+  });
+
+  it("returns text unchanged when exactly at maxLength", () => {
+    expect(truncate("hello", 5)).toBe("hello");
+  });
+
+  it("truncates text over maxLength with ellipsis", () => {
+    const result = truncate("hello world", 8);
+    expect(result).toBe("hello...");
+    expect(result.length).toBe(8);
+  });
+
+  it("returns just ellipsis when maxLength < 3", () => {
+    expect(truncate("hello", 2)).toBe("...");
+    expect(truncate("hello", 1)).toBe("...");
+    expect(truncate("hello", 0)).toBe("...");
+  });
+
+  it("handles empty input", () => {
+    expect(truncate("", 10)).toBe("");
+  });
+
+  it("handles maxLength of exactly 3", () => {
+    expect(truncate("hello", 3)).toBe("...");
+  });
+
+  it("handles maxLength of 4", () => {
+    const result = truncate("hello", 4);
+    expect(result).toBe("h...");
+    expect(result.length).toBe(4);
+  });
+});
+
+describe("truncateLines", () => {
+  it("returns text unchanged when fewer lines than limit", () => {
+    const text = "line1\nline2\nline3";
+    expect(truncateLines(text, 5)).toBe(text);
+  });
+
+  it("returns text unchanged when exactly at limit", () => {
+    const text = "line1\nline2\nline3";
+    expect(truncateLines(text, 3)).toBe(text);
+  });
+
+  it("truncates with indicator when over limit", () => {
+    const lines: string[] = [];
+    for (let i = 1; i <= 20; i++) {
+      lines.push(`line ${i}`);
+    }
+    const text = lines.join("\n");
+
+    const result = truncateLines(text, 10);
+    expect(result).toContain("lines omitted");
+    // Should keep some from start and some from end
+    expect(result).toContain("line 1");
+    expect(result).toContain("line 20");
+  });
+
+  it("handles empty input", () => {
+    expect(truncateLines("", 10)).toBe("");
+  });
+
+  it("handles single line input", () => {
+    expect(truncateLines("hello", 10)).toBe("hello");
+  });
+});

--- a/tests/sg-availability.test.ts
+++ b/tests/sg-availability.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest";
+import { isSgAvailable } from "../src/sg.js";
+
+describe("isSgAvailable", () => {
+  it("returns a boolean", () => {
+    const result = isSgAvailable();
+    expect(typeof result).toBe("boolean");
+  });
+});

--- a/tests/sg.format.test.ts
+++ b/tests/sg.format.test.ts
@@ -27,7 +27,7 @@ function text(result: any): string {
 function parseAnchors(block: string): Array<{ line: number; hash: string; anchor: string; content: string }> {
   const out: Array<{ line: number; hash: string; anchor: string; content: string }> = [];
   for (const line of block.split("\n")) {
-    const m = line.match(/^>>(\d+):([0-9a-f]{2})\|(.*)$/);
+    const m = line.match(/^>>(\d+):([0-9a-f]{3})\|(.*)$/);
     if (!m) continue;
     out.push({
       line: Number(m[1]),

--- a/tests/shell-mapper.test.ts
+++ b/tests/shell-mapper.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateMap } from "../src/readmap/mapper.js";
+import { SymbolKind } from "../src/readmap/enums.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = resolve(__dirname, "fixtures/sample.sh");
+
+describe("Shell readmap mapper", () => {
+  it("generates a map for .sh files", async () => {
+    const map = await generateMap(FIXTURE);
+    expect(map).not.toBeNull();
+    expect(map!.language).toBe("Shell");
+    expect(map!.symbols.length).toBeGreaterThan(0);
+  });
+
+  it("extracts 'function name()' style function", async () => {
+    const map = await generateMap(FIXTURE);
+    const deploy = map!.symbols.find(s => s.name === "deploy");
+    expect(deploy).toBeDefined();
+    expect(deploy!.kind).toBe(SymbolKind.Function);
+    expect(deploy!.startLine).toBeGreaterThan(0);
+    expect(deploy!.endLine).toBeGreaterThan(deploy!.startLine);
+  });
+
+  it("extracts 'name() {' style function", async () => {
+    const map = await generateMap(FIXTURE);
+    const build = map!.symbols.find(s => s.name === "build_image");
+    expect(build).toBeDefined();
+    expect(build!.kind).toBe(SymbolKind.Function);
+    expect(build!.startLine).toBeGreaterThan(0);
+    expect(build!.endLine).toBeGreaterThan(build!.startLine);
+  });
+
+  it("extracts 'function name {' style (no parens)", async () => {
+    const map = await generateMap(FIXTURE);
+    const cleanup = map!.symbols.find(s => s.name === "cleanup");
+    expect(cleanup).toBeDefined();
+    expect(cleanup!.kind).toBe(SymbolKind.Function);
+  });
+
+  it("extracts aliases as Variable kind", async () => {
+    const map = await generateMap(FIXTURE);
+    const ll = map!.symbols.find(s => s.name === "ll");
+    expect(ll).toBeDefined();
+    expect(ll!.kind).toBe(SymbolKind.Variable);
+  });
+
+  it("extracts exported variables as Variable kind", async () => {
+    const map = await generateMap(FIXTURE);
+    const appName = map!.symbols.find(s => s.name === "APP_NAME");
+    expect(appName).toBeDefined();
+    expect(appName!.kind).toBe(SymbolKind.Variable);
+  });
+
+  it("handles heredocs without misidentifying content as symbols", async () => {
+    const map = await generateMap(FIXTURE);
+    const genConfig = map!.symbols.find(s => s.name === "generate_config");
+    expect(genConfig).toBeDefined();
+    expect(genConfig!.kind).toBe(SymbolKind.Function);
+    // The heredoc content (server, host, port, name) should NOT be symbols
+    const server = map!.symbols.find(s => s.name === "server");
+    expect(server).toBeUndefined();
+  });
+
+  it("symbol lookup by name returns function body", async () => {
+    const map = await generateMap(FIXTURE);
+    const runTests = map!.symbols.find(s => s.name === "run_tests");
+    expect(runTests).toBeDefined();
+    expect(runTests!.kind).toBe(SymbolKind.Function);
+    expect(runTests!.startLine).toBeGreaterThan(0);
+    expect(runTests!.endLine).toBeGreaterThan(runTests!.startLine);
+  });
+});

--- a/tests/swift-mapper.test.ts
+++ b/tests/swift-mapper.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateMap } from "../src/readmap/mapper.js";
+import { SymbolKind } from "../src/readmap/enums.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = resolve(__dirname, "fixtures/sample.swift");
+
+describe("Swift readmap mapper", () => {
+  it("generates a map for .swift files", async () => {
+    const map = await generateMap(FIXTURE);
+    expect(map).not.toBeNull();
+    expect(map!.language).toBe("Swift");
+    expect(map!.symbols.length).toBeGreaterThan(0);
+  });
+
+  it("extracts class as Class kind", async () => {
+    const map = await generateMap(FIXTURE);
+    const shape = map!.symbols.find(s => s.name === "Shape");
+    expect(shape).toBeDefined();
+    expect(shape!.kind).toBe(SymbolKind.Class);
+    expect(shape!.startLine).toBeGreaterThan(0);
+    expect(shape!.endLine).toBeGreaterThan(shape!.startLine);
+  });
+
+  it("extracts protocol as Interface kind", async () => {
+    const map = await generateMap(FIXTURE);
+    const drawable = map!.symbols.find(s => s.name === "Drawable");
+    expect(drawable).toBeDefined();
+    expect(drawable!.kind).toBe(SymbolKind.Interface);
+  });
+
+  it("extracts struct as Class kind", async () => {
+    const map = await generateMap(FIXTURE);
+    const point = map!.symbols.find(s => s.name === "Point");
+    expect(point).toBeDefined();
+    expect(point!.kind).toBe(SymbolKind.Class);
+  });
+
+  it("extracts enum as Enum kind", async () => {
+    const map = await generateMap(FIXTURE);
+    const dir = map!.symbols.find(s => s.name === "Direction");
+    expect(dir).toBeDefined();
+    expect(dir!.kind).toBe(SymbolKind.Enum);
+  });
+
+  it("extracts extension", async () => {
+    const map = await generateMap(FIXTURE);
+    const ext = map!.symbols.find(s => s.name === "Shape" && s.startLine > 20);
+    // Extension should appear as a separate symbol
+    expect(ext).toBeDefined();
+  });
+
+  it("extracts top-level function", async () => {
+    const map = await generateMap(FIXTURE);
+    const helper = map!.symbols.find(s => s.name === "globalHelper");
+    expect(helper).toBeDefined();
+    expect(helper!.kind).toBe(SymbolKind.Function);
+  });
+});

--- a/tests/symbol-read-integration.test.ts
+++ b/tests/symbol-read-integration.test.ts
@@ -49,7 +49,7 @@ function getTextContent(result: any): string {
 function parseHashlineRows(text: string): HashlineRow[] {
   const rows: HashlineRow[] = [];
   for (const line of text.split("\n")) {
-    const match = line.match(/^(\d+):([0-9a-f]{2})\|(.*)$/);
+    const match = line.match(/^(\d+):([0-9a-f]{3})\|(.*)$/);
     if (!match) continue;
     rows.push({ line: Number(match[1]), hash: match[2], anchor: `${match[1]}:${match[2]}`, content: match[3] });
   }
@@ -208,7 +208,7 @@ describe("symbol read integration", () => {
     expect(text).toContain("process (function)");
     expect(text).toContain("lines 1-10");
     expect(text).toContain("lines 20-30");
-    expect(text).not.toMatch(/^\d+:[0-9a-f]{2}\|/m);
+    expect(text).not.toMatch(/^\d+:[0-9a-f]{3}\|/m);
   });
 
 	it("prepends not-found warning and then returns normal hashlines", async () => {

--- a/tests/tool-executor-emit.test.ts
+++ b/tests/tool-executor-emit.test.ts
@@ -19,7 +19,7 @@ describe("index.ts emits and stashes tool executors (task 2)", () => {
     init(pi as any);
     const stash = (globalThis as any).__hashlineToolExecutors;
     expect(stash).toBeDefined();
-    expect(Object.keys(stash).sort()).toEqual(["ast_search", "edit", "grep", "read"]);
+    expect(Object.keys(stash).sort()).toEqual(["ast_search", "edit", "grep", "read", "write"]);
   });
 
   it("emit channel is exactly 'hashline:tool-executors'", async () => {

--- a/tests/write-tool.test.ts
+++ b/tests/write-tool.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit, computeLineHash, applyHashlineEdits } from "../src/hashline.js";
+
+// We'll test the write tool's core logic directly
+// The tool registration requires pi's ExtensionAPI, but the core logic is testable
+
+describe("enhanced write tool", () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  afterEach(() => {
+    if (tmpDir && existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns hashlined output with 3-char hashes after writing", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "write-test-"));
+    const filePath = join(tmpDir, "test.ts");
+    const content = "line one\nline two\nline three";
+
+    // Import the write helper
+    const { executeWrite } = await import("../src/write.js");
+    const result = await executeWrite({ path: filePath, content });
+
+    // File should exist on disk
+    expect(readFileSync(filePath, "utf-8")).toBe(content);
+
+    // Output should have hashlined format
+    expect(result.text).toMatch(/^1:[0-9a-f]{3}\|line one$/m);
+    expect(result.text).toMatch(/^2:[0-9a-f]{3}\|line two$/m);
+    expect(result.text).toMatch(/^3:[0-9a-f]{3}\|line three$/m);
+  });
+
+  it("returned anchors work directly in applyHashlineEdits", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "write-test-"));
+    const filePath = join(tmpDir, "test.ts");
+    const content = "first\nsecond\nthird";
+
+    const { executeWrite } = await import("../src/write.js");
+    await executeWrite({ path: filePath, content });
+
+    // Extract anchor for line 2
+    const hash2 = computeLineHash(2, "second");
+    const anchor = `2:${hash2}`;
+
+    // Use the anchor in an edit
+    const edited = applyHashlineEdits(content, [
+      { set_line: { anchor, new_text: "SECOND" } },
+    ]);
+    expect(edited.content).toBe("first\nSECOND\nthird");
+  });
+
+  it("detects binary content and includes warning", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "write-test-"));
+    const filePath = join(tmpDir, "binary.bin");
+    // Binary content with null bytes
+    const content = "header\x00\x01\x02binary\x00data";
+
+    const { executeWrite } = await import("../src/write.js");
+    const result = await executeWrite({ path: filePath, content });
+
+    expect(result.text).toContain("binary");
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it("escapes control characters for display safety", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "write-test-"));
+    const filePath = join(tmpDir, "test.ts");
+    const content = "normal line\nline with \x01 control";
+
+    const { executeWrite } = await import("../src/write.js");
+    const result = await executeWrite({ path: filePath, content });
+
+    // Control char should be escaped
+    expect(result.text).toContain("\\u0001");
+    expect(result.text).not.toContain("\x01");
+  });
+
+  it("creates parent directories when needed", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "write-test-"));
+    const filePath = join(tmpDir, "nested", "deep", "test.ts");
+    const content = "hello";
+
+    const { executeWrite } = await import("../src/write.js");
+    await executeWrite({ path: filePath, content });
+
+    expect(existsSync(filePath)).toBe(true);
+    expect(readFileSync(filePath, "utf-8")).toBe("hello");
+  });
+
+  it("returns ptcValue with per-line anchors", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "write-test-"));
+    const filePath = join(tmpDir, "test.ts");
+    const content = "alpha\nbeta";
+
+    const { executeWrite } = await import("../src/write.js");
+    const result = await executeWrite({ path: filePath, content });
+
+    expect(result.ptcValue).toBeDefined();
+    expect(result.ptcValue.lines).toHaveLength(2);
+    expect(result.ptcValue.lines[0].line).toBe(1);
+    expect(result.ptcValue.lines[0].anchor).toMatch(/^1:[0-9a-f]{3}$/);
+    expect(result.ptcValue.lines[1].line).toBe(2);
+  });
+});

--- a/tests/xxhash-wasm.test.ts
+++ b/tests/xxhash-wasm.test.ts
@@ -26,14 +26,14 @@ describe("xxhash-wasm", () => {
 
   it("computeLineHash is synchronous after init and returns 2-char hex (AC 4, 5)", () => {
     const hash = computeLineHash(1, "hello world");
-    expect(hash).toMatch(/^[0-9a-f]{2}$/);
+    expect(hash).toMatch(/^[0-9a-f]{3}$/);
     // Deterministic: same input → same output
     expect(computeLineHash(1, "hello world")).toBe(hash);
   });
 
   it("hashLine produces LINE:HASH|content format (AC 6)", () => {
     const result = hashLine(12, "hello");
-    expect(result).toMatch(/^12:[0-9a-f]{2}\|hello$/);
+    expect(result).toMatch(/^12:[0-9a-f]{3}\|hello$/);
   });
 
   it("hashLines produces sequential 1-indexed LINE:HASH|content entries (AC 7)", () => {
@@ -41,8 +41,8 @@ describe("xxhash-wasm", () => {
     const result = hashLines(content);
     const lines = result.split("\n");
     expect(lines).toHaveLength(3);
-    expect(lines[0]).toMatch(/^1:[0-9a-f]{2}\|line one$/);
-    expect(lines[1]).toMatch(/^2:[0-9a-f]{2}\|line two$/);
-    expect(lines[2]).toMatch(/^3:[0-9a-f]{2}\|line three$/);
+    expect(lines[0]).toMatch(/^1:[0-9a-f]{3}\|line one$/);
+    expect(lines[1]).toMatch(/^2:[0-9a-f]{3}\|line two$/);
+    expect(lines[2]).toMatch(/^3:[0-9a-f]{3}\|line three$/);
   });
 });


### PR DESCRIPTION
## What

Batch release sharpening the pi-hashline-readmap toolchain across six areas. Bumps to **v0.5.0**.

### Hash Engine (3 improvements)
- **3-char hashes** — `HASH_LEN` 2→3 (256→4096 values), ~16x fewer collisions (#071)
- **Adaptive relocation window** — scales with edit batch size: `min(max(20, edits×5), 100)` (#070)
- **Fuzzy content-based recovery** — auto-relocates on hash mismatch when exactly one candidate has >0.8 token similarity (#075)

### Enhanced Write Tool (#069)
Returns `LINE:HASH|content` hashlined output after writing, eliminating write→read round-trips. Includes binary detection, control char escaping, optional structural map (`map: true`), and structured ptcValue.

### Readmap Mappers (#072)
- **Swift** (`.swift`) — classes, structs, enums, protocols, extensions, functions
- **Shell/Bash** (`.sh`/`.bash`/`.zsh`) — functions (both styles), aliases, exports, heredoc-safe

### Grep Prompt (#073)
New `prompts/grep.md` with comprehensive documentation of all search modes. Grep tool loads description from file (matching sg/nu pattern).

### ast_search Detection (#076)
`isSgAvailable()` probes for `sg` binary at startup. Grep guidelines cross-reference ast_search when available, or suggest install when absent.

### RTK Test Coverage (#074)
56 new dedicated unit tests for linter, git, and truncate modules.

## Stats
- 37 files changed, 1862 insertions, 54 deletions
- 124 test files, 665 tests, 0 failures
- Typecheck clean

Closes #069, #070, #071, #072, #073, #074, #075, #076