### PR TITLE
feat: add structured ptcValue.error envelopes across tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,46 @@ Includes grouped match ranges and anchored lines.
 ### `edit`
 Includes summary, diff, changed line, warnings, no-op metadata, and semantic edit classification.
 
+### `ptcValue.error`
+When a tool fails, its result includes a structured `error` envelope inside `ptcValue` so downstream consumers (`pi-prompt-assembler`, agent retry loops) can dispatch programmatically without parsing free text.
+
+**Shape:**
+
+```ts
+interface PtcError {
+  code: string;       // stable, kebab-case, drawn from src/ptc-error-codes.ts
+  message: string;    // matches (or is a clean superset of) content[0].text
+  hint?: string;      // concrete next-step recovery suggestion, when one exists
+  details?: unknown;  // tool-specific structured data (e.g. updatedAnchors for hash-mismatch)
+}
+```
+
+**Envelope on error:**
+
+```ts
+{
+  isError: true,                         // (or unset for nu — see below)
+  content: [{ type: "text", text: ... }],
+  details: {
+    ptcValue: {
+      tool: "<toolName>",                // read | edit | grep | ast_search | find | ls | write | nu
+      ok: false,
+      path?: string,                     // when the failure pertains to a specific path
+      error: PtcError,
+    },
+  },
+}
+```
+
+**Codes:** see [`src/ptc-error-codes.ts`](src/ptc-error-codes.ts) for the full taxonomy. Adding a new error code requires extending that file.
+
+**Warnings vs errors:**
+
+- **`ptcValue.warnings: PtcWarning[]`** — non-fatal. The tool produced its primary result but flagged something the agent should know (e.g. fuzzy symbol match, binary content written). `PtcWarning.code` shares the same kebab-case namespace as `PtcError.code`.
+- **`ptcValue.error: PtcError`** — fatal. The tool could not produce its primary result.
+
+**Special case — `nu`:** the nu tool always returns `isError` falsy and surfaces failure exclusively through `ptcValue.ok === false` plus `ptcValue.error`. This preserves backward-compatible streaming behavior while still giving consumers a uniform structured handle.
+
 Hashes and anchors are tied to raw file content. Display fields are escaped for safe rendering; raw fields preserve the underlying text.
 
 ### PTC tool policy contract

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -4,12 +4,13 @@ import type { Static } from "@sinclair/typebox";
 import { readFileSync } from "fs";
 import { readFile as fsReadFile, writeFile as fsWriteFile } from "fs/promises";
 import { detectLineEnding, generateCompactOrFullDiff, normalizeToLF, replaceText, restoreLineEndings, stripBom } from "./edit-diff";
-import { applyHashlineEdits, computeLineHash, ensureHashInit, parseLineRef, type HashlineEditItem, escapeControlCharsForDisplay } from "./hashline";
+import { HashlineMismatchError, applyHashlineEdits, computeLineHash, ensureHashInit, parseLineRef, type HashlineEditItem, escapeControlCharsForDisplay } from "./hashline";
 import { resolveToCwd } from "./path-utils";
 import { throwIfAborted } from "./runtime";
 import { buildEditOutput } from "./edit-output.js";
 import { classifyEdit, isDifftAvailable, runDifftastic } from "./edit-classify.js";
 import type { SemanticSummary } from "./ptc-value.js";
+import { buildPtcError } from "./ptc-value.js";
 import { Text } from "@mariozechner/pi-tui";
 import { formatEditCallText, formatEditResultText } from "./edit-render-helpers.js";
 
@@ -90,7 +91,20 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				return {
 					content: [{ type: "text", text: message }],
 					isError: true,
-					details: { diff: "", firstChangedLine: undefined } as EditToolDetails,
+					details: {
+						diff: "",
+						firstChangedLine: undefined,
+						ptcValue: {
+							tool: "edit",
+							ok: false,
+							path: absolutePath,
+							error: buildPtcError(
+								"file-not-read",
+								message,
+								`Call read(${JSON.stringify(rawPath)}) first, or use grep, ast_search, or write to produce fresh anchors for this file.`,
+							),
+						},
+					} as EditToolDetails & { ptcValue: any },
 				};
 			}
 			const legacyOldText =
@@ -112,9 +126,22 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			let legacyNormalizationWarning: string | undefined;
 			if (!hasEditsInput && hasLegacyInput) {
 				if (legacyOldText === undefined || legacyNewText === undefined) {
-					throw new Error(
-						"Legacy edit input requires both oldText/newText (or old_text/new_text) when 'edits' is omitted.",
-					);
+					const message =
+						"Legacy edit input requires both oldText/newText (or old_text/new_text) when 'edits' is omitted.";
+					return {
+						content: [{ type: "text", text: message }],
+						isError: true,
+						details: {
+							diff: "",
+							firstChangedLine: undefined,
+							ptcValue: {
+								tool: "edit",
+								ok: false,
+								path: absolutePath,
+								error: buildPtcError("invalid-edit-variant", message),
+							},
+						} as EditToolDetails & { ptcValue: any },
+					};
 				}
 				edits = [
 					{
@@ -133,7 +160,16 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				return {
 					content: [{ type: "text", text: "No edits provided." }],
 					isError: true,
-					details: { diff: "", firstChangedLine: undefined } as EditToolDetails,
+					details: {
+						diff: "",
+						firstChangedLine: undefined,
+						ptcValue: {
+							tool: "edit",
+							ok: false,
+							path: absolutePath,
+							error: buildPtcError("invalid-edit-variant", "No edits provided."),
+						},
+					} as EditToolDetails & { ptcValue: any },
 				};
 			}
 
@@ -142,14 +178,38 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				throwIfAborted(signal);
 				const e = edits[i] as Record<string, unknown>;
 				if (("old_text" in e || "new_text" in e) && !("replace" in e)) {
-					throw new Error(
-						`edits[${i}] has top-level 'old_text'/'new_text'. Use {replace: {old_text, new_text}} or {set_line}, {replace_lines}, {insert_after}.`,
-					);
+					const message = `edits[${i}] has top-level 'old_text'/'new_text'. Use {replace: {old_text, new_text}} or {set_line}, {replace_lines}, {insert_after}.`;
+					return {
+						content: [{ type: "text", text: message }],
+						isError: true,
+						details: {
+							diff: "",
+							firstChangedLine: undefined,
+							ptcValue: {
+								tool: "edit",
+								ok: false,
+								path: absolutePath,
+								error: buildPtcError("invalid-edit-variant", message),
+							},
+						} as EditToolDetails & { ptcValue: any },
+					};
 				}
 				if ("diff" in e) {
-					throw new Error(
-						`edits[${i}] contains 'diff' from patch mode. Hashline edit expects one of: {set_line}, {replace_lines}, {insert_after}, {replace}.`,
-					);
+					const message = `edits[${i}] contains 'diff' from patch mode. Hashline edit expects one of: {set_line}, {replace_lines}, {insert_after}, {replace}.`;
+					return {
+						content: [{ type: "text", text: message }],
+						isError: true,
+						details: {
+							diff: "",
+							firstChangedLine: undefined,
+							ptcValue: {
+								tool: "edit",
+								ok: false,
+								path: absolutePath,
+								error: buildPtcError("invalid-edit-variant", message),
+							},
+						} as EditToolDetails & { ptcValue: any },
+					};
 				}
 				const variantCount =
 					Number("set_line" in e) +
@@ -157,9 +217,21 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 					Number("insert_after" in e) +
 					Number("replace" in e);
 				if (variantCount !== 1) {
-					throw new Error(
-						`edits[${i}] must contain exactly one of: 'set_line', 'replace_lines', 'insert_after', 'replace'. Got: [${Object.keys(e).join(", ")}].`,
-					);
+					const message = `edits[${i}] must contain exactly one of: 'set_line', 'replace_lines', 'insert_after', 'replace'. Got: [${Object.keys(e).join(", ")}].`;
+					return {
+						content: [{ type: "text", text: message }],
+						isError: true,
+						details: {
+							diff: "",
+							firstChangedLine: undefined,
+							ptcValue: {
+								tool: "edit",
+								ok: false,
+								path: absolutePath,
+								error: buildPtcError("invalid-edit-variant", message),
+							},
+						} as EditToolDetails & { ptcValue: any },
+					};
 				}
 			}
 
@@ -175,16 +247,56 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				rawBuffer = await fsReadFile(absolutePath);
 			} catch (err: any) {
 				const code = err?.code;
+				let errCode: string;
+				let message: string;
+				let hint: string | undefined;
+				let errorDetails: { fsCode?: string; fsMessage?: string } | undefined;
 				if (code === "EISDIR") {
-					throw new Error(`Path is a directory: ${path}`);
+					errCode = "path-is-directory";
+					message = `Path is a directory: ${path}`;
+					hint = `Use ls(${JSON.stringify(path)}) to inspect directories.`;
+				} else if (code === "ENOENT") {
+					errCode = "file-not-found";
+					message = `File not found: ${path}`;
+				} else if (code === "EACCES" || code === "EPERM") {
+					errCode = "permission-denied";
+					message = `Permission denied: ${path}`;
+				} else {
+					errCode = "fs-error";
+					message = `File not readable: ${path}${err?.message ? ` — ${err.message}` : ""}`;
+					errorDetails = { fsCode: code, fsMessage: err?.message };
 				}
-				if (code === "ENOENT") {
-					throw new Error(`File not found: ${path}`);
-				}
-				throw new Error(`File not readable: ${path}`);
+				return {
+					content: [{ type: "text", text: message }],
+					isError: true,
+					details: {
+						diff: "",
+						firstChangedLine: undefined,
+						ptcValue: {
+							tool: "edit",
+							ok: false,
+							path: absolutePath,
+							error: buildPtcError(errCode, message, hint, errorDetails),
+						},
+					} as EditToolDetails & { ptcValue: any },
+				};
 			}
 			if (isBinaryBuffer(rawBuffer)) {
-				throw new Error(`Cannot edit binary file: ${path}`);
+				const message = `Cannot edit binary file: ${path}`;
+				return {
+					content: [{ type: "text", text: message }],
+					isError: true,
+					details: {
+						diff: "",
+						firstChangedLine: undefined,
+						ptcValue: {
+							tool: "edit",
+							ok: false,
+							path: absolutePath,
+							error: buildPtcError("binary-file", message),
+						},
+					} as EditToolDetails & { ptcValue: any },
+				};
 			}
 			throwIfAborted(signal);
 			const raw = rawBuffer.toString("utf-8");
@@ -193,14 +305,69 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			const originalNormalized = normalizeToLF(content);
 			let result = originalNormalized;
 
-			const anchorResult = applyHashlineEdits(result, anchorEdits, signal);
+			let anchorResult;
+			try {
+				anchorResult = applyHashlineEdits(result, anchorEdits, signal);
+			} catch (err) {
+				if (err instanceof HashlineMismatchError) {
+					return {
+						content: [{ type: "text", text: err.message }],
+						isError: true,
+						details: {
+							diff: "",
+							firstChangedLine: undefined,
+							ptcValue: {
+								tool: "edit",
+								ok: false,
+								path: absolutePath,
+								error: buildPtcError("hash-mismatch", err.message, undefined, {
+									updatedAnchors: err.updatedAnchors,
+								}),
+							},
+						} as EditToolDetails & { ptcValue: any },
+					};
+				}
+				throw err;
+			}
 			result = anchorResult.content;
 
 			for (const r of replaceEdits) {
 				throwIfAborted(signal);
-				if (!r.replace.old_text.length) throw new Error("replace.old_text must not be empty.");
+				if (!r.replace.old_text.length) {
+					const message = "replace.old_text must not be empty.";
+					return {
+						content: [{ type: "text", text: message }],
+						isError: true,
+						details: {
+							diff: "",
+							firstChangedLine: undefined,
+							ptcValue: {
+								tool: "edit",
+								ok: false,
+								path: absolutePath,
+								error: buildPtcError("invalid-edit-variant", message),
+							},
+						} as EditToolDetails & { ptcValue: any },
+					};
+				}
 				const rep = replaceText(result, r.replace.old_text, r.replace.new_text, { all: r.replace.all ?? false });
-				if (!rep.count) throw new Error(`Could not find text to replace in ${path}.`);
+				if (!rep.count) {
+					const message = `Could not find text to replace in ${path}.`;
+					return {
+						content: [{ type: "text", text: message }],
+						isError: true,
+						details: {
+							diff: "",
+							firstChangedLine: undefined,
+							ptcValue: {
+								tool: "edit",
+								ok: false,
+								path: absolutePath,
+								error: buildPtcError("text-not-found", message),
+							},
+						} as EditToolDetails & { ptcValue: any },
+					};
+				}
 				result = rep.content;
 			}
 
