### PR TITLE
fix: Swift mapper — recognize actor containers, operator overloads, and deinit blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This package is a good fit when you want pi to:
 - custom TUI rendering with symbol, map, warning, and truncation badges
 
 ### `read` feature details
-- Structural maps support **17 languages**: TypeScript, JavaScript, Python, Rust, Go, C, C++, Clojure, SQL, JSON, JSONL, Markdown, YAML, TOML, CSV, and related mapped variants in the readmap engine.
+- Structural maps support **19 languages**: TypeScript, JavaScript, Python, Rust, Go, C, C++, Swift, Shell/Bash, Clojure, SQL, JSON, JSONL, Markdown, YAML, TOML, CSV, and related mapped variants in the readmap engine. The Swift mapper recognizes classes, actors, structs, enums, protocols, extensions, functions (including operator overloads), and deinit lifecycle blocks.
 - `symbol` and `map` are mutually exclusive.
 - `symbol` cannot be combined with `offset` or `limit`.
 - `bundle: "local"` requires `symbol` and cannot be combined with `map` or `offset`.
@@ -428,8 +428,8 @@ npm run typecheck
 ```
 
 As of the current repository state, the suite passes with:
-- **107** test files
-- **524** tests
+- **125** test files
+- **668** tests
 
 ### Local development notes
 This repository is intended to be used as a pi extension workspace. In local development, changes can take effect immediately when the extension is installed from the local checkout.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, and bash output compression",
   "type": "module",
   "exports": {

--- a/src/readmap/mappers/swift.ts
+++ b/src/readmap/mappers/swift.ts
@@ -1,23 +1,59 @@
 /**
  * Swift mapper using regex-based extraction.
  *
- * Extracts classes, structs, enums, protocols, extensions, and functions.
+ * Extracts classes, actors, structs, enums, protocols, extensions, functions,
+ * and deinit lifecycle blocks.
  * No external dependencies — pure regex with brace-depth tracking.
  */
 import { readFile, stat } from "node:fs/promises";
-
 import type { FileMap, FileSymbol } from "../types.js";
 
 import { DetailLevel, SymbolKind } from "../enums.js";
 
-// Regex for Swift declarations (handles access modifiers and attributes)
-const SWIFT_DECL_RE =
-  /^(?:\s*)(?:@\w+\s+)*(?:(?:public|private|internal|open|fileprivate)\s+)?(?:(?:final|static|override|class|mutating|nonmutating)\s+)*(class|struct|enum|protocol|extension|func)\s+(\w+)/;
-
+const SWIFT_CONTAINER_DECL_RE =
+  /^(?:\s*)(?:@\w+\s+)*(?:(?:public|private|internal|open|fileprivate)\s+)?(?:(?:final|static|override|class|mutating|nonmutating)\s+)*(class|struct|enum|protocol|extension|actor)\s+(\w+)/;
+const SWIFT_FUNC_DECL_RE =
+  /^(?:\s*)(?:@\w+\s+)*(?:(?:public|private|internal|open|fileprivate)\s+)?(?:(?:final|static|override|class|mutating|nonmutating)\s+)*func\s+([^\s(<]+)/;
+const SWIFT_DEINIT_DECL_RE =
+  /^(?:\s*)(?:@\w+\s+)*(?:(?:public|private|internal|open|fileprivate)\s+)?(?:(?:final|static|override|class|mutating|nonmutating)\s+)*deinit\b/;
+interface SwiftDeclaration {
+  keyword: string;
+  name: string;
+  signature: string;
+}
 function countChar(s: string, ch: string): number {
   let n = 0;
   for (const c of s) if (c === ch) n++;
   return n;
+}
+function parseSwiftDeclaration(line: string): SwiftDeclaration | null {
+  const containerMatch = line.match(SWIFT_CONTAINER_DECL_RE);
+  if (containerMatch) {
+    const [, keyword, name] = containerMatch;
+    return {
+      keyword,
+      name,
+      signature: line.replace(/\{.*$/, "").trim(),
+    };
+  }
+  if (SWIFT_DEINIT_DECL_RE.test(line)) {
+    return {
+      keyword: "deinit",
+      name: "deinit",
+      signature: "deinit",
+    };
+  }
+  const funcMatch = line.match(SWIFT_FUNC_DECL_RE);
+  if (funcMatch) {
+    const [, name] = funcMatch;
+    return {
+      keyword: "func",
+      name,
+      signature: line.replace(/\{.*$/, "").trim(),
+    };
+  }
+
+  return null;
 }
 
 /**
@@ -30,35 +66,28 @@ export async function swiftMapper(
   try {
     const stats = await stat(filePath);
     const totalBytes = stats.size;
-
     const content = await readFile(filePath, "utf8");
 
     if (signal?.aborted) return null;
-
     const lines = content.split(/\r?\n/);
     const totalLines = lines.length;
     const symbols: FileSymbol[] = [];
-
     let braceDepth = 0;
     const declStack: { symbol: FileSymbol; startDepth: number }[] = [];
-
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
       const lineNum = i + 1;
       const trimmed = line.trim();
-
       if (trimmed.startsWith("//")) continue;
-
-      const match = trimmed.match(SWIFT_DECL_RE);
-      if (match) {
-        const keyword = match[1];
-        const name = match[2];
-
+      const decl = parseSwiftDeclaration(trimmed);
+      if (decl) {
+        const { keyword, name, signature } = decl;
         let kind: SymbolKind;
         switch (keyword) {
           case "class":
           case "struct":
           case "extension":
+          case "actor":
             kind = SymbolKind.Class;
             break;
           case "enum":
@@ -68,33 +97,28 @@ export async function swiftMapper(
             kind = SymbolKind.Interface;
             break;
           case "func":
+          case "deinit":
             kind = braceDepth > 0 ? SymbolKind.Method : SymbolKind.Function;
             break;
           default:
             kind = SymbolKind.Unknown;
         }
-
         const sym: FileSymbol = {
           name,
           kind,
           startLine: lineNum,
           endLine: lineNum,
-          signature: trimmed.replace(/\{.*$/, "").trim(),
+          signature,
         };
-
-        // Determine parent BEFORE pushing this symbol
-        const isChild = declStack.length > 0 && keyword === "func";
+        const isChild = declStack.length > 0 && (keyword === "func" || keyword === "deinit");
         const parentEntry = isChild ? declStack[declStack.length - 1] : null;
-
         const openBraces = countChar(line, "{");
         const closeBraces = countChar(line, "}");
-
         if (openBraces > closeBraces) {
           declStack.push({ symbol: sym, startDepth: braceDepth });
         } else {
           sym.endLine = lineNum;
         }
-
         if (isChild && parentEntry) {
           if (!parentEntry.symbol.children) parentEntry.symbol.children = [];
           parentEntry.symbol.children.push(sym);
@@ -106,12 +130,9 @@ export async function swiftMapper(
         continue;
       }
 
-      // Track braces for non-declaration lines
       const openBraces = countChar(line, "{");
       const closeBraces = countChar(line, "}");
       braceDepth += openBraces - closeBraces;
-
-      // Pop closed declarations
       while (declStack.length > 0) {
         const top = declStack[declStack.length - 1];
         if (braceDepth <= top.startDepth) {
@@ -122,8 +143,6 @@ export async function swiftMapper(
         }
       }
     }
-
-    // Close any remaining open declarations
     for (const item of declStack) {
       item.symbol.endLine = totalLines;
     }

--- a/tests/readme-license.test.ts
+++ b/tests/readme-license.test.ts
@@ -34,7 +34,7 @@ describe("README.md (AC-1, AC-2)", () => {
 
   it("mentions supported languages", () => {
     const readme = readFileSync(resolve(root, "README.md"), "utf8");
-    expect(readme).toContain("17 languages");
+    expect(readme).toContain("19 languages");
   });
 
   it("credits upstream projects", () => {

--- a/tests/swift-mapper-regressions.test.ts
+++ b/tests/swift-mapper-regressions.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { clearMapCache } from "../src/map-cache.js";
+
+async function getReadTool() {
+  const { registerReadTool } = await import("../src/read.js");
+  let capturedTool: any = null;
+  const mockPi = {
+    registerTool(def: any) {
+      capturedTool = def;
+    },
+  };
+  registerReadTool(mockPi as any);
+  if (!capturedTool) throw new Error("read tool was not registered");
+  return capturedTool;
+}
+
+async function callReadTool(params: { path: string; map?: boolean }) {
+  const tool = await getReadTool();
+  return tool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+async function withSwiftFile<T>(filename: string, content: string, run: (path: string) => Promise<T>) {
+  const dir = await mkdtemp(join(tmpdir(), "swift-read-"));
+  const file = join(dir, filename);
+  try {
+    await writeFile(file, content, "utf8");
+    return await run(file);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+describe("Swift mapper regressions", () => {
+  beforeEach(() => clearMapCache());
+
+  it("read(path, { map: true }) maps actor declarations as container symbols with nested methods", async () => {
+    const result = await withSwiftFile(
+      "actor.swift",
+      `actor BankAccount {
+    var balance: Double = 0
+    func deposit(_ amount: Double) {
+        balance += amount
+    }
+}
+`,
+      async path => callReadTool({ path, map: true }),
+    );
+
+    const text = result.content[0].text;
+    expect(text).toContain("File Map:");
+    expect(text).toContain("class actor BankAccount: [1-6]");
+    expect(text).toContain("  func deposit(_ amount: Double): [3-5]");
+  });
+
+  it("read(path, { map: true }) maps operator overloads as nested methods", async () => {
+    const result = await withSwiftFile(
+      "operator.swift",
+      `struct Tricky {
+    static func + (lhs: Tricky, rhs: Tricky) -> Tricky {
+        return lhs
+    }
+}
+`,
+      async path => callReadTool({ path, map: true }),
+    );
+
+    const text = result.content[0].text;
+    expect(text).toContain("File Map:");
+    expect(text).toContain("class struct Tricky: [1-5]");
+    expect(text).toContain("  static func + (lhs: Tricky, rhs: Tricky) -> Tricky: [2-4]");
+  });
+
+  it("read(path, { map: true }) maps deinit blocks as nested lifecycle symbols", async () => {
+    const result = await withSwiftFile(
+      "deinit.swift",
+      `class ModernClass {
+    deinit {
+        print("bye")
+    }
+}
+`,
+      async path => callReadTool({ path, map: true }),
+    );
+
+    const text = result.content[0].text;
+    expect(text).toContain("File Map:");
+    expect(text).toContain("class class ModernClass: [1-5]");
+    expect(text).toContain("  deinit: [2-4]");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes three related bugs in the Swift structural mapper where valid Swift declarations were silently dropped from `read(path, { map: true })` output. All three traced back to a single overly-restrictive regex in `parseSwiftDeclaration()`.

## What changed

### Bug fixes
- **`actor` containers** (#079): `actor BankAccount { func deposit(...) }` now maps `BankAccount` as a container with `deposit` nested underneath, instead of showing `deposit` as a top-level orphan.
- **Operator overloads** (#080): `static func + (lhs: T, rhs: T) -> T` inside a struct/class now appears as a nested method in the map, instead of being silently dropped.
- **`deinit` blocks** (#083): `deinit { ... }` inside a class now appears as a nested lifecycle symbol (`deinit: [N-M]`), instead of being invisible.

### Implementation
Replaced the single `SWIFT_DECL_RE` regex with three purpose-specific patterns:
- `SWIFT_CONTAINER_DECL_RE` — containers including `actor`
- `SWIFT_FUNC_DECL_RE` — functions with `[^\s(<]+` name capture (supports symbolic operators)
- `SWIFT_DEINIT_DECL_RE` — standalone `deinit` lifecycle blocks

Updated child nesting from `keyword === "func"` to `keyword === "func" || keyword === "deinit"`.

### Other
- Updated README: 17→19 supported languages, added Swift mapper capability details
- Updated test assertion for language count
- Bumped version to 0.5.1
- Added 3 end-to-end regression tests through `read(path, { map: true })`

## Test results
- **125** test files, **668** tests — all passing
- `tsc --noEmit` — clean

## Fixes
Closes #079, closes #080, closes #083