### PR TITLE
feat(grep): add scopeContext windowing for symbol-scoped output

### DIFF
--- a/prompts/grep.md
+++ b/prompts/grep.md
@@ -12,7 +12,7 @@ Includes N surrounding lines before and after each match. Nearby matches are mer
 Returns per-file match counts only — no line content, no anchors. Use this first to scope a broad search across many files, then drill into specific files with a targeted search.
 
 ### Symbol-scoped mode (`scope: "symbol"`)
-Groups matches by their enclosing function, method, or class. Shows the full symbol block containing each match, not just the matching line. Falls back gracefully for files without structural maps. Ignored when `summary: true`.
+Groups matches by their enclosing function, method, or class. By default, shows the full symbol block containing each match. Pass `scopeContext: N` to window output to ±N lines around each match (clipped at the symbol boundary); pass `scopeContext: 0` to get only match lines. The group header carries the line range and the `scoped to ±N lines` suffix. Falls back gracefully for files without structural maps. Ignored when `summary: true`.
 
 ## Parameters
 
@@ -25,6 +25,7 @@ Groups matches by their enclosing function, method, or class. Shows the full sym
 - `limit` — Maximum number of matches to return (default: 100)
 - `summary` — Return per-file match counts only (no hashline anchors)
 - `scope` — Set to `"symbol"` to group matches by enclosing symbol block
+- `scopeContext` — Number of context lines to show around each match within the enclosing symbol (requires `scope: "symbol"`). `0` = match lines only; `N > 0` = ±N lines clipped at the symbol boundary. Rejected when `scope` is not `"symbol"` — use `context` for non-symbol-scoped searches.
 
 ## Usage Guidance
 