@@ -244,14 +411,51 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 						diagnostic += `\nThe file currently contains:\n${preview}\nYour edits were normalized back to the original content. Ensure your replacement changes actual code, not just formatting.`;
 					}
 				}
-				throw new Error(diagnostic);
+				return {
+					content: [{ type: "text", text: diagnostic }],
+					isError: true,
+					details: {
+						diff: "",
+						firstChangedLine: undefined,
+						ptcValue: {
+							tool: "edit",
+							ok: false,
+							path: absolutePath,
+							error: buildPtcError("no-op", diagnostic),
+						},
+					} as EditToolDetails & { ptcValue: any },
+				};
 			}
 
 			throwIfAborted(signal);
 			try {
 				await fsWriteFile(absolutePath, bom + restoreLineEndings(result, originalEnding), "utf-8");
 			} catch (err: any) {
-				throw wrapWriteError(err, path);
+				const wrapped = wrapWriteError(err, path);
+				const code =
+					err?.code === "EACCES" || err?.code === "EPERM"
+						? "permission-denied"
+						: err?.code === "ENOENT"
+							? "file-not-found"
+							: "fs-error";
+				const message =
+					code === "fs-error" && err?.message ? `${wrapped.message} — ${err.message}` : wrapped.message;
+				return {
+					content: [{ type: "text", text: message }],
+					isError: true,
+					details: {
+						diff: "",
+						firstChangedLine: undefined,
+						ptcValue: {
+							tool: "edit",
+							ok: false,
+							path: absolutePath,
+							error: buildPtcError(code, message, undefined, code === "fs-error"
+								? { fsCode: err?.code, fsMessage: err?.message }
+								: undefined),
+						},
+					} as EditToolDetails & { ptcValue: any },
+				};
 			}
 
 			const diffResult = generateCompactOrFullDiff(originalNormalized, result);

--- a/src/find.ts
+++ b/src/find.ts
@@ -8,6 +8,7 @@ import { resolve, relative, join } from "node:path";
 import { resolveToCwd } from "./path-utils.js";
 import * as findStat from "./find-stat.js";
 import { parseRelativeOrIsoDate, parseSize } from "./find-parsers.js";
+import { buildPtcError } from "./ptc-value.js";
 
 const MAX_BYTES = 50 * 1024; // 50 KB
 const DEFAULT_LIMIT = 1000;
@@ -373,17 +374,51 @@ export function registerFindTool(pi: ExtensionAPI) {
       try {
         const s = await stat(searchPath);
         if (!s.isDirectory()) {
+          const message = `Error: '${params.path ?? searchPath}' is not a directory`;
           return {
-            content: [{ type: "text" as const, text: `Error: '${params.path ?? searchPath}' is not a directory` }],
+            content: [{ type: "text" as const, text: message }],
             isError: true,
-            details: {},
+            details: {
+              ptcValue: {
+                tool: "find",
+                ok: false,
+                path: params.path ?? searchPath,
+                error: buildPtcError(
+                  "path-not-directory",
+                  message,
+                  `Use ls on a directory, or read(${JSON.stringify(params.path ?? searchPath)}) for a single file.`,
+                ),
+              },
+            },
           };
         }
-      } catch {
+      } catch (err: any) {
+        const target = params.path ?? searchPath;
+        const code =
+          err?.code === "EACCES" || err?.code === "EPERM"
+            ? "permission-denied"
+            : err?.code === "ENOENT"
+              ? "path-not-found"
+              : "fs-error";
+        const message =
+          code === "permission-denied"
+            ? `Error: permission denied for path '${target}'`
+            : code === "path-not-found"
+              ? `Error: path '${target}' does not exist`
+              : `Error: could not access path '${target}': ${err?.message ?? String(err)}`;
         return {
-          content: [{ type: "text" as const, text: `Error: path '${params.path ?? searchPath}' does not exist` }],
+          content: [{ type: "text" as const, text: message }],
           isError: true,
-          details: {},
+          details: {
+            ptcValue: {
+              tool: "find",
+              ok: false,
+              path: target,
+              error: buildPtcError(code, message, undefined, code === "fs-error"
+                ? { fsCode: err?.code, fsMessage: err?.message }
+                : undefined),
+            },
+          },
         };
       }
 
@@ -397,17 +432,20 @@ export function registerFindTool(pi: ExtensionAPI) {
         try {
           re = new RegExp(pattern);
         } catch (err) {
+          const message =
+            `Error: invalid regex for fields 'pattern'/'regex' ` +
+            `(${JSON.stringify(pattern)}): ${(err as Error).message}`;
           return {
-            content: [
-              {
-                type: "text" as const,
-                text:
-                  `Error: invalid regex for fields 'pattern'/'regex' ` +
-                  `(${JSON.stringify(pattern)}): ${(err as Error).message}`,
-              },
-            ],
+            content: [{ type: "text" as const, text: message }],
             isError: true,
-            details: {},
+            details: {
+              ptcValue: {
+                tool: "find",
+                ok: false,
+                path: params.path ?? searchPath,
+                error: buildPtcError("invalid-params-combo", message),
+              },
+            },
           };
         }
         matcher = (basename: string) => re.test(basename);
@@ -439,10 +477,18 @@ export function registerFindTool(pi: ExtensionAPI) {
           maxSizeBytes = parseSize("maxSize", params.maxSize);
         }
       } catch (err) {
+        const message = `Error: ${(err as Error).message}`;
         return {
-          content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+          content: [{ type: "text" as const, text: message }],
           isError: true,
-          details: {},
+          details: {
+            ptcValue: {
+              tool: "find",
+              ok: false,
+              path: params.path ?? searchPath,
+              error: buildPtcError("invalid-params-combo", message),
+            },
+          },
         };
       }
       const sortBy = params.sortBy ?? "name";

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -7,7 +7,7 @@ import { readFileSync } from "node:fs";
 import { normalizeToLF, stripBom, hasBareCarriageReturn } from "./edit-diff";
 import { looksLikeBinary } from "./binary-detect";
 import { ensureHashInit, formatHashlineDisplay, escapeControlCharsForDisplay } from "./hashline";
-import { buildPtcLine } from "./ptc-value.js";
+import { buildPtcError, buildPtcLine } from "./ptc-value.js";
 import { buildGrepOutput } from "./grep-output.js";
 import { getOrGenerateMap } from "./map-cache.js";
 import { scopeGrepGroupsToSymbols } from "./grep-symbol-scope.js";
@@ -305,44 +305,72 @@ export function registerGrepTool(pi: ExtensionAPI, options: GrepToolOptions = {}
 				return {
 					content: [{ type: "text", text: context.message }],
 					isError: true,
-					details: {},
+					details: {
+						ptcValue: {
+							tool: "grep",
+							ok: false,
+							error: buildPtcError("invalid-params-combo", context.message),
+						},
+					},
 				};
 			}
-
 			const limit = coerceObviousBase10Int(rawParams.limit, "limit");
 			if (!limit.ok) {
 				return {
 					content: [{ type: "text", text: limit.message }],
 					isError: true,
-					details: {},
+					details: {
+						ptcValue: {
+							tool: "grep",
+							ok: false,
+							error: buildPtcError("invalid-limit", limit.message),
+						},
+					},
 				};
 			}
-
 			const scopeContext = coerceObviousBase10Int(rawParams.scopeContext, "scopeContext");
 			if (!scopeContext.ok) {
 				return {
 					content: [{ type: "text", text: scopeContext.message }],
 					isError: true,
-					details: {},
+					details: {
+						ptcValue: {
+							tool: "grep",
+							ok: false,
+							error: buildPtcError("invalid-params-combo", scopeContext.message),
+						},
+					},
 				};
 			}
-
 			if (scopeContext.value !== undefined && rawParams.scope !== "symbol") {
+				const message = 'Invalid scopeContext: requires scope: "symbol". For normal surrounding-line context outside symbol scope, use the `context` parameter.';
 				return {
 					content: [{
 						type: "text",
-						text: 'Invalid scopeContext: requires scope: "symbol". For normal surrounding-line context outside symbol scope, use the `context` parameter.',
+						text: message,
 					}],
 					isError: true,
-					details: {},
+					details: {
+						ptcValue: {
+							tool: "grep",
+							ok: false,
+							error: buildPtcError("invalid-params-combo", message),
+						},
+					},
 				};
 			}
-
 			if (scopeContext.value !== undefined && scopeContext.value < 0) {
+				const message = `Invalid scopeContext: expected a non-negative integer, received ${scopeContext.value}.`;
 				return {
-					content: [{ type: "text", text: `Invalid scopeContext: expected a non-negative integer, received ${scopeContext.value}.` }],
+					content: [{ type: "text", text: message }],
 					isError: true,
-					details: {},
+					details: {
+						ptcValue: {
+							tool: "grep",
+							ok: false,
+							error: buildPtcError("invalid-params-combo", message),
+						},
+					},
 				};
 			}
 			const p: GrepParams = {

--- a/src/hashline.ts
+++ b/src/hashline.ts
@@ -7,6 +7,7 @@
 
 import xxhashWasm from "xxhash-wasm";
 import { throwIfAborted } from "./runtime";
+import type { PtcLine } from "./ptc-value.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────
 
@@ -21,6 +22,16 @@ interface HashMismatch {
 	expected: string;
 	actual: string;
 	expectedContent?: string;
+}
+
+export class HashlineMismatchError extends Error {
+	readonly updatedAnchors: PtcLine[];
+
+	constructor(message: string, updatedAnchors: PtcLine[]) {
+		super(message);
+		this.name = "HashlineMismatchError";
+		this.updatedAnchors = updatedAnchors;
+	}
 }
 
 type ParsedRef = { line: number; hash: string; content?: string };
@@ -156,23 +167,35 @@ function findSimilarLines(
 		return `  ${c.line}:${hash}|${escapeControlCharsForDisplay(c.content)}`;
 	});
 }
-function formatMismatchError(mismatches: HashMismatch[], fileLines: string[], relocationWindow: number): string {
+function formatMismatchError(
+	mismatches: HashMismatch[],
+	fileLines: string[],
+	relocationWindow: number,
+): { message: string; updatedAnchors: PtcLine[] } {
 	const mismatchSet = new Map<number, HashMismatch>();
 	for (const m of mismatches) mismatchSet.set(m.line, m);
-
+	const updatedAnchors: PtcLine[] = mismatches.map((m) => {
+		const raw = fileLines[m.line - 1] ?? "";
+		const hash = computeLineHash(m.line, raw);
+		return {
+			line: m.line,
+			hash,
+			anchor: `${m.line}:${hash}`,
+			raw,
+			display: escapeControlCharsForDisplay(raw),
+		};
+	});
 	const displayLines = new Set<number>();
 	for (const m of mismatches) {
 		for (let i = Math.max(1, m.line - 2); i <= Math.min(fileLines.length, m.line + 2); i++) {
 			displayLines.add(i);
 		}
 	}
-
 	const sorted = [...displayLines].sort((a, b) => a - b);
 	const out: string[] = [
 		`${mismatches.length} line${mismatches.length > 1 ? "s have" : " has"} changed since last read. Auto-relocation checks only within ±${relocationWindow} lines of each anchor. Use the updated LINE:HASH references shown below (>>> marks changed lines).`,
 		"",
 	];
-
 	let prev = -1;
 	for (const num of sorted) {
 		if (prev !== -1 && num > prev + 1) out.push("    ...");
@@ -186,7 +209,6 @@ function formatMismatchError(mismatches: HashMismatch[], fileLines: string[], re
 				: `    ${prefix}|${escapeControlCharsForDisplay(content)}`,
 		);
 	}
-
 	const withContent = mismatches.filter((m) => m.expectedContent !== undefined);
 	if (withContent.length > 0) {
 		for (const m of withContent) {
@@ -199,7 +221,7 @@ function formatMismatchError(mismatches: HashMismatch[], fileLines: string[], re
 		}
 	}
 
-	return out.join("\n");
+	return { message: out.join("\n"), updatedAnchors };
 }
 
 // ─── DST preprocessing helpers ──────────────────────────────────────────
@@ -507,7 +529,10 @@ export function applyHashlineEdits(
 			}
 		}
 	}
