### PR TITLE
fix: read tool rejects non-positive offset/limit values (#081)

### DIFF
--- a/prompts/read.md
+++ b/prompts/read.md
@@ -6,6 +6,7 @@ Default limit: {{DEFAULT_MAX_LINES}} lines or {{DEFAULT_MAX_BYTES}}.
 When a file is truncated (exceeds {{DEFAULT_MAX_LINES}} lines or {{DEFAULT_MAX_BYTES}}), a **structural map** is appended after the hashlined content showing file symbols (classes, functions, interfaces, etc.) with line ranges.
 
 Use the appended map for targeted reads with `offset` and `limit` — e.g., `read(path, { offset: LINE, limit: N })`.
+When provided, `offset` and `limit` must be positive integers; `0` and negative values are invalid.
 
 Maps support 17 languages (including TypeScript, Python, Rust, Go, C/C++, Java, and more) and are cached in memory by file modification time for fast repeated access.
 

--- a/src/read-render-helpers.ts
+++ b/src/read-render-helpers.ts
@@ -20,7 +20,13 @@ export function formatReadCallText(
   if (typeof args?.offset === "number") {
     const offset = args.offset as number;
     const limit = typeof args?.limit === "number" ? (args.limit as number) : undefined;
+    if (offset < 1) {
+      return { path: rawPath, suffix: undefined };
+    }
     if (limit !== undefined) {
+      if (limit < 1) {
+        return { path: rawPath, suffix: undefined };
+      }
       return { path: rawPath, suffix: `lines ${offset}-${offset + limit - 1}` };
     }
     return { path: rawPath, suffix: `from line ${offset}` };

--- a/src/read.ts
+++ b/src/read.ts
@@ -98,6 +98,20 @@ export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}
 					details: {},
 				};
 			}
+			if (limit.value !== undefined && limit.value < 1) {
+				return {
+					content: [{ type: "text", text: `Invalid limit: expected a positive integer, received ${limit.value}.` }],
+					isError: true,
+					details: {},
+				};
+			}
+			if (offset.value !== undefined && offset.value < 1) {
+				return {
+					content: [{ type: "text", text: `Invalid offset: expected a positive integer, received ${offset.value}.` }],
+					isError: true,
+					details: {},
+				};
+			}
 			const p = {
 				...rawParams,
 				offset: offset.value,
@@ -189,9 +203,9 @@ export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}
 			const allLines = normalized.split("\n");
 			const total = allLines.length;
 			const structuredWarnings: PtcWarning[] = [];
