### PR TITLE
fix(read): require confirmation for fuzzy symbol matches

### DIFF
--- a/prompts/read.md
+++ b/prompts/read.md
@@ -44,8 +44,9 @@ Use the `symbol` parameter to read a specific symbol by name — no line numbers
 
 **Behavior by result:**
 
-- **Found:** Returns hashlined content for the symbol's line range only, prepended with `[Symbol: name (kind), lines X-Y of Z]`.
+- **Found (exact / case-insensitive / prefix):** Returns hashlined content for the symbol's line range only, prepended with `[Symbol: name (kind), lines X-Y of Z]`. Silent — no banner.
 - **Ambiguous (multiple matches):** Returns a disambiguation list with each candidate's name, kind, and line range. Use dot notation (e.g., `ClassName.methodName`) to narrow the match.
+- **Fuzzy (low-confidence match):** Returns the best match's content prefixed with a `[Symbol '<query>' not exact-matched ...]` banner that names the matched symbol, the match tier (`camelCase word boundary` or `substring`), up to 4 other candidates, and a `read({ symbol: "..." })` / `name@line` confirmation hint. Content is still returned so no extra round-trip is required when the guess is right, but the banner is a required signal that the match was approximate — re-verify before editing based on it.
 - **Not found:** Falls back to a normal read with a warning listing up to 20 available symbol names.
 - **Unmappable file:** Falls back to a normal read with a warning noting the file type doesn't support symbol lookup.
 

--- a/src/ptc-value.ts
+++ b/src/ptc-value.ts
@@ -8,9 +8,19 @@ export interface PtcLine {
   display: string;
 }
 
+export interface PtcWarningSymbol {
+  name: string;
+  kind: string;
+  startLine: number;
+  endLine: number;
+  parentName?: string;
+}
 export interface PtcWarning {
   code: string;
   message: string;
+  tier?: "camelCase" | "substring";
+  symbol?: PtcWarningSymbol;
+  otherCandidates?: PtcWarningSymbol[];
 }
 
 export interface PtcRange {
@@ -65,8 +75,12 @@ export function renderPtcLines(lines: PtcLine[]): string {
   return lines.map(renderPtcLine).join("\n");
 }
 
-export function buildPtcWarning(code: string, message: string): PtcWarning {
-  return { code, message };
+export function buildPtcWarning(
+  code: string,
+  message: string,
+  metadata: Omit<PtcWarning, "code" | "message"> = {},
+): PtcWarning {
+  return { code, message, ...metadata };
 }
 
 export function buildPtcRange(startLine: number, endLine: number, totalLines?: number): PtcRange {

--- a/src/read-render-helpers.ts
+++ b/src/read-render-helpers.ts
@@ -91,6 +91,7 @@ export function formatReadResultText(input: ReadResultTextInput): ReadResultText
   for (const w of warnings) {
     if (w.code === "binary-content") badges.push("\u26a0 binary");
     if (w.code === "bare-cr") badges.push("\u26a0 bare CR");
+    if (w.code === "fuzzy-symbol-match") badges.push("⚠ fuzzy match");
   }
 
   return {

--- a/src/read.ts
+++ b/src/read.ts
@@ -271,6 +271,28 @@ export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}
 						endIdx = Math.min(total, lookup.symbol.endLine);
 						symbolMatch = lookup.symbol;
 					}
+					if (lookup.type === "fuzzy") {
+						startLine = Math.max(1, lookup.symbol.startLine);
+						endIdx = Math.min(total, lookup.symbol.endLine);
+						symbolMatch = lookup.symbol;
+
+						const tierLabel = lookup.tier === "camelCase" ? "camelCase word boundary" : "substring";
+						const otherNames = lookup.otherCandidates.map((c) => `\`${c.name}\``).join(", ");
+						const confirmHint = `read({ symbol: "${lookup.symbol.name}" }) or ${lookup.symbol.name}@${lookup.symbol.startLine} to select by start line`;
+						const lines = [
+							`[Symbol '${p.symbol}' not exact-matched. Closest match: \`${lookup.symbol.name}\` (${lookup.symbol.kind}, lines ${lookup.symbol.startLine}-${lookup.symbol.endLine}) via ${tierLabel}.`,
+						];
+						if (otherNames) lines.push(` Other candidates: ${otherNames}.`);
+						lines.push(` To confirm: ${confirmHint}.]`);
+						const bannerText = lines.join("\n");
+						structuredWarnings.push(
+							buildPtcWarning("fuzzy-symbol-match", bannerText, {
+								tier: lookup.tier,
+								symbol: lookup.symbol,
+								otherCandidates: lookup.otherCandidates,
+							}),
+						);
+					}
 				}
 			}
 