-	if (mismatches.length) throw new Error(formatMismatchError(mismatches, fileLines, relocationWindow));
+	if (mismatches.length) {
+		const formatted = formatMismatchError(mismatches, fileLines, relocationWindow);
+		throw new HashlineMismatchError(formatted.message, formatted.updatedAnchors);
+	}
 
 	// Recompute after potential relocation
 	explicitlyTouchedLines = collectExplicitlyTouchedLines();

--- a/src/ls.ts
+++ b/src/ls.ts
@@ -4,6 +4,7 @@ import { Type } from "@sinclair/typebox";
 import { readFileSync } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { resolveToCwd } from "./path-utils.js";
+import { buildPtcError } from "./ptc-value.js";
 
 const MAX_BYTES = 50 * 1024; // 50 KB
 const DEFAULT_LIMIT = 500;
@@ -92,19 +93,52 @@ export function registerLsTool(pi: ExtensionAPI) {
       let pathStat;
       try {
         pathStat = await stat(targetPath);
-      } catch {
+      } catch (err: any) {
+        const target = params.path ?? targetPath;
+        const code =
+          err?.code === "EACCES" || err?.code === "EPERM"
+            ? "permission-denied"
+            : err?.code === "ENOENT"
+              ? "path-not-found"
+              : "fs-error";
+        const message =
+          code === "permission-denied"
+            ? `Error: permission denied for path '${target}'`
+            : code === "path-not-found"
+              ? `Error: path '${target}' does not exist`
+              : `Error: could not access path '${target}': ${err?.message ?? String(err)}`;
         return {
-          content: [{ type: "text" as const, text: `Error: path '${params.path ?? targetPath}' does not exist` }],
+          content: [{ type: "text" as const, text: message }],
           isError: true,
-          details: {},
+          details: {
+            ptcValue: {
+              tool: "ls",
+              ok: false,
+              path: target,
+              error: buildPtcError(code, message, undefined, code === "fs-error"
+                ? { fsCode: err?.code, fsMessage: err?.message }
+                : undefined),
+            },
+          },
         };
       }
-
       if (!pathStat.isDirectory()) {
+        const message = `Error: '${params.path ?? targetPath}' is a file, not a directory. Use read to inspect files.`;
         return {
-          content: [{ type: "text" as const, text: `Error: '${params.path ?? targetPath}' is a file, not a directory. Use read to inspect files.` }],
+          content: [{ type: "text" as const, text: message }],
           isError: true,
-          details: {},
+          details: {
+            ptcValue: {
+              tool: "ls",
+              ok: false,
+              path: params.path ?? targetPath,
+              error: buildPtcError(
+                "path-not-directory",
+                message,
+                `Use read(${JSON.stringify(params.path ?? targetPath)}) to inspect files.`,
+              ),
+            },
+          },
         };
       }
 

--- a/src/nu.ts
+++ b/src/nu.ts
@@ -6,6 +6,7 @@ import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
+import { buildPtcError } from "./ptc-value.js";
 import { stripAnsi } from "./rtk/ansi.js";
 
 const MAX_LINES = 2000;
@@ -314,12 +315,69 @@ export function registerNuTool(pi: ExtensionAPI): NuToolDefinition | false {
           ? (text) => onUpdate({ content: [{ type: "text", text }], details: {} })
           : undefined,
       });
+
+      const text = augmentNuOutput(result);
+      const details = {
+        exitCode: result.exitCode,
+        timedOut: result.timedOut,
+        shell: "nushell",
+      };
+
+      let ptcValue;
+      if (result.timedOut) {
+        ptcValue = {
+          tool: "nu",
+          ok: false,
+          error: buildPtcError(
+            "nu-timed-out",
+            text,
+            `Increase timeout via the 'timeout' parameter (current: ${params.timeout ?? 30}s).`,
+            { exitCode: result.exitCode, timedOut: true },
+          ),
+        };
+      } else if (/Error writing temp file:/.test(result.output)) {
+        ptcValue = {
+          tool: "nu",
+          ok: false,
+          error: buildPtcError(
+            "nu-temp-file-error",
+            text,
+            undefined,
+            { exitCode: result.exitCode, timedOut: false },
+          ),
+        };
+      } else if (
+        /Error spawning nushell:/.test(result.output) || /not found in PATH/.test(result.output)
+      ) {
+        ptcValue = {
+          tool: "nu",
+          ok: false,
+          error: buildPtcError(
+            "nu-spawn-error",
+            text,
+            "Install nushell: https://www.nushell.sh/",
+            { exitCode: result.exitCode, timedOut: false },
+          ),
+        };
+      } else if (result.exitCode !== 0 || result.exitCode === null) {
+        ptcValue = {
+          tool: "nu",
+          ok: false,
+          error: buildPtcError(
+            "nu-non-zero-exit",
+            text,
+            undefined,
+            { exitCode: result.exitCode, timedOut: false },
+          ),
+        };
+      } else {
+        ptcValue = { tool: "nu", ok: true };
+      }
       return {
-        content: [{ type: "text" as const, text: augmentNuOutput(result) }],
+        content: [{ type: "text" as const, text }],
         details: {
-          exitCode: result.exitCode,
-          timedOut: result.timedOut,
-          shell: "nushell",
+          ...details,
+          ptcValue,
         },
       };
     },

--- a/src/ptc-error-codes.ts
+++ b/src/ptc-error-codes.ts
@@ -1,0 +1,55 @@
+/**
+ * PTC error code taxonomy — single source of truth.
+ *
+ * Every error returned via `ptcValue.error.code` MUST be a key in this map.
+ * To add a new error: extend this object with a kebab-case code, a one-line
+ * description, and the trigger condition. Codes are stable: renaming is a
+ * breaking change for downstream consumers.
+ *
+ * Distinction:
+ * - errors (this file): fatal — the tool could not produce its primary result.
+ * - warnings (PtcWarning): non-fatal — the tool produced a result but flagged
+ *   something the agent should know.
+ */
+export const PTC_ERROR_CODES = {
+  // read
+  "file-not-found": { description: "Target file does not exist", trigger: "fs ENOENT on read" },
+  "path-is-directory": { description: "Path resolves to a directory, not a file", trigger: "fs EISDIR on read" },
+  "permission-denied": { description: "Filesystem refused access", trigger: "fs EACCES or EPERM" },
+  "fs-error": { description: "Unexpected filesystem failure outside the specific classified cases", trigger: "non-ENOENT/non-EISDIR/non-EACCES/non-EPERM fs error while reading, writing, or stat'ing a path" },
+  "offset-past-end": { description: "Requested offset exceeds file length", trigger: "offset > total lines" },
+  "invalid-params-combo": { description: "Mutually exclusive parameters combined", trigger: "e.g. symbol + offset, bundle + map, map + symbol" },
+  "invalid-offset": { description: "offset is not a positive integer", trigger: "non-int or value < 1" },
+  "invalid-limit": { description: "limit is not a positive integer", trigger: "non-int or value < 1" },
+
+  // edit
+  "file-not-read": { description: "edit called on a path that was not read in this session", trigger: "wasReadInSession returned false" },
+  "hash-mismatch": { description: "edit anchors do not verify against current file contents", trigger: "applyHashlineEdits detected stale anchors" },
+  "no-op": { description: "edits produced identical content", trigger: "originalNormalized === result after applying edits" },
+  "text-not-found": { description: "replace.old_text not present in file", trigger: "replaceText returned 0 matches" },
+  "binary-file": { description: "edit refused because file is binary", trigger: "isBinaryBuffer detected NUL bytes" },
+  "invalid-edit-variant": { description: "edits[i] is not exactly one of set_line/replace_lines/insert_after/replace", trigger: "exactly-one variant check failed" },
+
+  // grep
+  "binary-file-target": { description: "grep target is a binary file", trigger: "explicit binary path supplied" },
+  "passthrough-unparsed": { description: "builtin grep result format unrecognized", trigger: "passthrough warning from underlying tool" },
+
+  // ast_search
+  "sg-not-installed": { description: "ast-grep CLI is not installed", trigger: "ENOENT on `sg` invocation" },
+  "sg-execution-error": { description: "ast-grep process exited with an error", trigger: "non-zero exit or stderr output" },
+
+  // find / ls (shared shape)
+  "path-not-found": { description: "search/target path does not exist", trigger: "stat failed on path" },
+  "path-not-directory": { description: "path is a file, not a directory", trigger: "stat returned non-directory" },
+
+  // write
+  "binary-content": { description: "content written to write tool looks binary", trigger: "looksLikeBinary on supplied content" },
+
+  // nu
+  "nu-non-zero-exit": { description: "nushell command exited with non-zero status", trigger: "result.exitCode !== 0 (and not timed out)" },
+  "nu-timed-out": { description: "nushell command exceeded the timeout", trigger: "result.timedOut === true" },
+  "nu-spawn-error": { description: "failed to spawn the nushell process", trigger: "spawn ENOENT or other spawn-time error" },
+  "nu-temp-file-error": { description: "failed to write the temporary nushell script file", trigger: "fs writeFileSync failed in executeNuScript" },
+} as const;
+
+export type PtcErrorCode = keyof typeof PTC_ERROR_CODES;

--- a/src/ptc-value.ts
+++ b/src/ptc-value.ts
@@ -23,6 +23,13 @@ export interface PtcWarning {
   otherCandidates?: PtcWarningSymbol[];
 }
 
+export interface PtcError {
+  code: string;
+  message: string;
+  hint?: string;
+  details?: unknown;
+}
+
 export interface PtcRange {
   startLine: number;
   endLine: number;
@@ -81,6 +88,20 @@ export function buildPtcWarning(
   metadata: Omit<PtcWarning, "code" | "message"> = {},
 ): PtcWarning {
   return { code, message, ...metadata };
+}
+
+export function buildPtcError(
+  code: string,
+  message: string,
+  hint?: string,
+  details?: unknown,
+): PtcError {
+  return {
+    code,
+    message,
+    ...(hint !== undefined ? { hint } : {}),
+    ...(details !== undefined ? { details } : {}),
+  };
 }
 
 export function buildPtcRange(startLine: number, endLine: number, totalLines?: number): PtcRange {

--- a/src/read.ts
+++ b/src/read.ts
@@ -11,7 +11,7 @@ import { readFileSync } from "fs";
 import { readFile as fsReadFile } from "fs/promises";
 import { normalizeToLF, stripBom, hasBareCarriageReturn } from "./edit-diff";
 import { ensureHashInit, formatHashlineDisplay } from "./hashline";
-import { buildPtcWarning, buildPtcLines, type PtcWarning } from "./ptc-value.js";
+import { buildPtcError, buildPtcWarning, buildPtcLines, type PtcWarning } from "./ptc-value.js";
 import { looksLikeBinary } from "./binary-detect";
 import { resolveToCwd } from "./path-utils";
 import { throwIfAborted } from "./runtime";
@@ -87,7 +87,14 @@ export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}
 				return {
 					content: [{ type: "text", text: offset.message }],
 					isError: true,
-					details: {},
+					details: {
+						ptcValue: {
+							tool: "read",
+							ok: false,
+							path: rawParams.path,
+							error: buildPtcError("invalid-offset", offset.message),
+						},
+					},
 				};
 			}
 			const limit = coerceObviousBase10Int(rawParams.limit, "limit");
