### PR TITLE
edit: surface semantic annotations and replace-only guidance

### DIFF
--- a/prompts/edit.md
+++ b/prompts/edit.md
@@ -161,3 +161,5 @@ edit({ path: "src/new-file.ts", edits: [{ set_line: { anchor: "1:2f9", new_text:
 - Prefer anchored variants over `replace`.
 - Re-run `read`, `grep`, `ast_search`, or `write` whenever you need fresh anchors.
 - Anchored edits are validated and applied atomically from bottom to top.
+- If a non-whitespace-intent edit produces only whitespace-only changes, the tool emits a prominent warning so you can re-read and verify before assuming behavior changed.
+- After a successful replace-only batch, the tool emits an informational hint nudging you back toward anchored variants for safer future edits.

--- a/src/edit-output.ts
+++ b/src/edit-output.ts
@@ -1,5 +1,5 @@
+import { countEditTypes, parseDiffStats } from "./edit-render-helpers.js";
 import { buildPtcEditResult, type SemanticSummary } from "./ptc-value.js";
-
 export interface BuildEditOutputInput {
   path: string;
   displayPath: string;
@@ -8,18 +8,69 @@ export interface BuildEditOutputInput {
   warnings: string[];
   noopEdits: unknown[];
   semanticSummary?: SemanticSummary;
+  edits?: unknown[];
 }
-
 export interface EditOutputResult {
   text: string;
   ptcValue: ReturnType<typeof buildPtcEditResult>;
 }
-
+function getVisibleDiffStats(diff: string): { added: number; removed: number } {
+  const stats = parseDiffStats(diff);
+  if (stats.added > 0 || stats.removed > 0) return stats;
+  if (!diff.includes("→")) return stats;
+  if (diff.includes("→ [deleted]")) return { added: 0, removed: 1 };
+  return { added: 1, removed: 1 };
+}
+function buildVisibleSummary(displayPath: string, diff: string, edits: unknown[] | undefined): string {
+  const stats = getVisibleDiffStats(diff);
+  const counts = countEditTypes(edits);
+  const editCount = counts.total || 1;
+  const changeWord = editCount === 1 ? "change" : "changes";
+  const changedLineCount = Math.max(stats.added, stats.removed);
+  const lineWord = changedLineCount === 1 ? "line" : "lines";
+  return `Edited ${displayPath} (${editCount} ${changeWord}, +${stats.added} -${stats.removed} ${lineWord})`;
+}
+function extractNewTextValues(edits: unknown[] | undefined): string[] {
+  const values: string[] = [];
+  for (const edit of edits ?? []) {
+    if (!edit || typeof edit !== "object") continue;
+    if ("set_line" in edit && typeof (edit as any).set_line?.new_text === "string") values.push((edit as any).set_line.new_text);
+    if ("replace_lines" in edit && typeof (edit as any).replace_lines?.new_text === "string") values.push((edit as any).replace_lines.new_text);
+    if ("insert_after" in edit && typeof (edit as any).insert_after?.new_text === "string") values.push((edit as any).insert_after.new_text);
+    if ("replace" in edit && typeof (edit as any).replace?.new_text === "string") values.push((edit as any).replace.new_text);
+  }
+  return values;
+}
+function formatWhitespaceOnlyWarning(semanticSummary: SemanticSummary | undefined, edits: unknown[] | undefined): string | undefined {
+  if (semanticSummary?.classification !== "whitespace-only") return undefined;
+  if (!extractNewTextValues(edits).some((text) => /\S/.test(text))) return undefined;
+  return "⚠ Edit classified as whitespace-only — if you intended a behavior change, re-read to verify.";
+}
+function formatSemanticSuffix(semanticSummary: SemanticSummary | undefined): string {
+  const movedBlocks = semanticSummary?.movedBlocks ?? 0;
+  if (movedBlocks <= 0) return "";
+  const blockWord = movedBlocks === 1 ? "block" : "blocks";
+  return ` [semantic: ${semanticSummary!.classification}, ${movedBlocks} ${blockWord} moved]`;
+}
+function formatReplaceHint(edits: unknown[] | undefined, noopEdits: unknown[]): string | undefined {
+  if ((noopEdits ?? []).length > 0) return undefined;
+  const counts = countEditTypes(edits);
+  if (counts.replace === 0) return undefined;
+  if (counts.replace !== counts.total) return undefined;
+  return "[info: this edit used replace (unverified). For safer future edits, prefer set_line/replace_lines with an anchor from read/grep/ast_search.]";
+}
 export function buildEditOutput(input: BuildEditOutputInput): EditOutputResult {
   const summary = `Updated ${input.displayPath}`;
+  const visibleSummary = `${buildVisibleSummary(input.displayPath, input.diff, input.edits)}${formatSemanticSuffix(input.semanticSummary)}`;
+  const semanticWarning = formatWhitespaceOnlyWarning(input.semanticSummary, input.edits);
   const warningText = input.warnings.length ? `\n\nWarnings:\n${input.warnings.join("\n")}` : "";
+  const replaceHint = formatReplaceHint(input.edits, input.noopEdits);
+  let text = visibleSummary;
+  if (semanticWarning) text += `\n${semanticWarning}`;
+  text += warningText;
+  if (replaceHint) text += `\n${replaceHint}`;
   return {
-    text: `${summary}${warningText}`,
+    text,
     ptcValue: buildPtcEditResult({
       path: input.path,
       summary,

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -284,6 +284,7 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				firstChangedLine: anchorResult.firstChangedLine ?? diffResult.firstChangedLine,
 				warnings,
 				noopEdits: anchorResult.noopEdits ?? [],
+				edits,
 				semanticSummary,
 			});
 

--- a/tests/edit-output-semantic.test.ts
+++ b/tests/edit-output-semantic.test.ts
@@ -1,12 +1,10 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { ensureHashInit } from "../src/hashline.js";
 import { buildEditOutput } from "../src/edit-output.js";
-
 describe("buildEditOutput semanticSummary", () => {
   beforeAll(async () => {
     await ensureHashInit();
   });
-
   it("includes semanticSummary in ptcValue when provided", () => {
     const result = buildEditOutput({
       path: "/tmp/test.ts",
@@ -15,6 +13,7 @@ describe("buildEditOutput semanticSummary", () => {
       firstChangedLine: 1,
       warnings: [],
       noopEdits: [],
+      edits: [{ set_line: { anchor: "1:abc", new_text: "const x = 10;" } }],
       semanticSummary: {
         classification: "semantic",
         difftasticAvailable: true,
@@ -28,7 +27,6 @@ describe("buildEditOutput semanticSummary", () => {
       movedBlocks: 0,
     });
   });
-
   it("omits semanticSummary from ptcValue when not provided", () => {
     const result = buildEditOutput({
       path: "/tmp/test.ts",
@@ -37,32 +35,64 @@ describe("buildEditOutput semanticSummary", () => {
       firstChangedLine: 1,
       warnings: [],
       noopEdits: [],
+      edits: [{ set_line: { anchor: "1:abc", new_text: "const x = 10;" } }],
     });
-
     expect(result.ptcValue.semanticSummary).toBeUndefined();
   });
-
-  it("preserves existing ptcValue fields when semanticSummary is present", () => {
+  it("stays quiet for mixed classifications when no blocks moved", () => {
     const result = buildEditOutput({
       path: "/tmp/test.ts",
       displayPath: "test.ts",
-      diff: "+1 const x = 10;",
+      diff: [
+        "--- a/test.ts",
+        "+++ b/test.ts",
+        "@@ -1 +1 @@",
+        "-const value = 1;",
+        "+const value = 2; ",
+      ].join("\n"),
       firstChangedLine: 1,
-      warnings: ["some warning"],
+      warnings: [],
       noopEdits: [],
+      edits: [{ set_line: { anchor: "1:abc", new_text: "const value = 2; " } }],
       semanticSummary: {
-        classification: "whitespace-only",
+        classification: "mixed",
         difftasticAvailable: false,
+        movedBlocks: 0,
       },
     });
 
-    expect(result.ptcValue.tool).toBe("edit");
-    expect(result.ptcValue.ok).toBe(true);
-    expect(result.ptcValue.path).toBe("/tmp/test.ts");
-    expect(result.ptcValue.warnings).toEqual(["some warning"]);
+    expect(result.text).toBe("Edited test.ts (1 change, +1 -1 line)");
+    expect(result.text).not.toContain("[semantic:");
+    expect(result.text).not.toContain("⚠ Edit classified as whitespace-only");
+  });
+  it("preserves movedBlocks in ptcValue without changing the semanticSummary shape", () => {
+    const result = buildEditOutput({
+      path: "/tmp/test.ts",
+      displayPath: "test.ts",
+      diff: [
+        "--- a/test.ts",
+        "+++ b/test.ts",
+        "@@ -1,2 +1,2 @@",
+        "-const a = 1;",
+        "-const b = 2;",
+        "+const b = 2;",
+        "+const a = 1;",
+      ].join("\n"),
+      firstChangedLine: 1,
+      warnings: [],
+      noopEdits: [],
+      edits: [{ replace_lines: { start_anchor: "1:abc", end_anchor: "2:def", new_text: "const b = 2;\nconst a = 1;" } }],
+      semanticSummary: {
+        classification: "mixed",
+        difftasticAvailable: true,
+        movedBlocks: 2,
+      },
+    });
+
     expect(result.ptcValue.semanticSummary).toEqual({
-      classification: "whitespace-only",
-      difftasticAvailable: false,
+      classification: "mixed",
+      difftasticAvailable: true,
+      movedBlocks: 2,
     });
   });
 });

--- a/tests/edit-output.test.ts
+++ b/tests/edit-output.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { ensureHashInit, computeLineHash } from "../src/hashline.js";
 import * as editModule from "../src/edit.js";
 import * as editOutputModule from "../src/edit-output.js";
-
+import { buildEditOutput } from "../src/edit-output.js";
 async function callEditTool(params: Record<string, unknown>) {
   let capturedTool: any = null;
   const mockPi = { registerTool(def: any) { capturedTool = def; } };
@@ -13,7 +13,6 @@ async function callEditTool(params: Record<string, unknown>) {
   if (!capturedTool) throw new Error("edit tool was not registered");
   return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
 }
-
 function makeFixtureFile(): string {
   const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-output-"));
   const filePath = resolve(dir, "sample.ts");
@@ -24,27 +23,22 @@ function makeFixtureFile(): string {
   ].join("\n"), "utf-8");
   return filePath;
 }
-
 function getTextContent(result: any): string {
   return result.content.find((c: any) => c.type === "text")?.text ?? "";
 }
-
 describe("buildEditOutput", () => {
   beforeAll(async () => {
     await ensureHashInit();
   });
-
   afterEach(() => {
     vi.restoreAllMocks();
   });
-
   it("projects successful anchor-edit results through one shared builder", async () => {
     const spy = vi.spyOn(editOutputModule, "buildEditOutput");
     const filePath = makeFixtureFile();
     const originalLines = readFileSync(filePath, "utf-8").split("\n");
     const anchor1 = `1:${computeLineHash(1, originalLines[0])}`;
     const anchor2 = `2:${computeLineHash(2, originalLines[1])}`;
-
     const result = await callEditTool({
       path: filePath,
       edits: [
@@ -54,11 +48,23 @@ describe("buildEditOutput", () => {
     });
 
     const built = spy.mock.results.at(-1)?.value;
-    expect(built.text).toBe(`Updated ${filePath}`);
+    expect(built.text).toContain(`Edited ${filePath} (2 changes, +1 -1 line)`);
+    expect(built.ptcValue.summary).toBe(`Updated ${filePath}`);
     expect(getTextContent(result)).toBe(built.text);
     expect(result.details?.ptcValue).toEqual(built.ptcValue);
   });
-
+  it("pluralizes the visible summary for single-line insert diffs", () => {
+    const insertOnly = buildEditOutput({
+      path: "/tmp/test.ts",
+      displayPath: "test.ts",
+      diff: "@@ -1 +1,2 @@\n const x = 1;\n+const y = 2;",
+      firstChangedLine: 1,
+      warnings: [],
+      noopEdits: [],
+      edits: [{ insert_after: { anchor: "1:abc", new_text: "const y = 2;\n" } }],
+    });
+    expect(insertOnly.text).toContain("Edited test.ts (1 change, +1 -0 line)");
+  });
   it("projects legacy normalization warnings through the shared builder", async () => {
     const spy = vi.spyOn(editOutputModule, "buildEditOutput");
     const filePath = makeFixtureFile();

--- a/tests/edit-prompt-coverage.test.ts
+++ b/tests/edit-prompt-coverage.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 describe("prompts/edit.md coverage", () => {
-  it("documents recovery, variants, escape-hatch replace, and all anchor sources", () => {
+  it("documents recovery, variants, escape-hatch replace, anchor sources, whitespace warnings, and replace nudges", () => {
     const content = readFileSync(resolve("prompts/edit.md"), "utf8");
 
     expect(content).toContain("hash mismatch");
@@ -18,6 +18,10 @@ describe("prompts/edit.md coverage", () => {
     expect(content).toContain("grep");
     expect(content).toContain("ast_search");
     expect(content).toContain("write");
+    expect(content).toContain("non-whitespace-intent edit");
+    expect(content).toContain("whitespace-only changes");
+    expect(content).toContain("replace-only batch");
+    expect(content).toContain("anchored variants");
     expect(content.split("\n").length).toBeGreaterThanOrEqual(80);
   });
 });

--- a/tests/edit-ptc-value.test.ts
+++ b/tests/edit-ptc-value.test.ts
@@ -38,7 +38,6 @@ describe("edit ptcValue", () => {
     const originalLines = readFileSync(filePath, "utf-8").split("\n");
     const anchor1 = `1:${computeLineHash(1, originalLines[0])}`;
     const anchor2 = `2:${computeLineHash(2, originalLines[1])}`;
-
     const result = await callEditTool({
       path: filePath,
       edits: [
@@ -46,14 +45,12 @@ describe("edit ptcValue", () => {
         { set_line: { anchor: anchor2, new_text: "const two = 22;" } },
       ],
     });
-
     const text = getTextContent(result);
     const ptc = result.details?.ptcValue;
-
     expect(ptc).toBeDefined();
     expect(ptc.ok).toBe(true);
     expect(ptc.path).toBe(filePath);
-    expect(ptc.summary).toContain("Updated");
+    expect(ptc.summary).toBe(`Updated ${filePath}`);
     expect(ptc.firstChangedLine).toBe(2);
     expect(ptc.diff).toContain("const two = 2;");
     expect(ptc.diff).toContain("const two = 22;");
@@ -65,7 +62,7 @@ describe("edit ptcValue", () => {
         currentContent: "const one = 1;",
       },
     ]);
-    expect(text.startsWith("Updated")).toBe(true);
+    expect(text.split("\n")[0]).toBe(`Edited ${filePath} (2 changes, +1 -1 line)`);
   });
 
   it("returns legacy normalization warning when using top-level oldText/newText", async () => {

--- a/tests/edit-replace-hint.test.ts
+++ b/tests/edit-replace-hint.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+import { registerEditTool } from "../src/edit.js";
+
+const INFO_HINT = "[info: this edit used replace (unverified). For safer future edits, prefer set_line/replace_lines with an anchor from read/grep/ast_search.]";
+
+async function callEditTool(params: Record<string, unknown>) {
+  let capturedTool: any = null;
+  registerEditTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  if (!capturedTool) throw new Error("edit tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function makeFixture(content: string): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-replace-hint-"));
+  const filePath = resolve(dir, "sample.ts");
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+function getTextContent(result: any): string {
+  return result.content.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("edit replace hint", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("adds the info line for successful replace-only batches", async () => {
+    const filePath = makeFixture("const value = 1;\n");
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ replace: { old_text: "const value = 1;", new_text: "const value = 2;" } }],
+    });
+
+    const text = getTextContent(result);
+    expect(result.isError).not.toBe(true);
+    expect(text).toContain(INFO_HINT);
+    expect(text.split("\n").at(-1)).toBe(INFO_HINT);
+  });
+
+  it("omits the info line for anchored-only batches", async () => {
+    const filePath = makeFixture("const value = 1;\n");
+    const anchor = `1:${computeLineHash(1, "const value = 1;")}`;
+
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ set_line: { anchor, new_text: "const value = 2;" } }],
+    });
+
+    expect(getTextContent(result)).not.toContain(INFO_HINT);
+  });
+
+  it("omits the info line for mixed anchored-plus-replace batches", async () => {
+    const filePath = makeFixture("const one = 1;\nconst two = 2;\n");
+    const anchor = `1:${computeLineHash(1, "const one = 1;")}`;
+
+    const result = await callEditTool({
+      path: filePath,
+      edits: [
+        { set_line: { anchor, new_text: "const one = 11;" } },
+        { replace: { old_text: "const two = 2;", new_text: "const two = 22;" } },
+      ],
+    });
+
+    expect(getTextContent(result)).not.toContain(INFO_HINT);
+  });
+
+  it("puts the info line after warnings for legacy replace-only success", async () => {
+    const filePath = makeFixture("const two = 2;\n");
+    const result = await callEditTool({
+      path: filePath,
+      oldText: "const two = 2;",
+      newText: "const two = 22;",
+    });
+
+    const text = getTextContent(result);
+    expect(result.isError).not.toBe(true);
+    expect(text).toContain("Warnings:");
+    expect(text).toContain(INFO_HINT);
+    expect(text.indexOf("Warnings:")).toBeLessThan(text.indexOf(INFO_HINT));
+    expect(text.split("\n").at(-1)).toBe(INFO_HINT);
+  });
+
+  it("suppresses the info line for replace no-op results", async () => {
+    const filePath = makeFixture("const value = 1;\n");
+    let error: unknown;
+    try {
+      await callEditTool({
+        path: filePath,
+        edits: [{ replace: { old_text: "const value = 1;", new_text: "const value = 1;" } }],
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    expect(String((error as any)?.message ?? error)).toContain("No changes made to");
+    expect(String((error as any)?.message ?? error)).not.toContain(INFO_HINT);
+});
+});

--- a/tests/edit-semantic-integration.test.ts
+++ b/tests/edit-semantic-integration.test.ts
@@ -55,19 +55,17 @@ describe("edit semantic classification integration", () => {
     expect(ptc.semanticSummary.classification).toBe("whitespace-only");
   });
 
-  it("preserves existing text output unchanged when semanticSummary is added", async () => {
+  it("surfaces the Edited summary without adding semantic noise for plain semantic edits", async () => {
     const filePath = makeFixture("const a = 1;\n");
     const lines = readFileSync(filePath, "utf-8").split("\n");
     const anchor = `1:${computeLineHash(1, lines[0])}`;
-
     const result = await callEditTool({
       path: filePath,
       edits: [{ set_line: { anchor, new_text: "const a = 2;" } }],
     });
-
     const text = result.content.find((c: any) => c.type === "text")?.text ?? "";
-    expect(text).toContain("Updated");
-    expect(text).not.toContain("semantic");
-    expect(text).not.toContain("whitespace");
+    expect(text.split("\n")[0]).toBe(`Edited ${filePath} (1 change, +1 -1 line)`);
+    expect(text).not.toContain("[semantic:");
+    expect(text).not.toContain("⚠ Edit classified as whitespace-only");
   });
 });

--- a/tests/edit-semantic-surfacing.test.ts
+++ b/tests/edit-semantic-surfacing.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+import { registerEditTool } from "../src/edit.js";
+import * as classifyModule from "../src/edit-classify.js";
+async function callEditTool(params: Record<string, unknown>) {
+  let capturedTool: any = null;
+  registerEditTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  if (!capturedTool) throw new Error("edit tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+function makeFixture(content: string): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-semantic-surface-"));
+  const filePath = resolve(dir, "sample.ts");
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+function getTextContent(result: any): string {
+  return result.content.find((c: any) => c.type === "text")?.text ?? "";
+}
+describe("edit semantic surfacing", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+  it("warns when a whitespace-only result came from substantive new_text", async () => {
+    const filePath = makeFixture("  const value = 1;\n");
+    const anchor = `1:${computeLineHash(1, "  const value = 1;")}`;
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ set_line: { anchor, new_text: "    const value = 1;" } }],
+    });
+
+    const text = getTextContent(result);
+    expect(result.isError).not.toBe(true);
+    expect(text.split("\n")[0]).toBe(`Edited ${filePath} (1 change, +1 -1 line)`);
+    expect(text.split("\n")[1]).toBe(
+      "⚠ Edit classified as whitespace-only — if you intended a behavior change, re-read to verify.",
+    );
+  });
+  it("does not warn when every new_text is whitespace-only", async () => {
+    const filePath = makeFixture("  \n");
+    const anchor = `1:${computeLineHash(1, "  ")}`;
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ set_line: { anchor, new_text: "    " } }],
+    });
+
+    const text = getTextContent(result);
+    expect(result.isError).not.toBe(true);
+    expect(text).toBe(`Edited ${filePath} (1 change, +1 -1 line)`);
+  });
+  it("stays quiet for plain semantic edits", async () => {
+    const filePath = makeFixture("const a = 1;\n");
+    const anchor = `1:${computeLineHash(1, "const a = 1;")}`;
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ set_line: { anchor, new_text: "const a = 2;" } }],
+    });
+
+    const text = getTextContent(result);
+    expect(result.isError).not.toBe(true);
+    expect(text).toBe(`Edited ${filePath} (1 change, +1 -1 line)`);
+    expect(text).not.toContain("[semantic:");
+    expect(text).not.toContain("⚠ Edit classified as whitespace-only");
+  });
+  it("mentions moved blocks inline when semanticSummary reports moves", async () => {
+    vi.spyOn(classifyModule, "isDifftAvailable").mockResolvedValue(true);
+    vi.spyOn(classifyModule, "runDifftastic").mockResolvedValue({ classification: "mixed", movedBlocks: 2 });
+    const filePath = makeFixture("const a = 1;\nconst b = 2;\n");
+    const lines = readFileSync(filePath, "utf-8").split("\n");
+    const start = `1:${computeLineHash(1, lines[0])}`;
+    const end = `2:${computeLineHash(2, lines[1])}`;
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ replace_lines: { start_anchor: start, end_anchor: end, new_text: "const b = 2;\nconst a = 1;" } }],
+    });
+
+    const text = getTextContent(result);
+    expect(result.isError).not.toBe(true);
+    expect(text).toBe(`Edited ${filePath} (1 change, +1 -1 line) [semantic: mixed, 2 blocks moved]`);
+    expect(text).not.toContain("difftastic");
+  });
+});

--- a/tests/read-before-edit-session.test.ts
+++ b/tests/read-before-edit-session.test.ts
@@ -76,7 +76,7 @@ describe("extension-scoped read tracking", () => {
     );
 
     expect(editResult.isError).not.toBe(true);
-    expect(getTextContent(editResult)).toContain(`Updated ${filePath}`);
+    expect(getTextContent(editResult)).toContain(`Edited ${filePath} (1 change, +1 -1 line)`);
     expect(readFileSync(filePath, "utf-8")).toBe("const value = 2;\n");
   });
 });


### PR DESCRIPTION
## Why
`edit` already computed semantic classification and moved-block metadata, but those signals were only visible in structured metadata. This change makes the model-visible success text reflect the actionable cases while keeping the structured contract stable.

## What changed
- show `Edited <path> (...)` summaries in visible edit output while keeping `ptcValue.summary` as `Updated <path>`
- surface whitespace-only warnings only for substantive-intent edits and append moved-block suffixes when blocks were detected
- add a replace-only informational hint and document both runtime annotations in `prompts/edit.md`

## Testing
- npm test
- npm run typecheck
- npx vitest run tests/edit-output.test.ts tests/edit-ptc-value.test.ts tests/edit-output-semantic.test.ts tests/edit-semantic-surfacing.test.ts tests/edit-replace-hint.test.ts tests/edit-prompt-coverage.test.ts tests/read-before-edit-session.test.ts --reporter=verbose

Resolves #110
Covers #098 and #105