### PR TITLE
fix: bound grep session payload size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, and bash output compression",
   "type": "module",
   "exports": {

--- a/src/grep-output.ts
+++ b/src/grep-output.ts
@@ -1,7 +1,20 @@
 import type { PtcLine, PtcWarning } from "./ptc-value.js";
+import {
+  DEFAULT_MAX_BYTES,
+  DEFAULT_MAX_LINES,
+  formatSize,
+  truncateHead,
+} from "@mariozechner/pi-coding-agent";
 
 export interface GrepOutputRecord extends PtcLine {
   path: string;
+  kind: "match" | "context";
+}
+
+export interface GrepOutputPtcRecord {
+  path: string;
+  line: number;
+  anchor: string;
   kind: "match" | "context";
 }
 
@@ -42,6 +55,7 @@ export interface BuildGrepOutputInput {
   records: GrepOutputRecord[];
   scopeMode?: "symbol";
   scopeWarnings?: GrepScopeWarning[];
+  passthroughLines?: string[];
 }
 
 export interface GrepOutputResult {
@@ -50,7 +64,7 @@ export interface GrepOutputResult {
     tool: "grep";
     summary: boolean;
     totalMatches: number;
-    records: GrepOutputRecord[];
+    records: GrepOutputPtcRecord[];
     scopes?: {
       mode: "symbol";
       groups: Array<{
@@ -102,7 +116,6 @@ export function buildGrepOutput(input: BuildGrepOutputInput): GrepOutputResult {
   const fileCount = new Set(input.groups.map((group) => group.absolutePath)).size;
   const header = `[${input.totalMatches} matches in ${fileCount} files]`;
   let text: string;
-
   if (input.summary) {
     const fileLines = [...input.groups]
       .sort((a, b) => b.matchCount - a.matchCount)
@@ -118,26 +131,36 @@ export function buildGrepOutput(input: BuildGrepOutputInput): GrepOutputResult {
     }
     text = blocks.join("\n");
   }
-
+  if ((input.passthroughLines?.length ?? 0) > 0) {
+    text += `\n\n${input.passthroughLines!.join("\n")}`;
+  }
   if (input.limit !== undefined && input.totalMatches === input.limit) {
     text += `\n\n[Results truncated at ${input.limit} matches — refine pattern or increase limit]`;
   }
-
   if (!input.summary && input.scopeMode === "symbol" && (input.scopeWarnings?.length ?? 0) > 0) {
     text = `${input.scopeWarnings!.map((warning) => warning.message).join("\n\n")}\n\n${text}`;
   }
-
+  const truncated = truncateHead(text, {
+    maxLines: DEFAULT_MAX_LINES,
+    maxBytes: Math.min(DEFAULT_MAX_BYTES, 50 * 1024),
+  });
+  if (truncated.truncated) {
+    text = `${truncated.content}\n\n[Output truncated: showing ${truncated.outputLines} of ${truncated.totalLines} lines (${formatSize(truncated.outputBytes)} of ${formatSize(truncated.totalBytes)}). Refine pattern or increase limit.]`;
+  }
   const ptcValue: GrepOutputResult["ptcValue"] = {
     tool: "grep",
     summary: input.summary,
     totalMatches: input.totalMatches,
-    records: input.records,
+    records: input.records.map((record) => ({
+      path: record.path,
+      line: record.line,
+      anchor: record.anchor,
+      kind: record.kind,
+    })),
   };
-
   if (!input.summary && input.scopeMode === "symbol") {
     ptcValue.scopes = buildScopeMetadata(input.groups, input.scopeWarnings ?? []);
   }
-
   return {
     text,
     ptcValue,

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -6,7 +6,7 @@ import path from "path";
 import { readFileSync } from "node:fs";
 import { normalizeToLF, stripBom, hasBareCarriageReturn } from "./edit-diff";
 import { looksLikeBinary } from "./binary-detect";
-import { ensureHashInit, formatHashlineDisplay } from "./hashline";
+import { ensureHashInit, formatHashlineDisplay, escapeControlCharsForDisplay } from "./hashline";
 import { buildPtcLine } from "./ptc-value.js";
 import { buildGrepOutput } from "./grep-output.js";
 import { getOrGenerateMap } from "./map-cache.js";
@@ -394,6 +394,7 @@ export function registerGrepTool(pi: ExtensionAPI, options?: { astSearchGuidelin
 			};
 
 			const transformed: string[] = [];
+			const passthroughLines: string[] = [];
 			const recordByRenderedLine = new Map<string, GrepPtcRecord>();
 			let parsedCount = 0;
 			let candidateUnparsedCount = 0;
@@ -406,10 +407,13 @@ export function registerGrepTool(pi: ExtensionAPI, options?: { astSearchGuidelin
 					if (candidateLinePattern.test(line)) {
 						candidateUnparsedCount++;
 					}
+					const trimmed = line.trim();
+					if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+						passthroughLines.push(trimmed);
+					}
 					transformed.push(line);
 					continue;
 				}
-
 				parsedCount++;
 				const absolute = toAbsolutePath(parsed.displayPath);
 				const fileLines = await getFileLines(absolute);
@@ -459,7 +463,8 @@ export function registerGrepTool(pi: ExtensionAPI, options?: { astSearchGuidelin
 				const sourceLine = fileLines?.[parsed.lineNumber - 1] ?? parsed.text;
 				const built = buildPtcLine(parsed.lineNumber, sourceLine);
 				const marker = parsed.kind === "match" ? ">>" : "  ";
-				const renderedLine = `${parsed.displayPath}:${marker}${built.line}:${built.hash}|${built.display}`;
+				const renderedDisplay = escapeControlCharsForDisplay(parsed.text);
+				const renderedLine = `${parsed.displayPath}:${marker}${built.anchor}|${renderedDisplay}`;
 				transformed.push(renderedLine);
 				recordByRenderedLine.set(renderedLine, {
 					path: toAbsolutePath(parsed.displayPath),
@@ -468,7 +473,7 @@ export function registerGrepTool(pi: ExtensionAPI, options?: { astSearchGuidelin
 					anchor: built.anchor,
 					kind: parsed.kind,
 					raw: built.raw,
-					display: built.display,
+					display: renderedDisplay,
 				});
 			}
 
@@ -576,23 +581,29 @@ if (p.scope === "symbol" && !summary) {
 		),
 	);
 }
-	const builtOutput = buildGrepOutput({
-	summary: !!summary,
-	totalMatches: grepIR.totalMatches,
-	groups: renderedGroups,
-	limit: effectiveLimit,
-	records: ptcRecords,
-	scopeMode: p.scope === "symbol" && !summary ? "symbol" : undefined,
-	scopeWarnings,
-});
+			const builtOutput = buildGrepOutput({
+				summary: !!summary,
+				totalMatches: grepIR.totalMatches,
+				groups: renderedGroups,
+				limit: effectiveLimit,
+				records: ptcRecords,
+				scopeMode: p.scope === "symbol" && !summary ? "symbol" : undefined,
+				scopeWarnings,
+				passthroughLines,
+			});
 
+const existingDetails =
+	typeof result.details === "object" && result.details !== null
+		? (result.details as Record<string, unknown>)
+		: {};
+const { linesTruncated: _ignoredLinesTruncated, truncation: _ignoredTruncation, ...compactDetails } = existingDetails;
 return {
 	...result,
 	content: result.content.map((item) =>
 		item === textBlock ? ({ ...item, text: builtOutput.text } as typeof item) : item,
 	),
 	details: {
-		...(typeof result.details === "object" && result.details !== null ? result.details : {}),
+		...compactDetails,
 		ptcValue: builtOutput.ptcValue,
 	},
 };

--- a/tests/grep-builtin-line-truncation.test.ts
+++ b/tests/grep-builtin-line-truncation.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createGrepTool } from "@mariozechner/pi-coding-agent";
+import { registerGrepTool } from "../src/grep.js";
+
+function getText(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+async function runBoth() {
+  const dir = mkdtempSync(join(tmpdir(), "pi-grep-line-truncation-"));
+  const filePath = join(dir, "big.txt");
+  const line = "needle " + "x".repeat(20000);
+  writeFileSync(filePath, line, "utf8");
+
+  const builtin = createGrepTool(process.cwd());
+  let wrapped: any = null;
+  registerGrepTool({ registerTool(def: any) { wrapped = def; } } as any);
+
+  const builtinResult = await builtin.execute(
+    "builtin",
+    {
+      pattern: "needle",
+      path: filePath,
+      literal: true,
+      limit: 100,
+    },
+    new AbortController().signal,
+    () => {},
+  );
+
+  const wrappedResult = await wrapped.execute(
+    "wrapped",
+    {
+      pattern: "needle",
+      path: filePath,
+      literal: true,
+      limit: 100,
+    },
+    new AbortController().signal,
+    () => {},
+    { cwd: process.cwd() },
+  );
+
+  return {
+    builtinText: getText(builtinResult),
+    wrappedText: getText(wrappedResult),
+  };
+}
+
+describe("grep builtin line truncation", () => {
+  it("keeps builtin line truncation markers in wrapped match lines", async () => {
+    const { builtinText, wrappedText } = await runBoth();
+    const builtinFirstLine = builtinText.split("\n")[0] ?? "";
+    const wrappedMatchLine = wrappedText.split("\n").find((line) => line.startsWith("big.txt:>>1:")) ?? "";
+
+    expect(builtinFirstLine.endsWith("... [truncated]")).toBe(true);
+    expect(wrappedMatchLine.endsWith("... [truncated]")).toBe(true);
+  });
+});

--- a/tests/grep-output-budget.test.ts
+++ b/tests/grep-output-budget.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerGrepTool } from "../src/grep.js";
+
+function getText(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+async function callWrapped(params: { pattern: string; path: string; literal?: boolean; limit?: number }) {
+  let capturedTool: any = null;
+  registerGrepTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  if (!capturedTool) throw new Error("grep tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+describe("grep post-transform budgeting", () => {
+  it("adds a truncation notice when rendered hashline output exceeds the final budget", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-grep-budget-"));
+    const line = "needle " + "x".repeat(20000);
+
+    for (let i = 0; i < 12; i++) {
+      const filePath = join(dir, `file-${String(i + 1).padStart(2, "0")}.txt`);
+      writeFileSync(filePath, Array.from({ length: 10 }, () => line).join("\n"), "utf8");
+    }
+
+    const result = await callWrapped({
+      pattern: "needle",
+      path: dir,
+      literal: true,
+      limit: 200,
+    });
+
+    const text = getText(result);
+    expect(text).toContain("[Output truncated:");
+    expect(Buffer.byteLength(JSON.stringify(result))).toBeLessThan(100_000);
+  });
+});

--- a/tests/grep-output-scopes.test.ts
+++ b/tests/grep-output-scopes.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { buildPtcLine } from "../src/ptc-value.js";
 import { ensureHashInit } from "../src/hashline.js";
-import { buildGrepOutput, type GrepOutputRecord } from "../src/grep-output.js";
+import { buildGrepOutput } from "../src/grep-output.js";
 
 describe("buildGrepOutput symbol scope", () => {
   beforeAll(async () => {
     await ensureHashInit();
   });
+
   it("renders grouped symbol blocks and additive scopes metadata without replacing records", () => {
     const absolutePath = "/tmp/scoped.ts";
     const displayPath = "scoped.ts";
@@ -18,10 +19,16 @@ describe("buildGrepOutput symbol scope", () => {
     ];
 
     const ptcLines = rawLines.map((raw, index) => buildPtcLine(index + 1, raw));
-    const records: GrepOutputRecord[] = ptcLines.map((line, index) => ({
+    const records = ptcLines.map((line, index) => ({
       ...line,
       path: absolutePath,
-      kind: index === 1 || index === 2 ? "match" : "context",
+      kind: index === 1 || index === 2 ? ("match" as const) : ("context" as const),
+    }));
+    const compactRecords = ptcLines.map((line, index) => ({
+      path: absolutePath,
+      line: line.line,
+      anchor: line.anchor,
+      kind: index === 1 || index === 2 ? ("match" as const) : ("context" as const),
     }));
 
     const built = buildGrepOutput({
@@ -62,7 +69,8 @@ describe("buildGrepOutput symbol scope", () => {
       `scoped.ts:  ${ptcLines[3].anchor}|${ptcLines[3].display}`,
     ].join("\n"));
 
-    expect(built.ptcValue.records).toEqual(records);
+    expect(Object.keys(built.ptcValue.records[0]).sort()).toEqual(["anchor", "kind", "line", "path"]);
+    expect(built.ptcValue.records).toEqual(compactRecords);
     expect(built.ptcValue.scopes).toEqual({
       mode: "symbol",
       groups: [

--- a/tests/grep-ptc-value.test.ts
+++ b/tests/grep-ptc-value.test.ts
@@ -47,11 +47,11 @@ describe("grep ptcValue", () => {
     const result = await callGrepTool({ pattern: "createDemoDirectory", path: filePath, literal: true, context: 1 });
     const text = getTextContent(result);
     const ptc = result.details?.ptcValue;
-
     expect(ptc).toBeDefined();
     expect(ptc.tool).toBe("grep");
     expect(ptc.summary).toBe(false);
     expect(ptc.totalMatches).toBe(1);
+    expect(Object.keys(ptc.records[0]).sort()).toEqual(["anchor", "kind", "line", "path"]);
     expect(ptc.records).toEqual([
       { lineNumber: 44, kind: "context" as const },
       { lineNumber: 45, kind: "match" as const },
@@ -62,14 +62,10 @@ describe("grep ptcValue", () => {
       return {
         path: filePath,
         line: lineNumber,
-        hash,
         anchor: `${lineNumber}:${hash}`,
         kind,
-        raw,
-        display: escapeControlCharsForDisplay(raw),
       };
     }));
-
     const expectedText = [
       "[1 matches in 1 files]",
       `--- ${displayPath} (1 matches) ---`,
@@ -83,7 +79,6 @@ describe("grep ptcValue", () => {
         return `${displayPath}:${marker}${lineNumber}:${hash}|${escapeControlCharsForDisplay(raw)}`;
       }),
     ].join("\n");
-
     expect(text).toBe(expectedText);
   });
   it("keeps ptc records aligned with the truncated rendered output", async () => {

--- a/tests/repro-093-grep-bloat.test.ts
+++ b/tests/repro-093-grep-bloat.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createGrepTool } from "@mariozechner/pi-coding-agent";
+import { registerGrepTool } from "../src/grep.js";
+
+function getText(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+async function runBoth() {
+  const dir = mkdtempSync(join(tmpdir(), "pi-grep-bloat-"));
+  const filePath = join(dir, "big.txt");
+  const line = "needle " + "x".repeat(20000);
+  writeFileSync(filePath, Array.from({ length: 5 }, () => line).join("\n"), "utf8");
+
+  const builtin = createGrepTool(process.cwd());
+  let wrapped: any = null;
+  registerGrepTool({ registerTool(def: any) { wrapped = def; } } as any);
+
+  const builtinResult = await builtin.execute(
+    "builtin",
+    {
+      pattern: "needle",
+      path: filePath,
+      literal: true,
+      limit: 100,
+    },
+    new AbortController().signal,
+    () => {},
+  );
+
+  const wrappedResult = await wrapped.execute(
+    "wrapped",
+    {
+      pattern: "needle",
+      path: filePath,
+      literal: true,
+      limit: 100,
+    },
+    new AbortController().signal,
+    () => {},
+    { cwd: process.cwd() },
+  );
+
+  return {
+    builtinText: getText(builtinResult),
+    wrappedText: getText(wrappedResult),
+  };
+}
+
+describe("repro 093", () => {
+  it("preserves builtin truncation notices after hashline transformation", async () => {
+    const notice = "[Some lines truncated to 500 chars. Use read tool to see full lines]";
+    const { builtinText, wrappedText } = await runBoth();
+    expect(builtinText.includes(notice)).toBe(true);
+    expect(wrappedText.includes(notice)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the grep wrapper behavior behind issue #30, where a single large grep result could create a multi-megabyte session entry.

This change does three things:

1. **Compacts `details.ptcValue.records`**
   - stores only the fields downstream consumers need: `path`, `line`, `anchor`, `kind`
   - drops redundant `raw`, `display`, and duplicate hash-heavy payload from the structured result

2. **Adds a hard post-transform output cap**
   - applies a final truncation pass after hashline rendering
   - appends an explicit `[Output truncated: ...]` notice when the wrapped result exceeds the final output budget

3. **Preserves builtin truncation/warning notices**
   - carries through bracketed builtin grep notices so users still see line truncation guidance from the underlying tool

Also bumps the package version to **0.5.2** for npm publish.

## Why this addresses issue #30

The issue reported two separate sources of bloat:

- oversized rendered grep output
- oversized `details.ptcValue.records` payload, especially when raw/display data duplicated the rendered content

This PR now bounds both layers:

- rendered output is capped after the wrapper finishes transforming the builtin grep response
- structured records are reduced to a compact shape instead of repeating line content in metadata

## Verification

### Focused regressions

Ran:

```bash
npx vitest run \
  tests/grep-ptc-value.test.ts \
  tests/grep-output-scopes.test.ts \
  tests/grep-builtin-line-truncation.test.ts \
  tests/repro-093-grep-bloat.test.ts \
  tests/grep-output-budget.test.ts
```

Result: **5 files passed, 7 tests passed**

### Full validation

```bash
npm run typecheck
npm test
npm pack --dry-run
```

Result:
- `tsc --noEmit` passed
- full test suite passed: **141 files / 699 tests**
- dry-run pack succeeded for `pi-hashline-readmap@0.5.2`

### Live tool confirmation

Using the actual wrapped `grep` tool in this session against generated 20k-character matching lines:

- output retained builtin per-line `... [truncated]` markers
- output appended a final wrapper-level notice:
  - `[Output truncated: showing 105 of 109 lines (49.6KB of 50.7KB). Refine pattern or increase limit.]`
- compact structured payload measured at about **9.6 KB** for **96 records**
- each record contained only:
  - `anchor`, `kind`, `line`, `path`

## Files changed

- `src/grep.ts`
- `src/grep-output.ts`
- `tests/grep-ptc-value.test.ts`
- `tests/grep-output-scopes.test.ts`
- `tests/grep-builtin-line-truncation.test.ts`
- `tests/grep-output-budget.test.ts`
- `tests/repro-093-grep-bloat.test.ts`
- `package.json`
- `package-lock.json`

Closes #30.