@@ -95,21 +102,44 @@ export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}
 				return {
 					content: [{ type: "text", text: limit.message }],
 					isError: true,
-					details: {},
+					details: {
+						ptcValue: {
+							tool: "read",
+							ok: false,
+							path: rawParams.path,
+							error: buildPtcError("invalid-limit", limit.message),
+						},
+					},
 				};
 			}
 			if (limit.value !== undefined && limit.value < 1) {
+				const message = `Invalid limit: expected a positive integer, received ${limit.value}.`;
 				return {
-					content: [{ type: "text", text: `Invalid limit: expected a positive integer, received ${limit.value}.` }],
+					content: [{ type: "text", text: message }],
 					isError: true,
-					details: {},
+					details: {
+						ptcValue: {
+							tool: "read",
+							ok: false,
+							path: rawParams.path,
+							error: buildPtcError("invalid-limit", message),
+						},
+					},
 				};
 			}
 			if (offset.value !== undefined && offset.value < 1) {
+				const message = `Invalid offset: expected a positive integer, received ${offset.value}.`;
 				return {
-					content: [{ type: "text", text: `Invalid offset: expected a positive integer, received ${offset.value}.` }],
+					content: [{ type: "text", text: message }],
 					isError: true,
-					details: {},
+					details: {
+						ptcValue: {
+							tool: "read",
+							ok: false,
+							path: rawParams.path,
+							error: buildPtcError("invalid-offset", message),
+						},
+					},
 				};
 			}
 			const p = {
@@ -129,31 +159,63 @@ export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}
 
 			throwIfAborted(signal);
 			if (p.symbol && (p.offset !== undefined || p.limit !== undefined)) {
+				const message = "Cannot combine symbol with offset/limit. Use one or the other.";
 				return {
-					content: [{ type: "text", text: "Cannot combine symbol with offset/limit. Use one or the other." }],
+					content: [{ type: "text", text: message }],
 					isError: true,
-					details: {},
+					details: {
+						ptcValue: {
+							tool: "read",
+							ok: false,
+							path: rawParams.path,
+							error: buildPtcError("invalid-params-combo", message),
+						},
+					},
 				};
 			}
 			if (p.bundle && !p.symbol) {
+				const message = 'Cannot use bundle without symbol. Use read({ path, symbol, bundle: "local" }).';
 				return {
-					content: [{ type: "text", text: 'Cannot use bundle without symbol. Use read({ path, symbol, bundle: "local" }).' }],
+					content: [{ type: "text", text: message }],
 					isError: true,
-					details: {},
+					details: {
+						ptcValue: {
+							tool: "read",
+							ok: false,
+							path: rawParams.path,
+							error: buildPtcError("invalid-params-combo", message),
+						},
+					},
 				};
 			}
 			if (p.bundle && p.map) {
+				const message = "Cannot combine bundle with map. Use one or the other.";
 				return {
-					content: [{ type: "text", text: "Cannot combine bundle with map. Use one or the other." }],
+					content: [{ type: "text", text: message }],
 					isError: true,
-					details: {},
+					details: {
+						ptcValue: {
+							tool: "read",
+							ok: false,
+							path: rawParams.path,
+							error: buildPtcError("invalid-params-combo", message),
+						},
+					},
 				};
 			}
 			if (p.map && p.symbol) {
+				const message = "Cannot combine map with symbol. Use one or the other.";
 				return {
-					content: [{ type: "text", text: "Cannot combine map with symbol. Use one or the other." }],
+					content: [{ type: "text", text: message }],
 					isError: true,
-					details: {},
+					details: {
+						ptcValue: {
+							tool: "read",
+							ok: false,
+							path: rawParams.path,
+							error: buildPtcError("invalid-params-combo", message),
+						},
+					},
 				};
 			}
 			// Delegate images to the built-in read tool
@@ -171,30 +233,69 @@ export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}
 			} catch (err: any) {
 				const code = err?.code;
 				if (code === "EISDIR") {
+					const message = `Path is a directory: ${rawPath}. Use ls to inspect directories.`;
 					return {
-						content: [{ type: "text", text: `Path is a directory: ${rawPath}. Use ls to inspect directories.` }],
+						content: [{ type: "text", text: message }],
 						isError: true,
-						details: {},
+						details: {
+							ptcValue: {
+								tool: "read",
+								ok: false,
+								path: rawParams.path,
+								error: buildPtcError(
+									"path-is-directory",
+									message,
+									`Use ls(${JSON.stringify(rawPath)}) to inspect directories.`,
+								),
+							},
+						},
 					};
 				}
 				if (code === "EACCES" || code === "EPERM") {
+					const message = `Permission denied — cannot access: ${rawPath}`;
 					return {
-						content: [{ type: "text", text: `Permission denied — cannot access: ${rawPath}` }],
+						content: [{ type: "text", text: message }],
 						isError: true,
-						details: {},
+						details: {
+							ptcValue: {
+								tool: "read",
+								ok: false,
+								path: rawParams.path,
+								error: buildPtcError("permission-denied", message),
+							},
+						},
 					};
 				}
 				if (code === "ENOENT") {
+					const message = `File not found: ${rawPath}`;
 					return {
-						content: [{ type: "text", text: `File not found: ${rawPath}` }],
+						content: [{ type: "text", text: message }],
 						isError: true,
-						details: {},
+						details: {
+							ptcValue: {
+								tool: "read",
+								ok: false,
+								path: rawParams.path,
+								error: buildPtcError("file-not-found", message),
+							},
+						},
 					};
 				}
+				const message = `File not readable: ${rawPath}${err?.message ? ` — ${err.message}` : ""}`;
 				return {
-					content: [{ type: "text", text: `File not found: ${rawPath}` }],
+					content: [{ type: "text", text: message }],
 					isError: true,
-					details: {},
+					details: {
+						ptcValue: {
+							tool: "read",
+							ok: false,
+							path: rawParams.path,
+							error: buildPtcError("fs-error", message, undefined, {
+								fsCode: code,
+								fsMessage: err?.message,
+							}),
+						},
+					},
 				};
 			}
 			const hasBinaryContent = looksLikeBinary(rawBuffer);
@@ -206,10 +307,18 @@ export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}
 			let startLine = p.offset !== undefined ? p.offset : 1;
 			let endIdx = p.limit !== undefined ? Math.min(startLine - 1 + p.limit, total) : total;
 			if (p.offset !== undefined && startLine > total) {
+				const message = `[offset ${p.offset} is past end of file (${total} lines)]`;
 				return {
-					content: [{ type: "text", text: `[offset ${p.offset} is past end of file (${total} lines)]` }],
+					content: [{ type: "text", text: message }],
 					isError: true,
-					details: {},
+					details: {
+						ptcValue: {
+							tool: "read",
+							ok: false,
+							path: rawParams.path,
+							error: buildPtcError("offset-past-end", message),
+						},
+					},
 				};
 			}
 			let symbolMatch: SymbolMatch | undefined;

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -7,7 +7,7 @@ import { readFile as fsReadFile, stat as fsStat } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { normalizeToLF, stripBom } from "./edit-diff.js";
 import { ensureHashInit } from "./hashline.js";
-import { buildPtcLine } from "./ptc-value.js";
+import { buildPtcError, buildPtcLine } from "./ptc-value.js";
 import { resolveToCwd } from "./path-utils.js";
 import { buildSgOutput } from "./sg-output.js";
 
@@ -223,16 +223,34 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
         };
       } catch (err: any) {
         if (err?.code === "ENOENT") {
+          const message = "ast-grep (sg) is not installed. Run: brew install ast-grep";
           return {
-            content: [{ type: "text", text: "ast-grep (sg) is not installed. Run: brew install ast-grep" }],
+            content: [{ type: "text", text: message }],
             isError: true,
-            details: {},
+            details: {
+              ptcValue: {
+                tool: "ast_search",
+                ok: false,
+                error: buildPtcError(
+                  "sg-not-installed",
+                  message,
+                  "Install with: brew install ast-grep (or see https://ast-grep.github.io)",
+                ),
+              },
+            },
           };
         }
+        const message = String(err?.stderr || err?.message || err);
         return {
-          content: [{ type: "text", text: String(err?.stderr || err?.message || err) }],
+          content: [{ type: "text", text: message }],
           isError: true,
-          details: {},
+          details: {
+            ptcValue: {
+              tool: "ast_search",
+              ok: false,
+              error: buildPtcError("sg-execution-error", message),
+            },
+          },
         };
       }
     },

--- a/src/write.ts
+++ b/src/write.ts
@@ -5,7 +5,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, relative } from "node:path";
 import { resolveToCwd } from "./path-utils.js";
 import { ensureHashInit, formatHashlineDisplay } from "./hashline.js";
-import { buildPtcLine, buildPtcWarning, type PtcLine, type PtcWarning } from "./ptc-value.js";
+import { buildPtcError, buildPtcLine, buildPtcWarning, type PtcLine, type PtcWarning } from "./ptc-value.js";
 import { looksLikeBinary } from "./binary-detect.js";
 import { getOrGenerateMap } from "./map-cache.js";
 import { formatFileMapWithBudget } from "./readmap/formatter.js";