-			let startLine = p.offset ? Math.max(1, Number(p.offset)) : 1;
-			let endIdx = p.limit ? Math.min(startLine - 1 + Number(p.limit), total) : total;
-			if (p.offset && startLine > total) {
+			let startLine = p.offset !== undefined ? p.offset : 1;
+			let endIdx = p.limit !== undefined ? Math.min(startLine - 1 + p.limit, total) : total;
+			if (p.offset !== undefined && startLine > total) {
 				return {
 					content: [{ type: "text", text: `[offset ${p.offset} is past end of file (${total} lines)]` }],
 					isError: true,

--- a/tests/read-render-helpers-invalid-pagination.test.ts
+++ b/tests/read-render-helpers-invalid-pagination.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { formatReadCallText } from "../src/read-render-helpers.js";
+
+describe("formatReadCallText invalid pagination", () => {
+  it("omits numeric suffixes when offset or limit is not positive", () => {
+    const negativeOffset = formatReadCallText({ path: "src/foo.ts", offset: -5 });
+    expect(negativeOffset.suffix).toBeUndefined();
+
+    const zeroOffset = formatReadCallText({ path: "src/foo.ts", offset: 0, limit: 1 });
+    expect(zeroOffset.suffix).toBeUndefined();
+
+    const zeroLimit = formatReadCallText({ path: "src/foo.ts", offset: 1, limit: 0 });
+    expect(zeroLimit.suffix).toBeUndefined();
+
+    const validRange = formatReadCallText({ path: "src/foo.ts", offset: 10, limit: 20 });
+    expect(validRange).toEqual({ path: "src/foo.ts", suffix: "lines 10-29" });
+  });
+});

--- a/tests/repro-081-invalid-offset.test.ts
+++ b/tests/repro-081-invalid-offset.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { registerReadTool } from "../src/read.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+function captureReadTool() {
+  let capturedTool: any;
+  registerReadTool(
+    {
+      registerTool(def: any) {
+        capturedTool = def;
+      },
+    } as any,
+  );
+  return capturedTool;
+}
+
+function getTextContent(result: any): string {
+  return result.content?.find((item: any) => item.type === "text")?.text ?? "";
+}
+
+describe("issue #081 regression — invalid offset", () => {
+  it("rejects negative and zero offsets instead of clamping or treating them as missing", async () => {
+    const tool = captureReadTool();
+    const filePath = resolve(fixturesDir, "small.ts");
+
+    const negativeOffset = await tool.execute(
+      "read-081-negative-offset",
+      { path: filePath, offset: -5 },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    expect(negativeOffset.isError).toBe(true);
+    expect(getTextContent(negativeOffset)).toBe("Invalid offset: expected a positive integer, received -5.");
+    expect(negativeOffset.details?.ptcValue).toBeUndefined();
+
+    const zeroOffset = await tool.execute(
+      "read-081-zero-offset",
+      { path: filePath, offset: "0" },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    expect(zeroOffset.isError).toBe(true);
+    expect(getTextContent(zeroOffset)).toBe("Invalid offset: expected a positive integer, received 0.");
+    expect(zeroOffset.details?.ptcValue).toBeUndefined();
+  });
+});

--- a/tests/repro-081-negative-limit.test.ts
+++ b/tests/repro-081-negative-limit.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerReadTool } from "../src/read.js";
+
+function captureReadTool() {
+  let capturedTool: any;
+  registerReadTool(
+    {
+      registerTool(def: any) {
+        capturedTool = def;
+      },
+    } as any,
+  );
+  return capturedTool;
+}
+
+function getTextContent(result: any): string {
+  return result.content?.find((item: any) => item.type === "text")?.text ?? "";
+}
+
+describe("issue #081 regression — negative limit", () => {
+  it("returns a clear error instead of a garbled range for the exact reproduction steps", async () => {
+    const tool = captureReadTool();
+    const dir = mkdtempSync(join(tmpdir(), "pi-read-081-neg-limit-"));
+    const filePath = join(dir, "pi-read-negative-noeof.ts");
+    writeFileSync(filePath, "const x = 1;", "utf8");
+
+    try {
+      const result = await tool.execute(
+        "read-081-negative-limit",
+        { path: filePath, offset: -5, limit: -10 },
+        new AbortController().signal,
+        () => {},
+        { cwd: process.cwd() },
+      );
+
+      expect(result.isError).toBe(true);
+      expect(getTextContent(result)).toBe("Invalid limit: expected a positive integer, received -10.");
+      expect(result.details?.ptcValue).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/repro-081-zero-limit.test.ts
+++ b/tests/repro-081-zero-limit.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { registerReadTool } from "../src/read.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+function captureReadTool() {
+  let capturedTool: any;
+  registerReadTool(
+    {
+      registerTool(def: any) {
+        capturedTool = def;
+      },
+    } as any,
+  );
+  return capturedTool;
+}
+
+function getTextContent(result: any): string {
+  return result.content?.find((item: any) => item.type === "text")?.text ?? "";
+}
+
+describe("issue #081 regression — zero limit", () => {
+  it("treats numeric and string zero limits as invalid instead of as 'no limit'", async () => {
+    const tool = captureReadTool();
+    const filePath = resolve(fixturesDir, "small.ts");
+
+    const numericZero = await tool.execute(
+      "read-081-zero-limit-number",
+      { path: filePath, limit: 0 },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    expect(numericZero.isError).toBe(true);
+    expect(getTextContent(numericZero)).toBe("Invalid limit: expected a positive integer, received 0.");
+    expect(numericZero.details?.ptcValue).toBeUndefined();
+
+    const stringZero = await tool.execute(
+      "read-081-zero-limit-string",
+      { path: filePath, limit: "0" },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    expect(stringZero.isError).toBe(true);
+    expect(getTextContent(stringZero)).toBe("Invalid limit: expected a positive integer, received 0.");
+    expect(stringZero.details?.ptcValue).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Read tool now returns explicit errors for non-positive `offset` and `limit` values instead of silently clamping them.

### Changes
- `src/read.ts`: Validate offset < 1 and limit < 1 with clear error messages; remove `Math.max(1, ...)` clamping
- `src/read-render-helpers.ts`: Guard `formatReadCallText` against invalid pagination ranges  
- `prompts/read.md`: Document that offset and limit must be positive integers

### Tests
- `tests/repro-081-invalid-offset.test.ts` — offset 0 and negative offset
- `tests/repro-081-negative-limit.test.ts` — negative limit
- `tests/repro-081-zero-limit.test.ts` — limit 0
- `tests/read-render-helpers-invalid-pagination.test.ts` — renderCall guards

Closes #081