@@ -52,3 +53,29 @@ src/client.ts:>>12:c7e|const api = new ApiClient();
 ```
 
 Lines with `>>` are matches; lines with `  ` (two spaces) are context lines.
+
+### scope: "symbol" with scopeContext
+
+```
+[2 matches in 1 files]
+--- src/server.ts :: function handleRequest (42-180, 2 matches, scoped to ±3 lines) ---
+src/server.ts:  55:a12|  // validate input
+src/server.ts:  56:b34|  if (!req.body) return 400;
+src/server.ts:  57:c56|  // route lookup
+src/server.ts:>>58:d78|  const route = findRoute(req);
+src/server.ts:  59:e9a|  if (!route) return 404;
+src/server.ts:  60:f01|  // auth
+src/server.ts:  61:012|  const user = await authenticate(req);
+--
+src/server.ts:  75:234|  // response
+src/server.ts:>>76:456|  const result = await handle(route, user);
+src/server.ts:  77:678|  res.json(result);
+```
+
+With `scopeContext: 0`, only match lines are shown under the header:
+
+```
+--- src/server.ts :: function handleRequest (42-180, 2 matches, scoped to ±0 lines) ---
+src/server.ts:>>58:d78|  const route = findRoute(req);
+src/server.ts:>>76:456|  const result = await handle(route, user);
+```

--- a/src/grep-output.ts
+++ b/src/grep-output.ts
@@ -44,6 +44,7 @@ export interface GrepOutputGroup {
     mode: "symbol";
     symbol: GrepOutputScopeSymbol;
     matchLines: number[];
+    contextLines?: number;
   };
 }
 
@@ -92,7 +93,8 @@ function renderGroupHeader(group: GrepOutputGroup): string {
   }
 
   const parent = group.scope.symbol.parentName ? ` in ${group.scope.symbol.parentName}` : "";
-  return `--- ${group.displayPath} :: ${group.scope.symbol.kind} ${group.scope.symbol.name}${parent} (${group.scope.symbol.startLine}-${group.scope.symbol.endLine}, ${group.matchCount} matches) ---`;
+  const suffix = group.scope.contextLines !== undefined ? `, scoped to ±${group.scope.contextLines} lines` : "";
+  return `--- ${group.displayPath} :: ${group.scope.symbol.kind} ${group.scope.symbol.name}${parent} (${group.scope.symbol.startLine}-${group.scope.symbol.endLine}, ${group.matchCount} matches${suffix}) ---`;
 }
 
 function buildScopeMetadata(groups: GrepOutputGroup[], warnings: GrepScopeWarning[]) {

--- a/src/grep-symbol-scope.ts
+++ b/src/grep-symbol-scope.ts
@@ -40,11 +40,42 @@ function firstLineNumber(group: GrepOutputGroup): number {
   return first ? first.line.line : Number.MAX_SAFE_INTEGER;
 }
 
-function buildSymbolEntries(fileLines: string[], symbol: GrepOutputScopeSymbol, matchLines: Set<number>): GrepOutputEntry[] {
+function buildSymbolEntries(
+  fileLines: string[],
+  symbol: GrepOutputScopeSymbol,
+  matchLines: Set<number>,
+  scopeContext: number | undefined,
+): GrepOutputEntry[] {
+  if (scopeContext === undefined) {
+    const entries: GrepOutputEntry[] = [];
+    for (let lineNumber = symbol.startLine; lineNumber <= symbol.endLine; lineNumber++) {
+      const built = buildPtcLine(lineNumber, fileLines[lineNumber - 1] ?? "");
+      entries.push({ kind: matchLines.has(lineNumber) ? "match" : "context", line: built });
+    }
+    return entries;
+  }
+  // Windowed path: ±scopeContext lines, clipped, merged, with '--' separators between non-overlapping ranges.
+  const ranges = [...matchLines].sort((a, b) => a - b).map((ln) => ({
+    startLine: Math.max(symbol.startLine, ln - scopeContext),
+    endLine: Math.min(symbol.endLine, ln + scopeContext),
+  }));
+  const merged: Array<{ startLine: number; endLine: number }> = [];
+  for (const r of ranges) {
+    const last = merged[merged.length - 1];
+    if (last && r.startLine <= last.endLine + 1) {
+      last.endLine = Math.max(last.endLine, r.endLine);
+    } else {
+      merged.push({ ...r });
+    }
+  }
   const entries: GrepOutputEntry[] = [];
-  for (let lineNumber = symbol.startLine; lineNumber <= symbol.endLine; lineNumber++) {
-    const built = buildPtcLine(lineNumber, fileLines[lineNumber - 1] ?? "");
-    entries.push({ kind: matchLines.has(lineNumber) ? "match" : "context", line: built });
+  for (let i = 0; i < merged.length; i++) {
+    if (i > 0) entries.push({ kind: "separator", text: "--" });
+    const range = merged[i];
+    for (let ln = range.startLine; ln <= range.endLine; ln++) {
+      const built = buildPtcLine(ln, fileLines[ln - 1] ?? "");
+      entries.push({ kind: matchLines.has(ln) ? "match" : "context", line: built });
+    }
   }
   return entries;
 }
@@ -77,6 +108,7 @@ export function scopeGrepGroupsToSymbols(input: {
   fileLinesByPath: Map<string, string[]>;
   fileMapsByPath: Map<string, FileMap | null>;
   contextLines: number;
+  scopeContext?: number;
 }): { groups: GrepOutputGroup[]; warnings: GrepScopeWarning[] } {
   const warnings: GrepScopeWarning[] = [];
   const rendered: Array<{ order: number; group: GrepOutputGroup }> = [];
@@ -131,8 +163,9 @@ export function scopeGrepGroupsToSymbols(input: {
           mode: "symbol" as const,
           symbol,
           matchLines: [...matchLines].sort((a, b) => a - b),
+          ...(input.scopeContext !== undefined ? { contextLines: input.scopeContext } : {}),
         },
-        entries: buildSymbolEntries(fileLines, symbol, matchLines),
+        entries: buildSymbolEntries(fileLines, symbol, matchLines, input.scopeContext),
       }));
 
     for (const scopedGroup of scopedGroups) rendered.push({ order: scopedGroup.scope!.symbol.startLine, group: scopedGroup });

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -44,6 +44,12 @@ const grepSchema = Type.Object({
 			description: 'Scope matches to enclosing symbol blocks. Only "symbol" is defined, and it is ignored when summary: true.',
 		}),
 	),
+	scopeContext: Type.Optional(
+		Type.Union([
+			Type.Number({ description: "Context lines within symbol scope (requires scope: \"symbol\"). 0 = match lines only." }),
+			Type.String({ description: "Context lines within symbol scope (requires scope: \"symbol\"). 0 = match lines only." }),
+		]),
+	),
 });
 
 interface GrepParams {
@@ -56,6 +62,7 @@ interface GrepParams {
 	limit?: number | string;
 	summary?: boolean;
 	scope?: "symbol";
+	scopeContext?: number | string;
 }
 
 const MATCH_LINE_RE = /^(.*):(\d+): (.*)$/;
@@ -310,10 +317,39 @@ export function registerGrepTool(pi: ExtensionAPI, options: GrepToolOptions = {}
 					details: {},
 				};
 			}
+
+			const scopeContext = coerceObviousBase10Int(rawParams.scopeContext, "scopeContext");
+			if (!scopeContext.ok) {
+				return {
+					content: [{ type: "text", text: scopeContext.message }],
+					isError: true,
+					details: {},
+				};
+			}
+
+			if (scopeContext.value !== undefined && rawParams.scope !== "symbol") {
+				return {
+					content: [{
+						type: "text",
+						text: 'Invalid scopeContext: requires scope: "symbol". For normal surrounding-line context outside symbol scope, use the `context` parameter.',
+					}],
+					isError: true,
+					details: {},
+				};
+			}
+
+			if (scopeContext.value !== undefined && scopeContext.value < 0) {
+				return {
+					content: [{ type: "text", text: `Invalid scopeContext: expected a non-negative integer, received ${scopeContext.value}.` }],
+					isError: true,
+					details: {},
+				};
+			}
 			const p: GrepParams = {
 				...rawParams,
 				context: context.value,
 				limit: limit.value,
+				scopeContext: scopeContext.value,
 			};
 			const builtin = createGrepTool(ctx.cwd);
 			const result = await builtin.execute(
@@ -564,6 +600,7 @@ if (p.scope === "symbol" && !summary) {
 		fileLinesByPath,
 		fileMapsByPath,
 		contextLines: typeof p.context === "number" ? p.context : 0,
+		scopeContext: typeof p.scopeContext === "number" ? p.scopeContext : undefined,
 	});
 
 	renderedGroups = scoped.groups;

--- a/tests/grep-output.test.ts
+++ b/tests/grep-output.test.ts
@@ -6,6 +6,8 @@ import { tmpdir } from "node:os";
 import { ensureHashInit, computeLineHash, escapeControlCharsForDisplay } from "../src/hashline.js";
 import * as grepModule from "../src/grep.js";
 import * as grepOutputModule from "../src/grep-output.js";
+import { buildGrepOutput } from "../src/grep-output.js";
+import { buildPtcLine } from "../src/ptc-value.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixturesDir = resolve(__dirname, "fixtures");
@@ -81,5 +83,80 @@ describe("buildGrepOutput", () => {
     expect(built.text).toContain(`${filePath}: 60 matches`);
     expect(getTextContent(result)).toBe(built.text);
     expect(result.details?.ptcValue).toEqual(built.ptcValue);
+  });
+
+  it("appends 'scoped to ±N lines' to the symbol header when scope.contextLines is set", async () => {
+    const line3 = buildPtcLine(3, "  const x = 1;");
+    const out = buildGrepOutput({
+      summary: false,
+      totalMatches: 1,
+      groups: [
+        {
+          displayPath: "foo.ts",
+          absolutePath: "/tmp/foo.ts",
+          matchCount: 1,
+          entries: [{ kind: "match", line: line3 }],
+          scope: {
+            mode: "symbol",
+            symbol: { name: "alpha", kind: "function", startLine: 1, endLine: 10 },
+            matchLines: [3],
+            contextLines: 3,
+          },
+        },
+      ],
+      records: [{ path: "/tmp/foo.ts", kind: "match", ...line3 }],
+      scopeMode: "symbol",
+    });
+    expect(out.text).toContain("--- foo.ts :: function alpha (1-10, 1 matches, scoped to ±3 lines) ---");
+  });
+
+  it("renders '±0' when scope.contextLines is 0", async () => {
+    const line3 = buildPtcLine(3, "  const x = 1;");
+    const out = buildGrepOutput({
+      summary: false,
+      totalMatches: 1,
+      groups: [
+        {
+          displayPath: "foo.ts",
+          absolutePath: "/tmp/foo.ts",
+          matchCount: 1,
+          entries: [{ kind: "match", line: line3 }],
+          scope: {
+            mode: "symbol",
+            symbol: { name: "alpha", kind: "function", startLine: 1, endLine: 10 },
+            matchLines: [3],
+            contextLines: 0,
+          },
+        },
+      ],
+      records: [{ path: "/tmp/foo.ts", kind: "match", ...line3 }],
+      scopeMode: "symbol",
+    });
+    expect(out.text).toContain("scoped to ±0 lines");
+  });
+
+  it("omits the '±N lines' suffix when scope.contextLines is unset", async () => {
+    const line3 = buildPtcLine(3, "  const x = 1;");
+    const out = buildGrepOutput({
+      summary: false,
+      totalMatches: 1,
+      groups: [
+        {
+          displayPath: "foo.ts",
+          absolutePath: "/tmp/foo.ts",
+          matchCount: 1,
+          entries: [{ kind: "match", line: line3 }],
+          scope: {
+            mode: "symbol",
+            symbol: { name: "alpha", kind: "function", startLine: 1, endLine: 10 },
+            matchLines: [3],
+          },
+        },
+      ],
+      records: [{ path: "/tmp/foo.ts", kind: "match", ...line3 }],
+      scopeMode: "symbol",
+    });
+    expect(out.text).toContain("--- foo.ts :: function alpha (1-10, 1 matches) ---");
+    expect(out.text).not.toContain("scoped to");
   });
 });

--- a/tests/grep-scope-context.test.ts
+++ b/tests/grep-scope-context.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve, dirname, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import { ensureHashInit } from "../src/hashline.js";
+import { registerGrepTool } from "../src/grep.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function getGrepTool() {
+  let capturedTool: any = null;
+  registerGrepTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  if (!capturedTool) throw new Error("grep tool was not registered");
+  return capturedTool;
+}
+
+async function callGrepTool(params: Record<string, unknown>) {
+  const tool = await getGrepTool();
+  return tool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function getTextContent(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+export function writeFixture(name: string, content: string): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "pi-grep-scope-context-"));
+  const filePath = resolve(dir, name);
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+describe("grep scopeContext parameter", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("rejects non-numeric scopeContext string with a coercion error", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const result = await callGrepTool({
+      pattern: "createDemoDirectory",
+      path: filePath,
+      literal: true,
+      scope: "symbol",
+      scopeContext: "not-a-number",
+    });
+    expect(result.isError).toBe(true);
+    const text = getTextContent(result);
+    expect(text).toMatch(/scopeContext/);
+    expect(text).toMatch(/base-10 integer/);
+  });
+
+  it("rejects negative scopeContext with a non-negative-integer error", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const result = await callGrepTool({
+      pattern: "createDemoDirectory",
+      path: filePath,
+      literal: true,
+      scope: "symbol",
+      scopeContext: -1,
+    });
+    expect(result.isError).toBe(true);
+    expect(getTextContent(result)).toBe("Invalid scopeContext: expected a non-negative integer, received -1.");
+  });
+
+  it("rejects scopeContext when scope is not 'symbol' and points to 'context'", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const result = await callGrepTool({
+      pattern: "createDemoDirectory",
+      path: filePath,
+      literal: true,
+      scopeContext: 3,
+      // no scope: "symbol"
+    });
+    expect(result.isError).toBe(true);
+    const text = getTextContent(result);
+    expect(text).toContain("scopeContext");
+    expect(text).toContain('scope: "symbol"');
+    expect(text).toContain("context");
+  });
+
+  it("renders symbol header with '±0 lines' suffix and only match lines when scopeContext is 0", async () => {
+    const filePath = writeFixture("win0.ts", [
+      "export function alpha() {",
+      "  const a = 1;",
+      "  console.log(target);",
+      "  const c = 3;",
+      "  return target;",
+      "}",
+    ].join("\n"));
+
+    const result = await callGrepTool({
+      pattern: "target",
+      path: filePath,
+      literal: true,
+      scope: "symbol",
+      scopeContext: 0,
+    });
+    const text = getTextContent(result);
+    const displayPath = basename(filePath);
+
+    expect(text).toContain(`--- ${displayPath} :: function alpha (1-6, 2 matches, scoped to ±0 lines) ---`);
+    expect(text).toMatch(/:>>3:[0-9a-f]+\|/);
+    expect(text).toMatch(/:>>5:[0-9a-f]+\|/);
+    expect(text).not.toMatch(/:  1:/);
+    expect(text).not.toMatch(/:  2:/);
+    expect(text).not.toMatch(/:  4:/);
+    expect(text).not.toMatch(/:  6:/);
+  });
+
+  it("emits no extra warning line when the window clips at symbol boundary", async () => {
+    const filePath = writeFixture("clip.ts", [
+      "export function alpha() {",
+      "  const target = 1;",
+      "  const a = 2;",
+      "  const b = 3;",
+      "  const c = 4;",
+      "  const d = 5;",
+      "  return 0;",
+      "}",
+    ].join("\n"));
+
+    const result = await callGrepTool({
+      pattern: "target",
+      path: filePath,
+      literal: true,
+      scope: "symbol",
+      scopeContext: 5,
+    });
+    const text = getTextContent(result);
+
+    expect(text).not.toMatch(/clipped/i);
+    expect(text).not.toMatch(/\[Warning:.*boundary/);
+  });
+
+  it("renders ±N context lines around match with the header suffix (end-to-end)", async () => {
+    const filePath = writeFixture("winN.ts", [
+      "export function alpha() {",
+      "  const a = 1;",
+      "  const b = 2;",
+      "  const c = 3;",
+      "  const target = 4;",
+      "  const e = 5;",
+      "  const f = 6;",
+      "  const g = 7;",
+      "  return 0;",
+      "}",
+    ].join("\n"));
+
+    const result = await callGrepTool({
+      pattern: "target",
+      path: filePath,
+      literal: true,
+      scope: "symbol",
+      scopeContext: 2,
+    });
+    const text = getTextContent(result);
+    const displayPath = basename(filePath);
+
+    expect(text).toContain(`--- ${displayPath} :: function alpha (1-10, 1 matches, scoped to ±2 lines) ---`);
+    expect(text).toMatch(/:  3:[0-9a-f]+\|/);
+    expect(text).toMatch(/:  4:[0-9a-f]+\|/);
+    expect(text).toMatch(/:>>5:[0-9a-f]+\|/);
+    expect(text).toMatch(/:  6:[0-9a-f]+\|/);
+    expect(text).toMatch(/:  7:[0-9a-f]+\|/);
+    expect(text).not.toMatch(/:  1:/);
+    expect(text).not.toMatch(/:  2:/);
+    expect(text).not.toMatch(/:  8:/);
+    expect(text).not.toMatch(/:  9:/);
+    expect(text).not.toMatch(/:  10:/);
+  });
+
+  it("falls back unchanged when a file is unmappable; scopeContext has no effect", async () => {
+    const filePath = resolve(fixturesDir, "plain.txt");
+    const withCtx = await callGrepTool({
+      pattern: "plain text",
+      path: filePath,
+      literal: true,
+      scope: "symbol",
+      scopeContext: 3,
+    });
+    const withoutCtx = await callGrepTool({
+      pattern: "plain text",
+      path: filePath,
+      literal: true,
+      scope: "symbol",
+    });
+    const textWithCtx = getTextContent(withCtx);
+    const textWithoutCtx = getTextContent(withoutCtx);
+
+    expect(textWithCtx).toContain(`[Warning: symbol scoping unavailable for ${filePath}`);
+    expect(textWithCtx).toBe(textWithoutCtx);
+    expect(textWithCtx).not.toContain("scoped to");
+  });
+
+  it("falls back unchanged for matches with no enclosing symbol; scopeContext has no effect", async () => {
+    const filePath = writeFixture("no-symbol.ts", [
+      "// lonely marker",
+      "export function alpha() {",
+      "  return 1;",
+      "}",
+    ].join("\n"));
+
+    const withCtx = await callGrepTool({
+      pattern: "lonely",
+      path: filePath,
+      literal: true,
+      context: 1,
+      scope: "symbol",
+      scopeContext: 3,
+    });
+    const withoutCtx = await callGrepTool({
+      pattern: "lonely",
+      path: filePath,
+      literal: true,
+      context: 1,
+      scope: "symbol",
+    });
+    const textWithCtx = getTextContent(withCtx);
+    const textWithoutCtx = getTextContent(withoutCtx);
+
+    expect(textWithCtx).toContain(`[Warning: no enclosing symbol for ${filePath}:1`);
+    expect(textWithCtx).toBe(textWithoutCtx);
+    expect(textWithCtx).not.toContain("scoped to");
+  });
+
+  it("summary: true silently ignores scopeContext", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const summary = await callGrepTool({
+      pattern: "export",
+      path: filePath,
+      literal: true,
+      summary: true,
+      scope: "symbol",
+      scopeContext: 3,
+    });
+    const baseline = await callGrepTool({
+      pattern: "export",
+      path: filePath,
+      literal: true,
+      summary: true,
+    });
+
+    expect(summary.isError).toBeUndefined();
+    expect(getTextContent(summary)).toBe(getTextContent(baseline));
+    expect((summary.details?.ptcValue as any).scopes).toBeUndefined();
+    expect(getTextContent(summary)).not.toContain("scoped to");
+  });
+
+  it("omitting scopeContext returns byte-identical full-body output (back-compat)", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const full = await callGrepTool({
+      pattern: "createDemoDirectory",
+      path: filePath,
+      literal: true,
+      scope: "symbol",
+    });
+    const fullText = getTextContent(full);
+
+    expect(fullText).not.toContain("scoped to");
+    expect((full.details?.ptcValue as any).scopes.groups[0].symbol).toBeDefined();
+    expect((full.details?.ptcValue as any).scopes.groups[0].contextLines).toBeUndefined();
+  });
+});

--- a/tests/grep-symbol-scope-first-line.test.ts
+++ b/tests/grep-symbol-scope-first-line.test.ts
@@ -43,4 +43,280 @@ describe("scopeGrepGroupsToSymbols ordering", () => {
     expect(scoped.groups).toHaveLength(1);
     expect(scoped.groups[0].scope?.symbol.name).toBe("alpha");
   });
+
+  it("accepts scopeContext and records it on scope.contextLines while preserving full-body entries when undefined", () => {
+    const lines = ["export function alpha() {", "  const x = 1;", "  const y = 2;", "}"];
+    const map: FileMap = {
+      path: "/tmp/b.ts",
+      totalLines: 4,
+      totalBytes: lines.join("\n").length,
+      language: "typescript",
+      detailLevel: DetailLevel.Full,
+      imports: [],
+      symbols: [{ name: "alpha", kind: SymbolKind.Function, startLine: 1, endLine: 4 }],
+    };
+
+    const omitted = scopeGrepGroupsToSymbols({
+      groups: [
+        {
+          displayPath: "b.ts",
+          absolutePath: "/tmp/b.ts",
+          matchCount: 1,
+          entries: [{ kind: "match", line: buildPtcLine(2, lines[1]) }],
+        },
+      ],
+      fileLinesByPath: new Map([["/tmp/b.ts", lines]]),
+      fileMapsByPath: new Map([["/tmp/b.ts", map]]),
+      contextLines: 0,
+    });
+    expect(omitted.groups).toHaveLength(1);
+    expect(omitted.groups[0].scope?.contextLines).toBeUndefined();
+    expect(omitted.groups[0].entries).toHaveLength(4);
+
+    const withCtx = scopeGrepGroupsToSymbols({
+      groups: [
+        {
+          displayPath: "b.ts",
+          absolutePath: "/tmp/b.ts",
+          matchCount: 1,
+          entries: [{ kind: "match", line: buildPtcLine(2, lines[1]) }],
+        },
+      ],
+      fileLinesByPath: new Map([["/tmp/b.ts", lines]]),
+      fileMapsByPath: new Map([["/tmp/b.ts", map]]),
+      contextLines: 0,
+      scopeContext: 3,
+    });
+    expect(withCtx.groups).toHaveLength(1);
+    expect(withCtx.groups[0].scope?.contextLines).toBe(3);
+  });
+
+  it("emits only the match line when scopeContext is 0", () => {
+    const lines = [
+      "export function alpha() {",
+      "  const a = 1;",
+      "  const b = 2;",
+      "  const c = 3;",
+      "  const d = 4;",
+      "}",
+    ];
+    const map: FileMap = {
+      path: "/tmp/c.ts",
+      totalLines: 6,
+      totalBytes: lines.join("\n").length,
+      language: "typescript",
+      detailLevel: DetailLevel.Full,
+      imports: [],
+      symbols: [{ name: "alpha", kind: SymbolKind.Function, startLine: 1, endLine: 6 }],
+    };
+
+    const scoped = scopeGrepGroupsToSymbols({
+      groups: [
+        {
+          displayPath: "c.ts",
+          absolutePath: "/tmp/c.ts",
+          matchCount: 1,
+          entries: [{ kind: "match", line: buildPtcLine(3, lines[2]) }],
+        },
+      ],
+      fileLinesByPath: new Map([["/tmp/c.ts", lines]]),
+      fileMapsByPath: new Map([["/tmp/c.ts", map]]),
+      contextLines: 0,
+      scopeContext: 0,
+    });
+
+    expect(scoped.groups).toHaveLength(1);
+    const entries = scoped.groups[0].entries;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].kind).toBe("match");
+    expect(entries[0].kind === "match" && entries[0].line.line).toBe(3);
+  });
+
+  it("emits ±N context lines clipped at symbol start boundary", () => {
+    const lines = [
+      "export function alpha() {",
+      "  const target = 1;",
+      "  const a = 2;",
+      "  const b = 3;",
+      "  const c = 4;",
+      "  const d = 5;",
+      "  const e = 6;",
+      "  const f = 7;",
+      "  return target;",
+      "}",
+    ];
+    const map: FileMap = {
+      path: "/tmp/d.ts",
+      totalLines: 10,
+      totalBytes: lines.join("\n").length,
+      language: "typescript",
+      detailLevel: DetailLevel.Full,
+      imports: [],
+      symbols: [{ name: "alpha", kind: SymbolKind.Function, startLine: 1, endLine: 10 }],
+    };
+
+    const scoped = scopeGrepGroupsToSymbols({
+      groups: [
+        {
+          displayPath: "d.ts",
+          absolutePath: "/tmp/d.ts",
+          matchCount: 1,
+          entries: [{ kind: "match", line: buildPtcLine(2, lines[1]) }],
+        },
+      ],
+      fileLinesByPath: new Map([["/tmp/d.ts", lines]]),
+      fileMapsByPath: new Map([["/tmp/d.ts", map]]),
+      contextLines: 0,
+      scopeContext: 3,
+    });
+
+    const emittedLineNumbers = scoped.groups[0].entries
+      .filter((e): e is Extract<typeof e, { kind: "match" | "context" }> => e.kind !== "separator")
+      .map((e) => e.line.line);
+    expect(emittedLineNumbers).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("clips window at symbol endLine when match is near end", () => {
+    const lines = [
+      "export function alpha() {",
+      "  const a = 1;",
+      "  const b = 2;",
+      "  const c = 3;",
+      "  const d = 4;",
+      "  const e = 5;",
+      "  const f = 6;",
+      "  const g = 7;",
+      "  return target;",
+      "}",
+    ];
+    const map: FileMap = {
+      path: "/tmp/e.ts",
+      totalLines: 10,
+      totalBytes: lines.join("\n").length,
+      language: "typescript",
+      detailLevel: DetailLevel.Full,
+      imports: [],
+      symbols: [{ name: "alpha", kind: SymbolKind.Function, startLine: 1, endLine: 10 }],
+    };
+
+    const scoped = scopeGrepGroupsToSymbols({
+      groups: [
+        {
+          displayPath: "e.ts",
+          absolutePath: "/tmp/e.ts",
+          matchCount: 1,
+          entries: [{ kind: "match", line: buildPtcLine(9, lines[8]) }],
+        },
+      ],
+      fileLinesByPath: new Map([["/tmp/e.ts", lines]]),
+      fileMapsByPath: new Map([["/tmp/e.ts", map]]),
+      contextLines: 0,
+      scopeContext: 3,
+    });
+
+    const emittedLineNumbers = scoped.groups[0].entries
+      .filter((e): e is Extract<typeof e, { kind: "match" | "context" }> => e.kind !== "separator")
+      .map((e) => e.line.line);
+    expect(emittedLineNumbers).toEqual([6, 7, 8, 9, 10]);
+  });
+
+  it("merges two matches with overlapping windows into one contiguous range without duplicates", () => {
+    const lines = [
+      "export function alpha() {",
+      "  const a = 1;",
+      "  const target = 2;",
+      "  const c = 3;",
+      "  const d = 4;",
+      "  const target2 = 5;",
+      "  const f = 6;",
+      "  return 0;",
+      "}",
+    ];
+    const map: FileMap = {
+      path: "/tmp/f.ts",
+      totalLines: 9,
+      totalBytes: lines.join("\n").length,
+      language: "typescript",
+      detailLevel: DetailLevel.Full,
+      imports: [],
+      symbols: [{ name: "alpha", kind: SymbolKind.Function, startLine: 1, endLine: 9 }],
+    };
+
+    const scoped = scopeGrepGroupsToSymbols({
+      groups: [
+        {
+          displayPath: "f.ts",
+          absolutePath: "/tmp/f.ts",
+          matchCount: 2,
+          entries: [
+            { kind: "match", line: buildPtcLine(3, lines[2]) },
+            { kind: "match", line: buildPtcLine(6, lines[5]) },
+          ],
+        },
+      ],
+      fileLinesByPath: new Map([["/tmp/f.ts", lines]]),
+      fileMapsByPath: new Map([["/tmp/f.ts", map]]),
+      contextLines: 0,
+      scopeContext: 2,
+    });
+
+    const entries = scoped.groups[0].entries;
+    const emittedLineNumbers = entries
+      .filter((e): e is Extract<typeof e, { kind: "match" | "context" }> => e.kind !== "separator")
+      .map((e) => e.line.line);
+    expect(emittedLineNumbers).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it("emits a '--' separator between non-overlapping windows in the same symbol", () => {
+    const lines = [
+      "export function alpha() {",
+      "  const a = 1;",
+      "  const target = 2;",
+      "  const c = 3;",
+      "  const d = 4;",
+      "  const e = 5;",
+      "  const f = 6;",
+      "  const g = 7;",
+      "  const h = 8;",
+      "  const target2 = 9;",
+      "  const j = 10;",
+      "  return 0;",
+      "}",
+    ];
+    const map: FileMap = {
+      path: "/tmp/g.ts",
+      totalLines: 13,
+      totalBytes: lines.join("\n").length,
+      language: "typescript",
+      detailLevel: DetailLevel.Full,
+      imports: [],
+      symbols: [{ name: "alpha", kind: SymbolKind.Function, startLine: 1, endLine: 13 }],
+    };
+
+    const scoped = scopeGrepGroupsToSymbols({
+      groups: [
+        {
+          displayPath: "g.ts",
+          absolutePath: "/tmp/g.ts",
+          matchCount: 2,
+          entries: [
+            { kind: "match", line: buildPtcLine(3, lines[2]) },
+            { kind: "match", line: buildPtcLine(10, lines[9]) },
+          ],
+        },
+      ],
+      fileLinesByPath: new Map([["/tmp/g.ts", lines]]),
+      fileMapsByPath: new Map([["/tmp/g.ts", map]]),
+      contextLines: 0,
+      scopeContext: 1,
+    });
+
+    const entries = scoped.groups[0].entries;
+    const separators = entries.filter((e) => e.kind === "separator");
+    expect(separators).toHaveLength(1);
+    expect(separators[0]).toEqual({ kind: "separator", text: "--" });
+
+    const shape = entries.map((e) => (e.kind === "separator" ? "--" : e.line.line));
+    expect(shape).toEqual([2, 3, 4, "--", 9, 10, 11]);
+  });
 });

--- a/tests/grep-symbol-scope-schema.test.ts
+++ b/tests/grep-symbol-scope-schema.test.ts
@@ -68,4 +68,11 @@ describe("grep scope schema passthrough", () => {
     expect(normal.details?.ptcValue?.records).toHaveLength(3);
     expect((normal.details?.ptcValue as any).scopes).toBeUndefined();
   });
+
+  it("exposes optional scopeContext as a number-or-string union", async () => {
+    const tool = await getGrepTool();
+    expect(tool.parameters.properties.scopeContext).toBeDefined();
+    expect(tool.parameters.properties.scopeContext.anyOf).toBeDefined();
+    expect(tool.parameters.required ?? []).not.toContain("scopeContext");
+  });
 });


### PR DESCRIPTION
## Summary
- add optional `scopeContext` for `grep` when `scope: "symbol"` is used
- render clipped, merged symbol windows with `scoped to ±N lines` headers
- preserve full-body back-compat and unchanged fallback behavior for unmappable files and non-symbol matches
- document the new parameter and add end-to-end and unit coverage
- reject negative `scopeContext` values discovered during code review

## Verification
- npm test
- npm run typecheck

Resolves #101