@@ -53,7 +53,7 @@ export async function executeWrite(opts: {
   // Binary detection
   if (looksLikeBinary(Buffer.from(content, "utf-8"))) {
     warnings.push("File content appears to be binary.");
-    ptcWarnings.push(buildPtcWarning("binary", "File content appears to be binary."));
+    ptcWarnings.push(buildPtcWarning("binary-content", "File content appears to be binary."));
     return {
       text: `Wrote ${filePath}\n⚠️ File content appears to be binary — hashlines not generated.`,
       warnings,
@@ -144,6 +144,27 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
       if (result.ptcValue.lines.length > 0) {
         options.onFileAnchored?.(absolutePath);
       }
+
+      // Lift binary-content signal into a fatal ptcValue.error envelope so
+      // downstream consumers get the same taxonomy shape as every other tool.
+      // The existing PtcWarning entry is preserved on ptcValue.warnings for
+      // backward compatibility (see AC 12 — warnings namespace alignment).
+      const binaryWarning = result.ptcValue.warnings.find((w) => w.code === "binary-content");
+      if (binaryWarning) {
+        return {
+          content: [{ type: "text" as const, text: result.text }],
+          isError: true,
+          details: {
+            ptcValue: {
+              ...result.ptcValue,
+              ok: false,
+              error: buildPtcError("binary-content", binaryWarning.message),
+            },
+            warnings: result.warnings,
+          },
+        };
+      }
+
       return {
         content: [{ type: "text" as const, text: result.text }],
         details: {

--- a/tests/edit-replace-hint.test.ts
+++ b/tests/edit-replace-hint.test.ts
@@ -88,17 +88,14 @@ describe("edit replace hint", () => {
 
   it("suppresses the info line for replace no-op results", async () => {
     const filePath = makeFixture("const value = 1;\n");
-    let error: unknown;
-    try {
-      await callEditTool({
-        path: filePath,
-        edits: [{ replace: { old_text: "const value = 1;", new_text: "const value = 1;" } }],
-      });
-    } catch (err) {
-      error = err;
-    }
+  const result = await callEditTool({
+    path: filePath,
+    edits: [{ replace: { old_text: "const value = 1;", new_text: "const value = 1;" } }],
+  });
 
-    expect(String((error as any)?.message ?? error)).toContain("No changes made to");
-    expect(String((error as any)?.message ?? error)).not.toContain(INFO_HINT);
+  expect(result.isError).toBe(true);
+  const text = getTextContent(result);
+  expect(text).toContain("No changes made to");
+  expect(text).not.toContain(INFO_HINT);
 });
 });

--- a/tests/find-filters.test.ts
+++ b/tests/find-filters.test.ts
@@ -267,7 +267,11 @@ describe("find filter error handling", () => {
     const msg = result.content?.[0]?.text ?? "";
     expect(msg).toMatch(/modifiedSince/);
     expect(msg).toContain("1y");
-    expect(result.details?.ptcValue).toBeUndefined();
+    expect(result.details?.ptcValue).toMatchObject({
+      tool: "find",
+      ok: false,
+      error: { code: "invalid-params-combo", message: msg },
+  });
   });
   it("malformed minSize returns a tool error naming the field and value", async () => {
     _testable.isFdAvailable = () => false;

--- a/tests/find-regex.test.ts
+++ b/tests/find-regex.test.ts
@@ -165,6 +165,10 @@ describe("find regex invalid input", () => {
     expect(msg).toMatch(/pattern/i);
     expect(msg).toMatch(/regex/i);
     expect(msg).toContain(badPattern);
-    expect(result.details?.ptcValue).toBeUndefined();
+    expect(result.details?.ptcValue).toMatchObject({
+      tool: "find",
+      ok: false,
+      error: { code: "invalid-params-combo", message: msg },
+    });
   });
 });

--- a/tests/hashline-mismatch-error-anchors.test.ts
+++ b/tests/hashline-mismatch-error-anchors.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import {
+  applyHashlineEdits,
+  ensureHashInit,
+  computeLineHash,
+  HashlineMismatchError,
+} from "../src/hashline.js";
+
+describe("HashlineMismatchError exposes updatedAnchors", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("attaches PtcLine[] updatedAnchors for changed lines while preserving message text", () => {
+    const current = ["const a = 1;", "const b = 22;", "const c = 3;"].join("\n");
+    const staleAnchorForLine2 = `2:${computeLineHash(2, "const b = 2;")}`;
+
+    let caught: unknown;
+    try {
+      applyHashlineEdits(current, [{ set_line: { anchor: staleAnchorForLine2, new_text: "const b = 222;" } }]);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(HashlineMismatchError);
+    const err = caught as HashlineMismatchError;
+    expect(err.message).toContain("changed since last read");
+    expect(Array.isArray(err.updatedAnchors)).toBe(true);
+    expect(err.updatedAnchors.length).toBeGreaterThan(0);
+    const changed = err.updatedAnchors.find((a) => a.line === 2);
+    expect(changed).toBeDefined();
+    expect(changed!.hash).toBe(computeLineHash(2, "const b = 22;"));
+    expect(changed!.anchor).toBe(`2:${changed!.hash}`);
+    expect(changed!.raw).toBe("const b = 22;");
+    expect(typeof changed!.display).toBe("string");
+  });
+});

--- a/tests/ptc-error-builder.test.ts
+++ b/tests/ptc-error-builder.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { buildPtcError, type PtcError } from "../src/ptc-value.js";
+
+describe("buildPtcError", () => {
+  it("returns { code, message } when hint and details are omitted", () => {
+    const err: PtcError = buildPtcError("file-not-found", "File not found: foo.ts");
+    expect(err).toEqual({ code: "file-not-found", message: "File not found: foo.ts" });
+    expect(Object.prototype.hasOwnProperty.call(err, "hint")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(err, "details")).toBe(false);
+  });
+
+  it("includes hint when provided", () => {
+    const err = buildPtcError("file-not-read", "Read first.", "Call read(\"foo\") first.");
+    expect(err.hint).toBe("Call read(\"foo\") first.");
+    expect(Object.prototype.hasOwnProperty.call(err, "details")).toBe(false);
+  });
+
+  it("includes details when provided", () => {
+    const err = buildPtcError("hash-mismatch", "x", undefined, { updatedAnchors: [] });
+    expect(err.details).toEqual({ updatedAnchors: [] });
+    expect(Object.prototype.hasOwnProperty.call(err, "hint")).toBe(false);
+  });
+
+  it("omits hint property when explicitly undefined", () => {
+    const err = buildPtcError("x", "y", undefined, undefined);
+    expect(Object.prototype.hasOwnProperty.call(err, "hint")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(err, "details")).toBe(false);
+  });
+});

--- a/tests/ptc-error-codes.test.ts
+++ b/tests/ptc-error-codes.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { PTC_ERROR_CODES, type PtcErrorCode } from "../src/ptc-error-codes.js";
+
+const REQUIRED_CODES = [
+  "file-not-found",
+  "path-is-directory",
+  "permission-denied",
+  "offset-past-end",
+  "invalid-params-combo",
+  "invalid-offset",
+  "invalid-limit",
+  "file-not-read",
+  "hash-mismatch",
+  "no-op",
+  "text-not-found",
+  "binary-file",
+  "invalid-edit-variant",
+  "binary-file-target",
+  "passthrough-unparsed",
+  "sg-not-installed",
+  "sg-execution-error",
+  "path-not-found",
+  "path-not-directory",
+  "binary-content",
+  "nu-non-zero-exit",
+  "nu-timed-out",
+  "nu-spawn-error",
+  "nu-temp-file-error",
+] as const;
+
+describe("PTC_ERROR_CODES taxonomy", () => {
+  it("includes every required code from the spec", () => {
+    for (const code of REQUIRED_CODES) {
+      expect(PTC_ERROR_CODES).toHaveProperty(code);
+      expect(typeof PTC_ERROR_CODES[code as PtcErrorCode].description).toBe("string");
+      expect(PTC_ERROR_CODES[code as PtcErrorCode].description.length).toBeGreaterThan(0);
+      expect(typeof PTC_ERROR_CODES[code as PtcErrorCode].trigger).toBe("string");
+      expect(PTC_ERROR_CODES[code as PtcErrorCode].trigger.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("uses kebab-case for every code", () => {
+    for (const code of Object.keys(PTC_ERROR_CODES)) {
+      expect(code).toMatch(/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/);
+    }
+  });
+});

--- a/tests/ptc-error-contract.test.ts
+++ b/tests/ptc-error-contract.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit } from "../src/hashline.js";
+import { isNuAvailable } from "../src/nu.js";
+import { PTC_ERROR_CODES } from "../src/ptc-error-codes.js";
+
+async function callTool(
+  registerName:
+    | "registerReadTool"
+    | "registerEditTool"
+    | "registerGrepTool"
+    | "registerSgTool"
+    | "registerFindTool"
+    | "registerLsTool"
+    | "registerWriteTool"
+    | "registerNuTool",
+  modulePath: string,
+  params: Record<string, unknown>,
+  options?: any,
+) {
+  const mod: any = await import(modulePath);
+  const register = mod[registerName];
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  const ret = options !== undefined ? register(mockPi, options) : register(mockPi);
+  if (ret === false) return null;
+  if (!captured) throw new Error(`${registerName} did not register a tool`);
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+const getPtc = (r: any) => r?.details?.ptcValue;
+
+function assertContract(r: any, tool: string, expectedCode: string) {
+  expect(r).not.toBeNull();
+  const ptc = getPtc(r);
+  expect(ptc, `${tool}: ptcValue must be present on error`).toBeDefined();
+  expect(ptc.tool, `${tool}: ptcValue.tool`).toBe(tool);
+  expect(ptc.ok, `${tool}: ptcValue.ok must be false on error`).toBe(false);
+  expect(ptc.error, `${tool}: ptcValue.error must be present`).toBeDefined();
+  expect(typeof ptc.error.code, `${tool}: error.code is string`).toBe("string");
+  expect(ptc.error.code, `${tool}: error.code in taxonomy`).toBe(expectedCode);
+  expect(PTC_ERROR_CODES, `${tool}: error.code is documented`).toHaveProperty(expectedCode);
+  expect(typeof ptc.error.message, `${tool}: error.message is string`).toBe("string");
+  expect(ptc.error.message.length, `${tool}: error.message is non-empty`).toBeGreaterThan(0);
+}
+
+describe("ptc-error contract — every tool emits ptcValue.error on representative failure", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("read → file-not-found", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-c-r-"));
+    const r = await callTool("registerReadTool", "../src/read.js", { path: resolve(dir, "missing.txt") });
+    assertContract(r, "read", "file-not-found");
+  });
+
+  it("edit → file-not-read", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-c-e-"));
+    const f = resolve(dir, "f.ts");
+    writeFileSync(f, "x\n", "utf-8");
+    const r = await callTool(
+      "registerEditTool",
+      "../src/edit.js",
+      { path: f, edits: [{ set_line: { anchor: "1:00", new_text: "y" } }] },
+      { wasReadInSession: () => false },
+    );
+    assertContract(r, "edit", "file-not-read");
+  });
+
+  it("grep → invalid-limit", async () => {
+    const r = await callTool("registerGrepTool", "../src/grep.js", { pattern: "x", limit: "abc" });
+    assertContract(r, "grep", "invalid-limit");
+  });
+
+  it("ast_search → sg-not-installed (PATH stripped)", async () => {
+    const orig = process.env.PATH;
+    process.env.PATH = "/nonexistent";
+    try {
+      const r = await callTool("registerSgTool", "../src/sg.js", { pattern: "$X", lang: "ts" });
+      assertContract(r, "ast_search", "sg-not-installed");
+    } finally {
+      process.env.PATH = orig;
+    }
+  });
+
+  it("find → path-not-found", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-c-f-"));
+    const r = await callTool("registerFindTool", "../src/find.js", { pattern: "*.ts", path: resolve(dir, "missing") });
+    assertContract(r, "find", "path-not-found");
+  });
+
+  it("ls → path-not-found", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-c-l-"));
+    const r = await callTool("registerLsTool", "../src/ls.js", { path: resolve(dir, "missing") });
+    assertContract(r, "ls", "path-not-found");
+  });
+
+  it("write → binary-content (AC 14)", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-c-w-"));
+    const f = resolve(dir, "b.bin");
+    const r = await callTool("registerWriteTool", "../src/write.js", { path: f, content: "hello\u0000world" });
+    assertContract(r, "write", "binary-content");
+    expect(r!.isError).toBe(true);
+  });
+
+  (isNuAvailable() ? it : it.skip)("nu → nu-non-zero-exit (AC 15)", async () => {
+    const r = await callTool("registerNuTool", "../src/nu.js", { command: "exit 1" });
+    assertContract(r, "nu", "nu-non-zero-exit");
+    expect(r!.isError).toBeFalsy();
+  });
+});

--- a/tests/ptc-error-edit-binary.test.ts
+++ b/tests/ptc-error-edit-binary.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit } from "../src/hashline.js";
+
+async function callEdit(params: Record<string, unknown>) {
+  const { registerEditTool } = await import("../src/edit.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerEditTool(mockPi as any, { wasReadInSession: () => true });
+  if (!captured) throw new Error("edit tool not registered");
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+describe("edit ptcValue.error — binary-file", () => {
+  beforeAll(async () => { await ensureHashInit(); });
+
+  it("returns binary-file when target is binary", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-bin-"));
+    const f = resolve(dir, "b.bin");
+    writeFileSync(f, Buffer.from([0x48, 0x00, 0x6c]));
+    const r = await callEdit({
+      path: f,
+      edits: [{ set_line: { anchor: "1:00", new_text: "x" } }],
+    });
+    expect(r.isError).toBe(true);
+    const text = r.content.find((c: any) => c.type === "text")?.text ?? "";
+    expect(text).toMatch(/Cannot edit binary file/);
+    const ptc = r.details?.ptcValue;
+    expect(ptc?.tool).toBe("edit");
+    expect(ptc?.error?.code).toBe("binary-file");
+  });
+});

--- a/tests/ptc-error-edit-fs.test.ts
+++ b/tests/ptc-error-edit-fs.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit } from "../src/hashline.js";
+
+async function callEdit(params: Record<string, unknown>) {
+  const { registerEditTool } = await import("../src/edit.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerEditTool(mockPi as any, { wasReadInSession: () => true });
+  if (!captured) throw new Error("edit tool not registered");
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+const getPtc = (r: any) => r.details?.ptcValue;
+
+describe("edit ptcValue.error — fs read errors", () => {
+  beforeAll(async () => { await ensureHashInit(); });
+
+  it("path-is-directory when target is a directory", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-pd-"));
+    const sub = resolve(dir, "sub"); mkdirSync(sub);
+    const r = await callEdit({
+      path: sub,
+      edits: [{ set_line: { anchor: "1:00", new_text: "x" } }],
+    });
+    expect(r.isError).toBe(true);
+    expect(getPtc(r)?.error?.code).toBe("path-is-directory");
+  });
+
+  it("file-not-found when target missing", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-fnf-"));
+    const r = await callEdit({
+      path: resolve(dir, "missing.ts"),
+      edits: [{ set_line: { anchor: "1:00", new_text: "x" } }],
+    });
+    expect(getPtc(r)?.error?.code).toBe("file-not-found");
+  });
+});

--- a/tests/ptc-error-edit-invalid-variant.test.ts
+++ b/tests/ptc-error-edit-invalid-variant.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit } from "../src/hashline.js";
+
+async function callEdit(params: Record<string, unknown>) {
+  const { registerEditTool } = await import("../src/edit.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerEditTool(mockPi as any, { wasReadInSession: () => true });
+  if (!captured) throw new Error("edit tool not registered");
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+const getPtc = (r: any) => r.details?.ptcValue;
+
+describe("edit ptcValue.error — invalid-edit-variant", () => {
+  beforeAll(async () => { await ensureHashInit(); });
+
+  it("invalid-edit-variant when edits[i] has top-level old_text/new_text", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-tlv-"));
+    const f = resolve(dir, "f.ts"); writeFileSync(f, "const a = 1;\n", "utf-8");
+    const r = await callEdit({
+      path: f,
+      edits: [{ old_text: "a", new_text: "b" }],
+    });
+    expect(r.isError).toBe(true);
+    expect(getPtc(r)?.error?.code).toBe("invalid-edit-variant");
+  });
+
+  it("invalid-edit-variant when edits[i] contains diff", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-diff-"));
+    const f = resolve(dir, "f.ts"); writeFileSync(f, "const a = 1;\n", "utf-8");
+    const r = await callEdit({
+      path: f,
+      edits: [{ diff: "@@ -1 +1 @@\n-x\n+y\n" }],
+    });
+    expect(getPtc(r)?.error?.code).toBe("invalid-edit-variant");
+  });
+
+  it("invalid-edit-variant when edits[i] has zero variant keys", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-zero-"));
+    const f = resolve(dir, "f.ts"); writeFileSync(f, "const a = 1;\n", "utf-8");
+    const r = await callEdit({
+      path: f,
+      edits: [{}],
+    });
+    expect(getPtc(r)?.error?.code).toBe("invalid-edit-variant");
+  });
+
+  it("invalid-edit-variant when legacy input partial (only oldText)", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-leg-"));
+    const f = resolve(dir, "f.ts"); writeFileSync(f, "const a = 1;\n", "utf-8");
+    const r = await callEdit({ path: f, oldText: "a" });
+    expect(getPtc(r)?.error?.code).toBe("invalid-edit-variant");
+  });
+});