@@ -471,7 +493,7 @@ return succeed({
 			const ptcValue = (result.details as any)?.ptcValue as {
 				tool: "read";
 				range: { startLine: number; endLine: number; totalLines: number };
-				warnings: Array<{ code: string; message: string }>;
+				warnings: PtcWarning[];
 				truncation: { outputLines: number; totalLines: number; outputBytes: number; totalBytes: number } | null;
 				symbol: { query: string; name: string; kind: string; parentName?: string; startLine: number; endLine: number } | null;
 				map: { requested: boolean; appended: boolean };

--- a/src/readmap/symbol-lookup.ts
+++ b/src/readmap/symbol-lookup.ts
@@ -12,6 +12,12 @@ export interface SymbolMatch {
 export type SymbolLookupResult =
   | { type: "found"; symbol: SymbolMatch }
   | { type: "ambiguous"; candidates: SymbolMatch[] }
+  | {
+      type: "fuzzy";
+      symbol: SymbolMatch;
+      tier: "camelCase" | "substring";
+      otherCandidates: SymbolMatch[];
+    }
   | { type: "not-found" };
 
 function toMatch(symbol: FileSymbol, parentName?: string): SymbolMatch {
@@ -127,12 +133,37 @@ export function findSymbol(map: FileMap, query: string): SymbolLookupResult {
     const words = c.symbol.name.replace(/([a-z])([A-Z])/g, "$1 $2").toLowerCase().split(/[\s_]+/);
     return words.some((w) => w === qLower);
   });
-  if (camelCase.length === 1) return { type: "found", symbol: toMatch(camelCase[0].symbol, camelCase[0].parentName) };
-  if (camelCase.length > 1) return { type: "ambiguous", candidates: toMatches(camelCase.slice(0, 5)) };
 
   // Tier 4: substring match
   const partial = allSymbols.filter((c) => c.symbol.name.toLowerCase().includes(qLower));
-  if (partial.length === 1) return { type: "found", symbol: toMatch(partial[0].symbol, partial[0].parentName) };
+  const buildOtherCandidates = (chosen: SymbolCandidate): SymbolMatch[] => {
+    const pool: SymbolCandidate[] = [];
+    const seen = new Set<FileSymbol>();
+    seen.add(chosen.symbol);
+    for (const c of [...camelCase, ...partial]) {
+      if (seen.has(c.symbol)) continue;
+      seen.add(c.symbol);
+      pool.push(c);
+    }
+    return toMatches(pool.slice(0, 4));
+  };
+  if (camelCase.length === 1) {
+    return {
+      type: "fuzzy",
+      symbol: toMatch(camelCase[0].symbol, camelCase[0].parentName),
+      tier: "camelCase",
+      otherCandidates: buildOtherCandidates(camelCase[0]),
+    };
+  }
+  if (camelCase.length > 1) return { type: "ambiguous", candidates: toMatches(camelCase.slice(0, 5)) };
+  if (partial.length === 1) {
+    return {
+      type: "fuzzy",
+      symbol: toMatch(partial[0].symbol, partial[0].parentName),
+      tier: "substring",
+      otherCandidates: buildOtherCandidates(partial[0]),
+    };
+  }
   if (partial.length > 1) return { type: "ambiguous", candidates: toMatches(partial.slice(0, 5)) };
 
   return { type: "not-found" };

--- a/tests/read-render-helpers.test.ts
+++ b/tests/read-render-helpers.test.ts
@@ -107,6 +107,18 @@ describe("formatReadResultText", () => {
     expect(result.badges).toContain("⚠ bare CR");
   });
 
+  it("adds a fuzzy match badge when warnings include fuzzy-symbol-match", () => {
+    const out = formatReadResultText({
+      range: { startLine: 42, endLine: 58, totalLines: 100 },
+      truncation: null,
+      symbol: { query: "get", name: "initGetters", kind: "function", startLine: 42, endLine: 58 },
+      map: { requested: false, appended: false },
+      warnings: [{ code: "fuzzy-symbol-match", message: "[Symbol 'get' not exact-matched...]" }],
+    });
+
+    expect(out.badges).toContain("⚠ fuzzy match");
+  });
+
   it("shows truncation in summary", () => {
     const result = formatReadResultText({
       range: { startLine: 1, endLine: 2000, totalLines: 5000 },

--- a/tests/read-symbol-fuzzy.test.ts
+++ b/tests/read-symbol-fuzzy.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { clearMapCache } from "../src/map-cache.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+type ReadParams = {
+  path: string;
+  offset?: number;
+  limit?: number;
+  symbol?: string;
+};
+
+async function getReadTool() {
+  const { registerReadTool } = await import("../src/read.js");
+  let capturedTool: any = null;
+  const mockPi = {
+    registerTool(def: any) {
+      capturedTool = def;
+    },
+  };
+  registerReadTool(mockPi as any);
+  if (!capturedTool) throw new Error("read tool was not registered");
+  return capturedTool;
+}
+
+async function callReadTool(params: ReadParams) {
+  const tool = await getReadTool();
+  return tool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function getTextContent(result: any): string {
+  return result.content.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("read — fuzzy symbol match (issue 099)", () => {
+  beforeEach(() => clearMapCache());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("tier 4 substring: returns content AND prepends fuzzy banner AND emits fuzzy-symbol-match warning", async () => {
+    const cacheModule = await import("../src/map-cache.js");
+    const { DetailLevel, SymbolKind } = await import("../src/readmap/enums.js");
+
+    vi.spyOn(cacheModule, "getOrGenerateMap").mockResolvedValue({
+      path: resolve(fixturesDir, "small.ts"),
+      totalLines: 100,
+      totalBytes: 1000,
+      language: "typescript",
+      symbols: [
+        { name: "initGetters", kind: SymbolKind.Function, startLine: 45, endLine: 49 },
+        { name: "formatOutput", kind: SymbolKind.Function, startLine: 60, endLine: 70 },
+      ],
+      imports: [],
+      detailLevel: DetailLevel.Full,
+    });
+
+    const result = await callReadTool({
+      path: resolve(fixturesDir, "small.ts"),
+      symbol: "get",
+    });
+
+    const text = getTextContent(result);
+
+    expect(text).toContain("[Symbol 'get' not exact-matched");
+    expect(text).toContain("initGetters");
+    expect(text).toContain("substring");
+    expect(text).toContain("[Symbol: initGetters (function)");
+
+    const warnings = (result.details as any)?.ptcValue?.warnings ?? [];
+    expect(warnings.some((w: any) => w.code === "fuzzy-symbol-match")).toBe(true);
+  });
+
+  it("tier 3 camelCase: returns content AND prepends fuzzy banner with camelCase tier", async () => {
+    const cacheModule = await import("../src/map-cache.js");
+    const { DetailLevel, SymbolKind } = await import("../src/readmap/enums.js");
+
+    vi.spyOn(cacheModule, "getOrGenerateMap").mockResolvedValue({
+      path: resolve(fixturesDir, "small.ts"),
+      totalLines: 100,
+      totalBytes: 1000,
+      language: "typescript",
+      symbols: [
+        { name: "getHandler", kind: SymbolKind.Function, startLine: 45, endLine: 49 },
+        { name: "formatOutput", kind: SymbolKind.Function, startLine: 60, endLine: 70 },
+      ],
+      imports: [],
+      detailLevel: DetailLevel.Full,
+    });
+
+    const result = await callReadTool({
+      path: resolve(fixturesDir, "small.ts"),
+      symbol: "handler",
+    });
+
+    const text = getTextContent(result);
+    expect(text).toContain("[Symbol 'handler' not exact-matched");
+    expect(text).toContain("getHandler");
+    expect(text).toContain("camelCase");
+    expect(text).toContain("[Symbol: getHandler (function)");
+
+    const warnings = (result.details as any)?.ptcValue?.warnings ?? [];
+    expect(warnings.some((w: any) => w.code === "fuzzy-symbol-match")).toBe(true);
+  });
+
+  it("tier 1 case-insensitive exact — no fuzzy banner (silent)", async () => {
+    const cacheModule = await import("../src/map-cache.js");
+    const { DetailLevel, SymbolKind } = await import("../src/readmap/enums.js");
+
+    vi.spyOn(cacheModule, "getOrGenerateMap").mockResolvedValue({
+      path: resolve(fixturesDir, "small.ts"),
+      totalLines: 100,
+      totalBytes: 1000,
+      language: "typescript",
+      symbols: [
+        { name: "ParseConfig", kind: SymbolKind.Function, startLine: 1, endLine: 2 },
+      ],
+      imports: [],
+      detailLevel: DetailLevel.Full,
+    });
+
+    const result = await callReadTool({
+      path: resolve(fixturesDir, "small.ts"),
+      symbol: "parseconfig",
+    });
+
+    const text = getTextContent(result);
+    expect(text).not.toContain("not exact-matched");
+    const warnings = (result.details as any)?.ptcValue?.warnings ?? [];
+    expect(warnings.some((w: any) => w.code === "fuzzy-symbol-match")).toBe(false);
+  });
+
+  it("fuzzy banner lists otherCandidates when cross-tier alternatives exist", async () => {
+    const cacheModule = await import("../src/map-cache.js");
+    const { DetailLevel, SymbolKind } = await import("../src/readmap/enums.js");
+
+    vi.spyOn(cacheModule, "getOrGenerateMap").mockResolvedValue({
+      path: resolve(fixturesDir, "small.ts"),
+      totalLines: 100,
+      totalBytes: 1000,
+      language: "typescript",
+      symbols: [
+        { name: "getHandler", kind: SymbolKind.Function, startLine: 10, endLine: 20 },
+        { name: "myhandlerthing", kind: SymbolKind.Function, startLine: 30, endLine: 35 },
+        { name: "prehandlerX", kind: SymbolKind.Function, startLine: 40, endLine: 45 },
+      ],
+      imports: [],
+      detailLevel: DetailLevel.Full,
+    });
+
+    const result = await callReadTool({
+      path: resolve(fixturesDir, "small.ts"),
+      symbol: "handler",
+    });
+
+    const text = getTextContent(result);
+    expect(text).toContain("Other candidates:");
+    expect(text).toContain("myhandlerthing");
+    expect(text).toContain("prehandlerX");
+    expect(text).toContain("To confirm:");
+    expect(text).toContain("getHandler@10");
+    const warnings = (result.details as any)?.ptcValue?.warnings ?? [];
+    const fuzzyWarning = warnings.find((w: any) => w.code === "fuzzy-symbol-match");
+    expect(fuzzyWarning?.message).toContain("Other candidates: `myhandlerthing`, `prehandlerX`.");
+    expect(fuzzyWarning?.message).toContain("To confirm: read({ symbol: \"getHandler\" }) or getHandler@10");
+  });
+
+  it("fuzzy warning exposes machine-readable tier and otherCandidates", async () => {
+    const cacheModule = await import("../src/map-cache.js");
+    const { DetailLevel, SymbolKind } = await import("../src/readmap/enums.js");
+
+    vi.spyOn(cacheModule, "getOrGenerateMap").mockResolvedValue({
+      path: resolve(fixturesDir, "small.ts"),
+      totalLines: 100,
+      totalBytes: 1000,
+      language: "typescript",
+      symbols: [
+        { name: "getHandler", kind: SymbolKind.Function, startLine: 10, endLine: 20 },
+        { name: "myhandlerthing", kind: SymbolKind.Function, startLine: 30, endLine: 35 },
+        { name: "prehandlerX", kind: SymbolKind.Function, startLine: 40, endLine: 45 },
+      ],
+      imports: [],
+      detailLevel: DetailLevel.Full,
+    });
+
+    const result = await callReadTool({
+      path: resolve(fixturesDir, "small.ts"),
+      symbol: "handler",
+    });
+
+    const warnings = (result.details as any)?.ptcValue?.warnings ?? [];
+    const fuzzyWarning = warnings.find((w: any) => w.code === "fuzzy-symbol-match");
+
+    expect(fuzzyWarning).toMatchObject({
+      code: "fuzzy-symbol-match",
+      tier: "camelCase",
+      otherCandidates: [
+        { name: "myhandlerthing", kind: "function", startLine: 30, endLine: 35 },
+        { name: "prehandlerX", kind: "function", startLine: 40, endLine: 45 },
+      ],
+    });
+  });
+});

--- a/tests/repro-099-fuzzy-confirmation.test.ts
+++ b/tests/repro-099-fuzzy-confirmation.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import type { FileMap } from "../src/readmap/types.js";
+import { DetailLevel, SymbolKind } from "../src/readmap/enums.js";
+import { findSymbol } from "../src/readmap/symbol-lookup.js";
+
+function makeMap(symbols: FileMap["symbols"]): FileMap {
+  return {
+    path: "/tmp/test.ts",
+    totalLines: 100,
+    totalBytes: 1000,
+    language: "typescript",
+    symbols,
+    imports: [],
+    detailLevel: DetailLevel.Full,
+  };
+}
+
+// Issue 099: tiers 3 (camelCase word-boundary) and 4 (substring) currently
+// return { type: "found" } silently. Expected behavior is { type: "fuzzy", tier, ... }.
+describe("repro #099 — fuzzy symbol match silently resolves for tiers 3 & 4", () => {
+  it("tier 4 substring: read({symbol:'get'}) should NOT silently resolve to initGetters", () => {
+    const map = makeMap([
+      { name: "initGetters", kind: SymbolKind.Function, startLine: 42, endLine: 58 },
+      { name: "formatOutput", kind: SymbolKind.Function, startLine: 60, endLine: 70 },
+    ]);
+
+    const result = findSymbol(map, "get");
+    // BUG: currently returns { type: "found", symbol: initGetters } with no warning.
+    expect(result.type).toBe("fuzzy");
+  });
+
+  it("tier 3 camelCase: read({symbol:'handler'}) should NOT silently resolve to getHandler", () => {
+    const map = makeMap([
+      { name: "getHandler", kind: SymbolKind.Function, startLine: 10, endLine: 20 },
+      { name: "formatOutput", kind: SymbolKind.Function, startLine: 60, endLine: 70 },
+    ]);
+
+    const result = findSymbol(map, "handler");
+    // BUG: currently returns { type: "found", symbol: getHandler } with no warning.
+    expect(result.type).toBe("fuzzy");
+  });
+});

--- a/tests/symbol-lookup-fuzzy.test.ts
+++ b/tests/symbol-lookup-fuzzy.test.ts
@@ -53,16 +53,96 @@ describe("findSymbol ranked fuzzy matching (task 7)", () => {
     });
   });
 
-  it("camelCase boundary match: config matches parseConfig", () => {
+  it("prefix beats a camelCase candidate for the same query", () => {
+    const map = makeMap([
+      { name: "handlerConfig", kind: SymbolKind.Function, startLine: 1, endLine: 2 },
+      { name: "getHandler", kind: SymbolKind.Function, startLine: 3, endLine: 4 },
+    ]);
+
+    expect(findSymbol(map, "handler")).toEqual({
+      type: "found",
+      symbol: { name: "handlerConfig", kind: "function", startLine: 1, endLine: 2 },
+    });
+  });
+
+  it("multiple camelCase matches stay ambiguous before substring fallback", () => {
+    const map = makeMap([
+      { name: "getHandler", kind: SymbolKind.Function, startLine: 10, endLine: 20 },
+      { name: "setHandler", kind: SymbolKind.Function, startLine: 30, endLine: 40 },
+      { name: "myhandlerthing", kind: SymbolKind.Function, startLine: 50, endLine: 60 },
+    ]);
+
+    expect(findSymbol(map, "handler")).toEqual({
+      type: "ambiguous",
+      candidates: [
+        { name: "getHandler", kind: "function", startLine: 10, endLine: 20 },
+        { name: "setHandler", kind: "function", startLine: 30, endLine: 40 },
+      ],
+    });
+  });
+
+  it("camelCase boundary match: config matches parseConfig returns fuzzy", () => {
     const map = makeMap([
       { name: "parseConfig", kind: SymbolKind.Function, startLine: 1, endLine: 2 },
       { name: "myconfigvalue", kind: SymbolKind.Function, startLine: 3, endLine: 4 },
     ]);
 
-    expect(findSymbol(map, "config")).toEqual({
-      type: "found",
-      symbol: { name: "parseConfig", kind: "function", startLine: 1, endLine: 2 },
-    });
+    const result = findSymbol(map, "config");
+    expect(result.type).toBe("fuzzy");
+    if (result.type === "fuzzy") {
+      expect(result.symbol).toEqual({ name: "parseConfig", kind: "function", startLine: 1, endLine: 2 });
+      expect(result.tier).toBe("camelCase");
+      expect(Array.isArray(result.otherCandidates)).toBe(true);
+    }
+  });
+
+  it("substring match: single tier-4 hit returns fuzzy with tier substring", () => {
+    const map = makeMap([
+      { name: "initGetters", kind: SymbolKind.Function, startLine: 42, endLine: 58 },
+      { name: "formatOutput", kind: SymbolKind.Function, startLine: 60, endLine: 70 },
+    ]);
+
+    const result = findSymbol(map, "get");
+    expect(result.type).toBe("fuzzy");
+    if (result.type === "fuzzy") {
+      expect(result.symbol).toEqual({ name: "initGetters", kind: "function", startLine: 42, endLine: 58 });
+      expect(result.tier).toBe("substring");
+    }
+  });
+
+  it("fuzzy tier 3 (camelCase) returns up to 4 other candidates from merged tier-3+tier-4 pool", () => {
+    const map = makeMap([
+      { name: "getHandler", kind: SymbolKind.Function, startLine: 10, endLine: 20 },
+      { name: "myhandlerthing", kind: SymbolKind.Function, startLine: 30, endLine: 35 },
+      { name: "prehandlerX", kind: SymbolKind.Function, startLine: 40, endLine: 45 },
+      { name: "ahandlerB", kind: SymbolKind.Function, startLine: 50, endLine: 55 },
+      { name: "xhandlerY", kind: SymbolKind.Function, startLine: 60, endLine: 65 },
+      { name: "zhandlerQ", kind: SymbolKind.Function, startLine: 70, endLine: 75 },
+    ]);
+
+    const result = findSymbol(map, "handler");
+    expect(result.type).toBe("fuzzy");
+    if (result.type === "fuzzy") {
+      expect(result.symbol.name).toBe("getHandler");
+      expect(result.tier).toBe("camelCase");
+      expect(result.otherCandidates.length).toBeLessThanOrEqual(4);
+      expect(result.otherCandidates.length).toBeGreaterThan(0);
+      expect(result.otherCandidates.every((c) => c.name !== "getHandler")).toBe(true);
+    }
+  });
+
+  it("fuzzy tier 4 with a single overall substring hit returns empty otherCandidates", () => {
+    const map = makeMap([
+      { name: "initGetters", kind: SymbolKind.Function, startLine: 42, endLine: 58 },
+      { name: "formatOutput", kind: SymbolKind.Function, startLine: 60, endLine: 70 },
+    ]);
+
+    const result = findSymbol(map, "get");
+    expect(result.type).toBe("fuzzy");
+    if (result.type === "fuzzy") {
+      expect(result.tier).toBe("substring");
+      expect(result.otherCandidates).toEqual([]);
+    }
   });
 
   it("ambiguity returns at most 5 candidates", () => {


### PR DESCRIPTION
## Summary
- return explicit `fuzzy` symbol lookup results for single camelCase and substring matches
- prepend read output with a confirmation banner and structured `fuzzy-symbol-match` warning metadata
- surface fuzzy matches in the TUI badge row and lock behavior with regression tests/docs

## Verification
- `npm test`
- `npm run typecheck`
- `npx vitest run tests/repro-099-fuzzy-confirmation.test.ts --reporter verbose`

Issue: 099-require-confirmation-for-fuzzy-symbol-ma