### PR TITLE
fix: warn on conflicting duplicate single-target hashline edits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, and bash output compression",
   "type": "module",
   "exports": {

--- a/src/hashline.ts
+++ b/src/hashline.ts
@@ -512,8 +512,13 @@ export function applyHashlineEdits(
 	// Recompute after potential relocation
 	explicitlyTouchedLines = collectExplicitlyTouchedLines();
 
-	// Deduplicate identical edits
-	const seen = new Map<string, number>();
+	// Detect conflicting duplicate single-target edits and deduplicate identical edits.
+	// For single-target edits, keep the last identical occurrence so resolution remains last-wins.
+	const duplicateTargetWarnings: string[] = [];
+	const warnedSingleTargets = new Set<string>();
+	const seenSingleTargets = new Map<string, string>();
+	const seenSingleEditByKey = new Map<string, number>();
+	const seenNonSingleEditByKey = new Map<string, number>();
 	const dupes = new Set<number>();
 	for (let i = 0; i < parsed.length; i++) {
 		throwIfAborted(signal);
@@ -524,9 +529,27 @@ export function applyHashlineEdits(
 				: p.spec.kind === "range"
 					? `r:${p.spec.start.line}:${p.spec.end.line}`
 					: `i:${p.spec.after.line}`;
-		const key = `${lk}|${p.dstLines.join("\n")}`;
-		if (seen.has(key)) dupes.add(i);
-		else seen.set(key, i);
+		const dstKey = p.dstLines.join("\n");
+		const key = `${lk}|${dstKey}`;
+		if (p.spec.kind === "single") {
+			const previousIdx = seenSingleEditByKey.get(key);
+			if (previousIdx !== undefined) dupes.add(previousIdx);
+			seenSingleEditByKey.set(key, i);
+			const previousDstKey = seenSingleTargets.get(lk);
+			if (previousDstKey !== undefined && previousDstKey !== dstKey && !warnedSingleTargets.has(lk)) {
+				duplicateTargetWarnings.push(
+					`Warning: multiple edits target the same anchor ${p.spec.ref.line}:${p.spec.ref.hash} — only the last will apply`,
+				);
+				warnedSingleTargets.add(lk);
+			}
+			seenSingleTargets.set(lk, dstKey);
+			continue;
+		}
+		if (seenNonSingleEditByKey.has(key)) {
+			dupes.add(i);
+		} else {
+			seenNonSingleEditByKey.set(key, i);
+		}
 	}
 	const deduped = parsed.filter((_, i) => !dupes.has(i));
 
@@ -653,7 +676,7 @@ export function applyHashlineEdits(
 		}
 	}
 
-	const warnings: string[] = [...relocationNotes];
+	const warnings: string[] = [...relocationNotes, ...duplicateTargetWarnings];
 	let diff = Math.abs(fileLines.length - origLines.length);
 	for (let i = 0; i < Math.min(fileLines.length, origLines.length); i++) {
 		if (fileLines[i] !== origLines[i]) diff++;

--- a/tests/hashline-duplicate-single-target-warning.test.ts
+++ b/tests/hashline-duplicate-single-target-warning.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { applyHashlineEdits, computeLineHash, ensureHashInit } from "../src/hashline.js";
+
+describe("duplicate single-target hashline warnings", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("warns for same-line replace_lines conflicts and keeps the last effective single-target edit", () => {
+    const content = ["const a = 1;", "const b = 2;", "const c = 3;"].join("\n");
+    const anchor = `2:${computeLineHash(2, "const b = 2;")}`;
+
+    const result = applyHashlineEdits(content, [
+      { replace_lines: { start_anchor: anchor, end_anchor: anchor, new_text: "const b = 20;" } },
+      { replace_lines: { start_anchor: anchor, end_anchor: anchor, new_text: "const b = 200;" } },
+      { replace_lines: { start_anchor: anchor, end_anchor: anchor, new_text: "const b = 20;" } },
+    ]);
+
+    expect(result.content).toBe(["const a = 1;", "const b = 20;", "const c = 3;"].join("\n"));
+    expect(result.warnings).toContain(
+      `Warning: multiple edits target the same anchor ${anchor} — only the last will apply`,
+    );
+  });
+});

--- a/tests/hashline-identical-duplicate-single-target.test.ts
+++ b/tests/hashline-identical-duplicate-single-target.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { applyHashlineEdits, computeLineHash, ensureHashInit } from "../src/hashline.js";
+describe("identical duplicate single-target edits", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+  it("silently deduplicates identical replacements without warning", () => {
+    const content = ["const a = 1;", "const b = 2;", "const c = 3;"].join("\n");
+    const anchor = `3:${computeLineHash(3, "const c = 3;")}`;
+    const result = applyHashlineEdits(content, [
+      { set_line: { anchor, new_text: "const c = 30;" } },
+      { set_line: { anchor, new_text: "const c = 30;" } },
+    ]);
+    expect(result.content).toBe(["const a = 1;", "const b = 2;", "const c = 30;"].join("\n"));
+    expect(result.warnings).toBeUndefined();
+  });
+});

--- a/tests/repro-082-duplicate-anchor-warning.test.ts
+++ b/tests/repro-082-duplicate-anchor-warning.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+import { registerEditTool } from "../src/edit.js";
+
+function captureEditTool() {
+  let capturedTool: any = null;
+  registerEditTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  if (!capturedTool) throw new Error("edit tool was not registered");
+  return capturedTool;
+}
+
+function getTextContent(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("issue #082 reproduction — duplicate anchors in one edit batch", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("warns when multiple set_line operations target the same anchor in one batch", async () => {
+    const tool = captureEditTool();
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-repro-082-"));
+    const filePath = resolve(dir, "sample.ts");
+    writeFileSync(filePath, ["const a = 1;", "const b = 2;", "const c = 3;"].join("\n"), "utf8");
+
+    try {
+      const originalLines = readFileSync(filePath, "utf8").split("\n");
+      const anchor = `3:${computeLineHash(3, originalLines[2])}`;
+
+      const result = await tool.execute(
+        "repro-082-duplicate-anchor-warning",
+        {
+          path: filePath,
+          edits: [
+            { set_line: { anchor, new_text: "const c = 30;" } },
+            { set_line: { anchor, new_text: "const c = 300;" } },
+          ],
+        },
+        new AbortController().signal,
+        () => {},
+        { cwd: process.cwd() },
+      );
+
+      expect(readFileSync(filePath, "utf8")).toContain("const c = 300;");
+      expect(result.details?.ptcValue?.warnings).toContain(
+        `Warning: multiple edits target the same anchor ${anchor} — only the last will apply`,
+      );
+      expect(getTextContent(result)).toContain(
+        `Warning: multiple edits target the same anchor ${anchor} — only the last will apply`,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- warn when a single edit batch contains conflicting duplicate single-target anchor edits
- move duplicate-target detection into `applyHashlineEdits()` so same-line `replace_lines` and `set_line` share the same behavior
- keep identical duplicate single-target edits silent while preserving last-wins resolution
- bump package version to `0.5.3` for publishing this fix

## What changed
- added a reproduction test for the original duplicate-anchor edit-tool symptom
- added shared-engine coverage for conflicting same-line `replace_lines`
- added a regression test proving identical duplicate single-target edits stay silent
- updated `src/hashline.ts` to emit conflict warnings from the shared engine and preserve existing warning paths

## Verification
- `npm test`
- `npx vitest run tests/repro-082-duplicate-anchor-warning.test.ts`
- `npx vitest run tests/hashline-duplicate-single-target-warning.test.ts tests/hashline-identical-duplicate-single-target.test.ts tests/edit-ptc-value.test.ts tests/adaptive-relocation-window.test.ts`