--- a/tests/ptc-error-edit-noop-textnotfound.test.ts
+++ b/tests/ptc-error-edit-noop-textnotfound.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+
+async function callEdit(params: Record<string, unknown>) {
+  const { registerEditTool } = await import("../src/edit.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerEditTool(mockPi as any, { wasReadInSession: () => true });
+  if (!captured) throw new Error("edit tool not registered");
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+const getPtc = (r: any) => r.details?.ptcValue;
+
+describe("edit ptcValue.error — text-not-found and no-op", () => {
+  beforeAll(async () => { await ensureHashInit(); });
+
+  it("text-not-found when replace.old_text missing", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-tnf-"));
+    const f = resolve(dir, "f.ts"); writeFileSync(f, "const a = 1;\n", "utf-8");
+    const r = await callEdit({
+      path: f,
+      edits: [{ replace: { old_text: "DOES_NOT_EXIST", new_text: "x" } }],
+    });
+    expect(r.isError).toBe(true);
+    expect(getPtc(r)?.error?.code).toBe("text-not-found");
+    const text = r.content.find((c: any) => c.type === "text")?.text ?? "";
+    expect(text).toMatch(/Could not find text to replace/);
+  });
+
+  it("no-op when edits produce identical content", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-noop-"));
+    const f = resolve(dir, "f.ts"); writeFileSync(f, "const a = 1;\n", "utf-8");
+    const lines = readFileSync(f, "utf-8").split("\n");
+    const anchor = `1:${computeLineHash(1, lines[0])}`;
+    const r = await callEdit({
+      path: f,
+      edits: [{ set_line: { anchor, new_text: lines[0] } }],
+    });
+    expect(r.isError).toBe(true);
+    expect(getPtc(r)?.error?.code).toBe("no-op");
+    const text = r.content.find((c: any) => c.type === "text")?.text ?? "";
+    expect(text).toMatch(/No changes made/);
+  });
+});

--- a/tests/ptc-error-edit-validation.test.ts
+++ b/tests/ptc-error-edit-validation.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+
+async function callEdit(params: Record<string, unknown>, options: any = {}) {
+  const { registerEditTool } = await import("../src/edit.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerEditTool(mockPi as any, options);
+  if (!captured) throw new Error("edit tool not registered");
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+const getPtc = (r: any) => r.details?.ptcValue;
+
+describe("edit ptcValue.error — validation", () => {
+  beforeAll(async () => { await ensureHashInit(); });
+
+  it("file-not-read when wasReadInSession returns false", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-fnr-"));
+    const f = resolve(dir, "f.ts"); writeFileSync(f, "const a = 1;\n", "utf-8");
+    const lines = readFileSync(f, "utf-8").split("\n");
+    const anchor = `1:${computeLineHash(1, lines[0])}`;
+    const r = await callEdit(
+      { path: f, edits: [{ set_line: { anchor, new_text: "const a = 2;" } }] },
+      { wasReadInSession: () => false },
+    );
+    expect(r.isError).toBe(true);
+    expect(getPtc(r)?.tool).toBe("edit");
+    expect(getPtc(r)?.ok).toBe(false);
+    expect(getPtc(r)?.path).toBe(f);
+    expect(getPtc(r)?.error?.code).toBe("file-not-read");
+    expect(getPtc(r)?.error?.hint).toBeDefined();
+    expect(typeof getPtc(r)?.error?.hint).toBe("string");
+    expect(getPtc(r)?.error?.hint!.length).toBeGreaterThan(0);
+  });
+
+  it("invalid-edit-variant when edits array is empty", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-iev-"));
+    const f = resolve(dir, "f.ts"); writeFileSync(f, "const a = 1;\n", "utf-8");
+    const r = await callEdit(
+      { path: f, edits: [] },
+      { wasReadInSession: () => true },
+    );
+    expect(getPtc(r)?.error?.code).toBe("invalid-edit-variant");
+  });
+});

--- a/tests/ptc-error-find.test.ts
+++ b/tests/ptc-error-find.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+async function callFindTool(params: Record<string, unknown>) {
+  const { registerFindTool } = await import("../src/find.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerFindTool(mockPi as any);
+  if (!captured) throw new Error("find tool not registered");
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+const getPtc = (r: any) => r.details?.ptcValue;
+
+describe("find ptcValue.error", () => {
+  it("path-not-found when path does not exist", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-find-nf-"));
+    const r = await callFindTool({ pattern: "*.ts", path: resolve(dir, "missing") });
+    expect(r.isError).toBe(true);
+    expect(getPtc(r)?.tool).toBe("find");
+    expect(getPtc(r)?.error?.code).toBe("path-not-found");
+  });
+
+  it("path-not-directory when path is a file", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-find-nd-"));
+    const f = resolve(dir, "f.txt"); writeFileSync(f, "x", "utf-8");
+    const r = await callFindTool({ pattern: "*.ts", path: f });
+    expect(getPtc(r)?.error?.code).toBe("path-not-directory");
+  });
+
+  it("invalid-params-combo when regex pattern is invalid", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-find-iv-"));
+    const r = await callFindTool({ pattern: "[unclosed", path: dir, regex: true });
+    expect(getPtc(r)?.error?.code).toBe("invalid-params-combo");
+  });
+});

--- a/tests/ptc-error-fixes-v2.test.ts
+++ b/tests/ptc-error-fixes-v2.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+import { PTC_ERROR_CODES } from "../src/ptc-error-codes.js";
+
+async function callTool(
+  registerName:
+    | "registerReadTool"
+    | "registerEditTool"
+    | "registerLsTool"
+    | "registerFindTool"
+    | "registerWriteTool",
+  modulePath: string,
+  params: Record<string, unknown>,
+  options?: any,
+) {
+  const mod: any = await import(modulePath);
+  const register = mod[registerName];
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  const ret = options !== undefined ? register(mockPi, options) : register(mockPi);
+  if (ret === false) return null;
+  if (!captured) throw new Error(`${registerName} did not register a tool`);
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+const getPtc = (r: any) => r?.details?.ptcValue;
+
+describe("ptc-error fixes v2 — AC 6/8/14 gaps", () => {
+  beforeAll(async () => { await ensureHashInit(); });
+
+  // AC 8 — concrete recovery text in content[0].text must also populate error.hint
+  it("read → path-is-directory populates error.hint with the recovery step", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-v2-rdir-"));
+    const sub = resolve(dir, "sub"); mkdirSync(sub);
+    const r = await callTool("registerReadTool", "../src/read.js", { path: sub });
+    const ptc = getPtc(r);
+    expect(ptc?.error?.code).toBe("path-is-directory");
+    expect(typeof ptc?.error?.hint).toBe("string");
+    expect(ptc!.error!.hint!.length).toBeGreaterThan(0);
+    expect(ptc!.error!.hint!.toLowerCase()).toContain("ls");
+  });
+
+  it("edit → path-is-directory populates error.hint with the recovery step", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-v2-edir-"));
+    const sub = resolve(dir, "sub"); mkdirSync(sub);
+    const r = await callTool(
+      "registerEditTool",
+      "../src/edit.js",
+      { path: sub, edits: [{ set_line: { anchor: "1:00", new_text: "x" } }] },
+      { wasReadInSession: () => true },
+    );
+    const ptc = getPtc(r);
+    expect(ptc?.error?.code).toBe("path-is-directory");
+    expect(typeof ptc?.error?.hint).toBe("string");
+    expect(ptc!.error!.hint!.length).toBeGreaterThan(0);
+  });
+
+  it("ls → path-not-directory populates error.hint with the recovery step", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-v2-lsnd-"));
+    const f = resolve(dir, "f.txt"); writeFileSync(f, "x", "utf-8");
+    const r = await callTool("registerLsTool", "../src/ls.js", { path: f });
+    const ptc = getPtc(r);
+    expect(ptc?.error?.code).toBe("path-not-directory");
+    expect(typeof ptc?.error?.hint).toBe("string");
+    expect(ptc!.error!.hint!.length).toBeGreaterThan(0);
+    expect(ptc!.error!.hint!.toLowerCase()).toContain("read");
+  });
+
+  it("find → path-not-directory populates error.hint with the recovery step", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-v2-fnd-"));
+    const f = resolve(dir, "f.txt"); writeFileSync(f, "x", "utf-8");
+    const r = await callTool("registerFindTool", "../src/find.js", { pattern: "*.ts", path: f });
+    const ptc = getPtc(r);
+    expect(ptc?.error?.code).toBe("path-not-directory");
+    expect(typeof ptc?.error?.hint).toBe("string");
+    expect(ptc!.error!.hint!.length).toBeGreaterThan(0);
+  });
+
+  // AC 6 — trigger alignment: filter-parse errors are NOT stat failures
+  it("find → malformed minSize surfaces invalid-params-combo (not path-not-found)", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-v2-fms-"));
+    const r = await callTool("registerFindTool", "../src/find.js", {
+      pattern: "*.ts",
+      path: dir,
+      minSize: "not-a-size",
+    });
+    const ptc = getPtc(r);
+    expect(ptc?.error?.code).toBe("invalid-params-combo");
+    expect(PTC_ERROR_CODES).toHaveProperty(ptc!.error!.code);
+  });
+
+  it("find → malformed modifiedSince surfaces invalid-params-combo (not path-not-found)", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-v2-fmd-"));
+    const r = await callTool("registerFindTool", "../src/find.js", {
+      pattern: "*.ts",
+      path: dir,
+      modifiedSince: "not-a-date",
+    });
+    const ptc = getPtc(r);
+    expect(ptc?.error?.code).toBe("invalid-params-combo");
+  });
+
+  // AC 14 — write must emit a representative ptcValue.error path with taxonomy code
+  it("write → binary content emits fatal ptcValue.error with code binary-content", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-v2-wbin-"));
+    const f = resolve(dir, "b.bin");
+    const content = "hello\u0000world"; // contains NUL → binary
+    const r = await callTool("registerWriteTool", "../src/write.js", { path: f, content });
+    expect(r?.isError).toBe(true);
+    const ptc = getPtc(r);
+    expect(ptc?.tool).toBe("write");
+    expect(ptc?.ok).toBe(false);
+    expect(ptc?.error?.code).toBe("binary-content");
+    expect(typeof ptc?.error?.message).toBe("string");
+    expect(ptc!.error!.message.length).toBeGreaterThan(0);
+    expect(PTC_ERROR_CODES).toHaveProperty("binary-content");
+  });
+
+  it("read → unexpected fs failures surface fs-error (not file-not-found)", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-v2-rfs-"));
+    const tooLong = resolve(dir, "a".repeat(5000));
+    const r = await callTool("registerReadTool", "../src/read.js", { path: tooLong });
+    const ptc = getPtc(r);
+    expect(ptc?.error?.code).toBe("fs-error");
+    expect(ptc?.error?.message).toContain("File not readable");
+  });
+
+  it("edit → unexpected fs failures surface fs-error (not file-not-found)", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-v2-efs-"));
+    const tooLong = resolve(dir, "a".repeat(5000));
+    const r = await callTool(
+      "registerEditTool",
+      "../src/edit.js",
+      { path: tooLong, edits: [{ set_line: { anchor: "1:00", new_text: "x" } }] },
+      { wasReadInSession: () => true },
+    );
+    const ptc = getPtc(r);
+    expect(ptc?.error?.code).toBe("fs-error");
+    expect(ptc?.error?.message).toContain("File not readable");
+  });
+
+  it("find → unexpected fs failures surface fs-error (not path-not-found)", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-v2-ffs-"));
+    const tooLong = resolve(dir, "a".repeat(5000));
+    const r = await callTool("registerFindTool", "../src/find.js", { pattern: "*.ts", path: tooLong });
+    const ptc = getPtc(r);
+    expect(ptc?.error?.code).toBe("fs-error");
+    expect(ptc?.error?.message).toContain("could not access");
+  });
+
+  it("ls → unexpected fs failures surface fs-error (not path-not-found)", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-v2-lfs-"));
+    const tooLong = resolve(dir, "a".repeat(5000));
+    const r = await callTool("registerLsTool", "../src/ls.js", { path: tooLong });
+    const ptc = getPtc(r);
+    expect(ptc?.error?.code).toBe("fs-error");
+    expect(ptc?.error?.message).toContain("could not access");
+  });
+});

--- a/tests/ptc-error-grep-validation.test.ts
+++ b/tests/ptc-error-grep-validation.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+
+async function callGrepTool(params: Record<string, unknown>) {
+  const { registerGrepTool } = await import("../src/grep.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerGrepTool(mockPi as any);
+  if (!captured) throw new Error("grep tool not registered");
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+const getPtc = (r: any) => r.details?.ptcValue;
+
+describe("grep ptcValue.error — parameter validation", () => {
+  it("invalid-params-combo when context is non-numeric string", async () => {
+    const r = await callGrepTool({ pattern: "x", context: "abc" });
+    expect(r.isError).toBe(true);
+    expect(getPtc(r)?.error?.code).toBe("invalid-params-combo");
+    expect(typeof getPtc(r)?.error?.message).toBe("string");
+  });
+
+  it("invalid-limit when limit is non-numeric string", async () => {
+    const r = await callGrepTool({ pattern: "x", limit: "abc" });
+    expect(getPtc(r)?.error?.code).toBe("invalid-limit");
+  });
+
+  it("invalid-params-combo when scopeContext given without scope:symbol", async () => {
+    const r = await callGrepTool({ pattern: "x", scopeContext: 2 });
+    expect(getPtc(r)?.error?.code).toBe("invalid-params-combo");
+  });
+
+  it("invalid-params-combo when scopeContext is negative", async () => {
+    const r = await callGrepTool({ pattern: "x", scope: "symbol", scopeContext: -1 });
+    expect(getPtc(r)?.error?.code).toBe("invalid-params-combo");
+  });
+});

--- a/tests/ptc-error-hash-mismatch.test.ts
+++ b/tests/ptc-error-hash-mismatch.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+
+async function callEdit(params: Record<string, unknown>) {
+  const { registerEditTool } = await import("../src/edit.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerEditTool(mockPi as any, { wasReadInSession: () => true });
+  if (!captured) throw new Error("edit tool not registered");
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+describe("edit ptcValue.error — hash-mismatch with updatedAnchors", () => {
+  beforeAll(async () => { await ensureHashInit(); });
+
+  it("returns hash-mismatch with PtcLine[] updatedAnchors in error.details", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-hm-"));
+    const f = resolve(dir, "f.ts");
+    writeFileSync(f, ["const a = 1;", "const b = 22;", "const c = 3;"].join("\n"), "utf-8");
+
+    const staleHash = computeLineHash(2, "const b = 2;");
+    const staleAnchor = `2:${staleHash}`;
+
+    const r = await callEdit({
+      path: f,
+      edits: [{ set_line: { anchor: staleAnchor, new_text: "const b = 222;" } }],
+    });
+
+    expect(r.isError).toBe(true);
+    const ptc = r.details?.ptcValue;
+    expect(ptc?.tool).toBe("edit");
+    expect(ptc?.ok).toBe(false);
+    expect(ptc?.error?.code).toBe("hash-mismatch");
+    expect(typeof ptc?.error?.message).toBe("string");
+    expect(ptc.error.message).toContain("changed since last read");
+
+    const anchors = ptc.error.details?.updatedAnchors;
+    expect(Array.isArray(anchors)).toBe(true);
+    expect(anchors.length).toBeGreaterThan(0);
+    for (const a of anchors) {
+      expect(typeof a.line).toBe("number");
+      expect(typeof a.hash).toBe("string");
+      expect(typeof a.anchor).toBe("string");
+      expect(typeof a.raw).toBe("string");
+      expect(typeof a.display).toBe("string");
+    }
+    const changed = anchors.find((x: any) => x.line === 2);
+    expect(changed).toBeDefined();
+    expect(changed.hash).toBe(computeLineHash(2, "const b = 22;"));
+  });
+});

--- a/tests/ptc-error-ls.test.ts
+++ b/tests/ptc-error-ls.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+async function callLsTool(params: Record<string, unknown>) {
+  const { registerLsTool } = await import("../src/ls.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerLsTool(mockPi as any);
+  if (!captured) throw new Error("ls tool not registered");
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+const getPtc = (r: any) => r.details?.ptcValue;
+
+describe("ls ptcValue.error", () => {
+  it("path-not-found when path does not exist", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-ls-nf-"));
+    const r = await callLsTool({ path: resolve(dir, "missing") });
+    expect(r.isError).toBe(true);
+    expect(getPtc(r)?.tool).toBe("ls");
+    expect(getPtc(r)?.error?.code).toBe("path-not-found");
+  });
+
+  it("path-not-directory when path is a file", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-ls-nd-"));
+    const f = resolve(dir, "f.txt"); writeFileSync(f, "x", "utf-8");
+    const r = await callLsTool({ path: f });
+    expect(getPtc(r)?.error?.code).toBe("path-not-directory");
+  });
+});

--- a/tests/ptc-error-nu.test.ts
+++ b/tests/ptc-error-nu.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { isNuAvailable } from "../src/nu.js";
+
+const nuAvailable = isNuAvailable();
+const itIfNu = nuAvailable ? it : it.skip;
+
+async function callNu(params: Record<string, unknown>) {
+  const { registerNuTool } = await import("../src/nu.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  const tool = registerNuTool(mockPi as any);
+  if (tool === false) return null;
+  if (!captured) throw new Error("nu tool not registered");
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+describe("nu ptcValue envelope", () => {
+  itIfNu("ok:true and no error on successful command", async () => {
+    const r = await callNu({ command: "echo 'hello'" });
+    expect(r).not.toBeNull();
+    const ptc = r!.details?.ptcValue;
+    expect(ptc).toBeDefined();
+    expect(ptc.tool).toBe("nu");
+    expect(ptc.ok).toBe(true);
+    expect(ptc.error).toBeUndefined();
+    expect(r!.isError).toBeFalsy();
+  });
+
+  itIfNu("nu-non-zero-exit when command exits non-zero", async () => {
+    const r = await callNu({ command: "exit 1" });
+    expect(r).not.toBeNull();
+    const ptc = r!.details?.ptcValue;
+    expect(ptc.tool).toBe("nu");
+    expect(ptc.ok).toBe(false);
+    expect(ptc.error?.code).toBe("nu-non-zero-exit");
+    expect(typeof ptc.error?.message).toBe("string");
+    expect(ptc.error?.message.length).toBeGreaterThan(0);
+    expect(ptc.error?.details).toMatchObject({ exitCode: expect.any(Number) });
+    // AC 11: nu does not flip isError
+    expect(r!.isError).toBeFalsy();
+  });
+});

--- a/tests/ptc-error-read-invalid-offset.test.ts
+++ b/tests/ptc-error-read-invalid-offset.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+async function callReadTool(params: Record<string, unknown>) {
+  const { registerReadTool } = await import("../src/read.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerReadTool(mockPi as any);
+  if (!captured) throw new Error("read tool not registered");
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+describe("read ptcValue.error — invalid-offset", () => {
+  it("populates ptcValue.error with code invalid-offset when offset < 1", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-read-err-"));
+    const filePath = resolve(dir, "f.txt");
+    writeFileSync(filePath, "a\nb\n", "utf-8");
+    const result = await callReadTool({ path: filePath, offset: 0 });
+    expect(result.isError).toBe(true);
+    const text = result.content.find((c: any) => c.type === "text")?.text ?? "";
+    expect(text).toContain("Invalid offset");
+    const ptc = result.details?.ptcValue;
+    expect(ptc).toBeDefined();
+    expect(ptc.tool).toBe("read");
+    expect(ptc.ok).toBe(false);
+    expect(ptc.error).toBeDefined();
+    expect(ptc.error.code).toBe("invalid-offset");
+    expect(typeof ptc.error.message).toBe("string");
+    expect(ptc.error.message.length).toBeGreaterThan(0);
+    expect(text.includes(ptc.error.message) || ptc.error.message.includes(text)).toBe(true);
+  });
+});

--- a/tests/ptc-error-read-sites.test.ts
+++ b/tests/ptc-error-read-sites.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+async function callReadTool(params: Record<string, unknown>) {
+  const { registerReadTool } = await import("../src/read.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerReadTool(mockPi as any);
+  if (!captured) throw new Error("read tool not registered");
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function getPtc(result: any) { return result.details?.ptcValue; }
+
+describe("read ptcValue.error — remaining error sites", () => {
+  it("invalid-limit when limit < 1", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-r-il-"));
+    const f = resolve(dir, "f.txt"); writeFileSync(f, "a\n", "utf-8");
+    const r = await callReadTool({ path: f, limit: 0 });
+    expect(getPtc(r)?.error?.code).toBe("invalid-limit");
+  });
+
+  it("invalid-params-combo when symbol combined with offset", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-r-ipc-"));
+    const f = resolve(dir, "f.ts"); writeFileSync(f, "function foo() {}\n", "utf-8");
+    const r = await callReadTool({ path: f, symbol: "foo", offset: 1 });
+    expect(getPtc(r)?.error?.code).toBe("invalid-params-combo");
+  });
+
+  it("invalid-params-combo when bundle without symbol", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-r-ipc2-"));
+    const f = resolve(dir, "f.ts"); writeFileSync(f, "x\n", "utf-8");
+    const r = await callReadTool({ path: f, bundle: "local" });
+    expect(getPtc(r)?.error?.code).toBe("invalid-params-combo");
+  });
+
+  it("invalid-params-combo when bundle combined with map", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-r-ipc3-"));
+    const f = resolve(dir, "f.ts"); writeFileSync(f, "function foo(){}\n", "utf-8");
+    const r = await callReadTool({ path: f, symbol: "foo", bundle: "local", map: true });
+    expect(getPtc(r)?.error?.code).toBe("invalid-params-combo");
+  });
+
+  it("invalid-params-combo when map combined with symbol", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-r-ipc4-"));
+    const f = resolve(dir, "f.ts"); writeFileSync(f, "function foo(){}\n", "utf-8");
+    const r = await callReadTool({ path: f, symbol: "foo", map: true });
+    expect(getPtc(r)?.error?.code).toBe("invalid-params-combo");
+  });
+
+  it("path-is-directory when path is a directory", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-r-dir-"));
+    const sub = resolve(dir, "sub"); mkdirSync(sub);
+    const r = await callReadTool({ path: sub });
+    expect(getPtc(r)?.error?.code).toBe("path-is-directory");
+  });
+
+  it("file-not-found when file is missing", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-r-nf-"));
+    const r = await callReadTool({ path: resolve(dir, "missing.txt") });
+    expect(getPtc(r)?.error?.code).toBe("file-not-found");
+  });
+
+  it("offset-past-end when offset > total lines", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-r-pe-"));
+    const f = resolve(dir, "f.txt"); writeFileSync(f, "one\ntwo\n", "utf-8");
+    const r = await callReadTool({ path: f, offset: 999 });
+    expect(getPtc(r)?.error?.code).toBe("offset-past-end");
+  });
+});

--- a/tests/ptc-error-sg.test.ts
+++ b/tests/ptc-error-sg.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+
+async function callSgTool(params: Record<string, unknown>) {
+  const { registerSgTool } = await import("../src/sg.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerSgTool(mockPi as any);
+  if (!captured) throw new Error("sg tool not registered");
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+const getPtc = (r: any) => r.details?.ptcValue;
+
+describe("ast_search ptcValue.error", () => {
+  it("sg-not-installed when ENOENT", async () => {
+    const origPath = process.env.PATH;
+    process.env.PATH = "/nonexistent";
+    try {
+      const r = await callSgTool({ pattern: "$X", lang: "ts" });
+      expect(r.isError).toBe(true);
+      const ptc = getPtc(r);
+      expect(ptc?.tool).toBe("ast_search");
+      expect(ptc?.ok).toBe(false);
+      expect(ptc?.error?.code).toBe("sg-not-installed");
+      expect(typeof ptc?.error?.message).toBe("string");
+      expect(ptc?.error?.hint).toMatch(/brew install ast-grep/i);
+    } finally {
+      process.env.PATH = origPath;
+    }
+  });
+});

--- a/tests/ptc-error-write-binary.test.ts
+++ b/tests/ptc-error-write-binary.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+async function callWrite(params: Record<string, unknown>) {
+  const { registerWriteTool } = await import("../src/write.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerWriteTool(mockPi as any);
+  if (!captured) throw new Error("write tool not registered");
+  return captured.execute("tc", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+describe("write ptcValue — binary-content code alignment", () => {
+  it("uses code 'binary-content' for the binary warning (taxonomy alignment)", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-write-bin-"));
+    const f = resolve(dir, "b.bin");
+    const content = "hello\u0000world";  // contains NUL → looks binary
+    const r = await callWrite({ path: f, content });
+    const ptc = r.details?.ptcValue;
+    expect(ptc).toBeDefined();
+    expect(ptc.tool).toBe("write");
+    const warnings = ptc.warnings ?? [];
+    const codes = warnings.map((w: any) => w.code);
+    expect(codes).toContain("binary-content");
+  });
+});

--- a/tests/repro-023-edit-readonly.test.ts
+++ b/tests/repro-023-edit-readonly.test.ts
@@ -52,17 +52,18 @@ describe("Bug #023: edit readonly file -> permission denied", () => {
 		if (!capturedTool) throw new Error("edit tool was not registered");
 
 		const hash1 = computeLineHash(1, "line1");
-		await expect(
-			capturedTool.execute(
-				"test-call",
-				{
-					path: readonlyFile,
-					edits: [{ set_line: { anchor: `1:${hash1}`, new_text: "modified" } }],
-				},
-				new AbortController().signal,
-				() => {},
-				{ cwd: process.cwd() },
-			),
-		).rejects.toThrow(/Permission denied/);
+		const result = await capturedTool.execute(
+			"test-call",
+			{
+				path: readonlyFile,
+				edits: [{ set_line: { anchor: `1:${hash1}`, new_text: "modified" } }],
+			},
+			new AbortController().signal,
+			() => {},
+			{ cwd: process.cwd() },
+		);
+		expect(result.isError).toBe(true);
+		const text = result.content.find((c: any) => c.type === "text")?.text ?? "";
+		expect(text).toMatch(/Permission denied/);
 	});
 });

--- a/tests/repro-030a-edit-binary-guard.test.ts
+++ b/tests/repro-030a-edit-binary-guard.test.ts
@@ -49,17 +49,18 @@ describe("Bug #030a: binary file guard in edit", () => {
     registerEditTool(mockPi as any);
     if (!capturedTool) throw new Error("edit tool was not registered");
 
-    await expect(
-      capturedTool.execute(
-        "test-call",
-        {
-          path: binaryFile,
-          edits: [{ set_line: { anchor: "1:00", new_text: "modified" } }],
-        },
-        new AbortController().signal,
-        () => {},
-        { cwd: process.cwd() },
-      ),
-    ).rejects.toThrow(/Cannot edit binary file/);
+    const result = await capturedTool.execute(
+      "test-call",
+      {
+        path: binaryFile,
+        edits: [{ set_line: { anchor: "1:00", new_text: "modified" } }],
+      },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+    expect(result.isError).toBe(true);
+    const text = result.content.find((c: any) => c.type === "text")?.text ?? "";
+    expect(text).toMatch(/Cannot edit binary file/);
   });
 });

--- a/tests/repro-052-edit-diagnostic-control-chars.test.ts
+++ b/tests/repro-052-edit-diagnostic-control-chars.test.ts
@@ -28,16 +28,15 @@ describe("Bug #052: edit no-op diagnostics escape control characters", () => {
     const { computeLineHash } = await import("../src/hashline.js");
     const anchor = `2:${computeLineHash(2, "line with \x07 bell")}`;
 
-    try {
-      await callEditTool({
-        path: filePath,
-        edits: [{ set_line: { anchor, new_text: "line with \x07 bell" } }],
-      });
-      expect.unreachable("Expected no-op diagnostic error");
-    } catch (err: any) {
-      expect(err.message).toContain("No changes made");
-      expect(err.message).toContain("\\u0007");
-      expect(CONTROL_CHAR_RE.test(err.message)).toBe(false);
-    }
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ set_line: { anchor, new_text: "line with \x07 bell" } }],
+    });
+
+    expect(result.isError).toBe(true);
+    const text = result.content.find((c: any) => c.type === "text")?.text ?? "";
+    expect(text).toContain("No changes made");
+    expect(text).toContain("\\u0007");
+    expect(CONTROL_CHAR_RE.test(text)).toBe(false);
   });
 });

--- a/tests/repro-081-invalid-offset.test.ts
+++ b/tests/repro-081-invalid-offset.test.ts
@@ -37,8 +37,15 @@ describe("issue #081 regression — invalid offset", () => {
 
     expect(negativeOffset.isError).toBe(true);
     expect(getTextContent(negativeOffset)).toBe("Invalid offset: expected a positive integer, received -5.");
-    expect(negativeOffset.details?.ptcValue).toBeUndefined();
-
+    expect(negativeOffset.details?.ptcValue).toEqual({
+      tool: "read",
+      ok: false,
+      path: filePath,
+      error: {
+        code: "invalid-offset",
+        message: "Invalid offset: expected a positive integer, received -5.",
+      },
+    });
     const zeroOffset = await tool.execute(
       "read-081-zero-offset",
       { path: filePath, offset: "0" },
@@ -46,9 +53,16 @@ describe("issue #081 regression — invalid offset", () => {
       () => {},
       { cwd: process.cwd() },
     );
-
     expect(zeroOffset.isError).toBe(true);
     expect(getTextContent(zeroOffset)).toBe("Invalid offset: expected a positive integer, received 0.");
-    expect(zeroOffset.details?.ptcValue).toBeUndefined();
+    expect(zeroOffset.details?.ptcValue).toEqual({
+      tool: "read",
+      ok: false,
+      path: filePath,
+      error: {
+        code: "invalid-offset",
+        message: "Invalid offset: expected a positive integer, received 0.",
+      },
+    });
   });
 });

--- a/tests/repro-081-negative-limit.test.ts
+++ b/tests/repro-081-negative-limit.test.ts
@@ -38,7 +38,15 @@ describe("issue #081 regression — negative limit", () => {
 
       expect(result.isError).toBe(true);
       expect(getTextContent(result)).toBe("Invalid limit: expected a positive integer, received -10.");
-      expect(result.details?.ptcValue).toBeUndefined();
+      expect(result.details?.ptcValue).toMatchObject({
+        tool: "read",
+        ok: false,
+        path: filePath,
+        error: {
+          code: "invalid-limit",
+          message: "Invalid limit: expected a positive integer, received -10.",
+        },
+      });
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/repro-081-zero-limit.test.ts
+++ b/tests/repro-081-zero-limit.test.ts
@@ -37,7 +37,15 @@ describe("issue #081 regression — zero limit", () => {
 
     expect(numericZero.isError).toBe(true);
     expect(getTextContent(numericZero)).toBe("Invalid limit: expected a positive integer, received 0.");
-    expect(numericZero.details?.ptcValue).toBeUndefined();
+    expect(numericZero.details?.ptcValue).toMatchObject({
+      tool: "read",
+      ok: false,
+      path: filePath,
+      error: {
+        code: "invalid-limit",
+        message: "Invalid limit: expected a positive integer, received 0.",
+      },
+    });
 
     const stringZero = await tool.execute(
       "read-081-zero-limit-string",
@@ -49,6 +57,14 @@ describe("issue #081 regression — zero limit", () => {
 
     expect(stringZero.isError).toBe(true);
     expect(getTextContent(stringZero)).toBe("Invalid limit: expected a positive integer, received 0.");
-    expect(stringZero.details?.ptcValue).toBeUndefined();
+    expect(stringZero.details?.ptcValue).toMatchObject({
+      tool: "read",
+      ok: false,
+      path: filePath,
+      error: {
+        code: "invalid-limit",
+        message: "Invalid limit: expected a positive integer, received 0.",
+      },
+    });
   });
 });


### PR DESCRIPTION
## Why
Downstream consumers were forced to regex free-text tool failures. That made retries, wrappers, and prompt-assembler logic brittle, especially for cases like stale edit anchors, parameter validation, filesystem failures, and `nu` commands that fail without using `isError`.

This PR adds a stable, machine-dispatchable error envelope under `details.ptcValue.error` across the affected tools while preserving the existing human-readable output.

## What changed
- added a shared `PtcError` interface and `buildPtcError(...)` helper in `src/ptc-value.ts`
- added `src/ptc-error-codes.ts` as the single source of truth for shipped error codes, descriptions, and trigger conditions
- updated every fatal return site in `read`, `edit`, `grep`, `ast_search`, `find`, `ls`, and `write` to emit:
  - `tool`
  - `ok: false`
  - `error: { code, message, hint?, details? }`
  - `path` when the failure is path-specific
- updated `edit` hash mismatches to return `error.code === "hash-mismatch"` plus `error.details.updatedAnchors: PtcLine[]`
- updated `nu` to always return `ptcValue: { tool: "nu", ok: boolean }`, with typed failure codes while keeping `isError` falsy
- added `fs-error` so unexpected filesystem failures no longer masquerade as `file-not-found` / `path-not-found`
- documented the contract and warning-vs-error distinction in the README

## Notable behavior details
- `content[0].text` remains the primary human-readable error surface; `ptcValue.error.message` matches or cleanly contains it
- `PtcWarning` stays structurally unchanged; warnings and errors now share the same kebab-case namespace conventions
- `nu` remains transport-compatible: failures are represented through `ptcValue.ok/error`, not `isError`
- `write` now lifts `binary-content` into a fatal structured error envelope for contract consistency, while preserving warning metadata

## Test coverage
Added focused coverage for:
- `buildPtcError` shape/omission behavior
- taxonomy completeness + kebab-case enforcement
- per-tool representative contract failures
- `edit` hash mismatch `updatedAnchors` typing
- regression coverage for hints and filesystem classification fixes

## Verification
- `npm run typecheck`
- `npm test`
- `npx vitest run tests/ptc-error-contract.test.ts tests/ptc-error-hash-mismatch.test.ts tests/ptc-error-builder.test.ts tests/ptc-error-codes.test.ts tests/ptc-error-fixes-v2.test.ts --reporter=verbose`

Current branch status before merge:
- `npm test`: 196/196 files passed, 932/932 tests passed
- CI: passing

Closes #106
