### PR TITLE
release 0.7.0: validation gap cleanup & docs refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Repo-local guide for working on `pi-hashline-readmap`.
 - `ast_search` — ast-grep wrapper with hashlined output
 - `bash` filtering — command-aware output compression
 
-The extension is symlinked from `~/.pi/agent/extensions/pi-hashline-readmap` to this workspace, so local edits take effect immediately.
+The extension is loaded via an absolute path entry in `~/.pi/agent/settings.json`'s `extensions` array (pointing at this workspace's `index.ts`), so **new agent sessions** pick up local edits automatically. Running sessions do **not** hot-reload the module graph — restart any in-flight agent session to see changes take effect.
 
 ## Version Control
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,31 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [0.7.0] - 2026-04-20
 
-No unreleased entries yet.
+### Added
+- Anchor-contract prompt/docs alignment (#42).
+- Surface edit semantic annotations + replace-only guidance (#43).
+- Require confirmation for fuzzy symbol matches (#44).
+- `grep` `scopeContext` windowing (#45).
+- `find` regex pattern, `modifiedSince`, `minSize`/`maxSize`, `sortBy`/`reverse` options (#46).
+- Expose `ls` / `find` / `nu` hashline executor surface (#47).
+- `nu` lazy-load advanced guidelines (#48).
+- Structured `ptcValue` error envelopes (#49).
+- Doom-loop escalate from warning → append-then-review in `edit` (#50).
+- Bash compression raw-bypass via `PI_RTK_BYPASS=1` (#51).
+- Persistent structural-map cache across sessions (#52).
+
+### Fixed
+- `find`: validate `maxDepth` ≥ 0 before spawning `fd` (#112).
+- `read`: reject empty / whitespace-only `symbol` instead of silently returning full file (#113).
+- `ls`: validate `limit > 0` and surface invalid-glob errors (#114).
+- `ast_search`: report `path '<x>' does not exist` instead of silent "No matches" (#115).
+- `write`: map `EACCES`/`EPERM`/`EISDIR`/`ENOENT`/`ENOSPC`/`EROFS` to friendly messages (#116).
+
+### Docs
+- `AGENTS.md`: correct extension-loading description (absolute-path entry in `~/.pi/agent/settings.json`, not a symlink) and note the restart requirement for running sessions (#117).
+- `README.md`: document persistent map cache, `scopeContext`, new `find` filters, `PI_RTK_BYPASS`, edit semantic summaries, and fuzzy-symbol confirmation banners (#118).
 
 ## [0.4.0] - 2026-03-24
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,19 @@ This package is a good fit when you want pi to:
 - `symbol` cannot be combined with `offset` or `limit`.
 - `bundle: "local"` requires `symbol` and cannot be combined with `map` or `offset`.
 
+### Persistent structural-map cache
+
+Symbol maps computed by `read({ path, map: true })` and the `read({ path, symbol: ... })` lookup path are cached to disk across agent sessions, so repeated reads of the same file can skip recomputation when the cache key still matches.
+
+- `PI_HASHLINE_MAP_CACHE_DIR` — override the cache directory directly.
+- `XDG_CACHE_HOME` — when `PI_HASHLINE_MAP_CACHE_DIR` is unset, the cache lives under `$XDG_CACHE_HOME/pi-hashline-readmap/maps`.
+- default fallback — `~/.cache/pi-hashline-readmap/maps`
+- `PI_HASHLINE_NO_PERSIST_MAPS=1` — disable the on-disk cache entirely and keep caching in-memory only.
+
+### Fuzzy symbol fallback banners
+
+When `symbol` does not resolve through the normal exact / case-insensitive / prefix path, `read` falls back to fuzzy tiers: camelCase word boundary, then substring. Approximate matches still return content, but the output prepends a confirmation banner naming the matched symbol, the tier that matched, nearby candidates, and the confirmation hint so you can decide whether to trust the guess or tighten the query.
+
 ## `edit`
 - hash-verified anchored edits using `LINE:HASH` anchors from `read`, `grep`, or `ast_search`
 - operations: `set_line`, `replace_lines`, `insert_after`, `replace`
@@ -97,7 +110,13 @@ After each successful edit, `details.ptcValue.semanticSummary` classifies the ch
 
 When [difftastic](https://difftastic.wilfred.me/) (`difft`) is installed, classification uses AST-aware diffing for better formatting-only detection and moved-block summaries. When difftastic is unavailable or fails, the tool falls back silently to internal heuristics.
 
-The success text output stays unchanged. Semantic classification is additive metadata only.
+The base success text stays compact; semantic classification is additive metadata, and moved-block summaries may append a `[semantic: ...]` suffix.
+### Anchor-first edit guidance
+
+`edit` returns a semantic summary alongside the normal diff output. In structured data this lives at `details.ptcValue.semanticSummary`; when moved blocks are detected, the visible text also carries a `[semantic: ...]` suffix so agents can distinguish formatting-only edits from structural changes quickly.
+
+Prefer `set_line`, `replace_lines`, and `insert_after` over broad `replace` whenever possible. Anchor-based operations minimise blast radius, preserve hash verification, and keep semantic summaries precise.
+
 
 ## `grep`
 - hash-anchored matches ready for direct use with `edit`
@@ -105,10 +124,12 @@ The success text output stays unchanged. Semantic classification is additive met
 - `summary: true` mode for per-file match counts
 - result truncation indicators
 - symbol-scoped results via `scope: "symbol"`
+- symbol-local match windowing via `scopeContext` when combined with `scope: "symbol"`
 - custom TUI rendering with match distribution and truncation badges
 
 ### Symbol-scoped grep
 With `scope: "symbol"`, matches are grouped by their enclosing function, method, class, or other mapped symbol when possible. Unsupported files and unmappable cases fall back gracefully to normal grep output.
+Pass `scopeContext: N` to show only ±N lines around each match within the resolved symbol block. Use `scopeContext: 0` for match lines only. For ordinary raw file-line context outside symbol boundaries, use `context` instead.
 
 ## `ast_search`
 - wraps [ast-grep](https://ast-grep.github.io/) for structural code search
@@ -180,6 +201,16 @@ Recursive file discovery optimized for agents. Uses [`fd`](https://github.com/sh
 - `maxDepth` — maximum directory depth
 
 Returns sorted relative paths with forward slashes and structured `ptcValue`. Output bounded by entry count and 50 KB byte budget.
+### Filters and ordering
+
+| Option | Effect |
+|---|---|
+| `regex: true` | Treat `pattern` as a JavaScript regex against the file basename |
+| `modifiedSince` | Keep entries whose mtime is strictly after the given date (`24h`, `7d`, `2024-01-01`, ISO-8601 timestamp) |
+| `minSize` / `maxSize` | Keep files within an inclusive byte range. Numbers are bytes; strings accept `B` / `K` / `KB` / `M` / `MB` / `G` / `GB` |
+| `sortBy` | `"name"` (default) / `"mtime"` / `"size"` |
+| `reverse` | Descending order. Combine with `sortBy` for newest-first or largest-first results |
+
 
 ## Quick Start
 
@@ -340,6 +371,14 @@ grep({ pattern: "addRoute", path: "src", literal: true, scope: "symbol" })
 ```
 
 Use this when the match location alone is not enough and you want the enclosing function or method block.
+To clamp output to the enclosing symbol instead of the whole file, add `scopeContext`:
+
+```text
+grep({ pattern: "addRoute", path: "src", literal: true, scope: "symbol", scopeContext: 3 })
+```
+
+Use `scopeContext: 0` for only the matching lines.
+
 
 ## Structural code search with ast_search
 ```text
@@ -454,6 +493,7 @@ The same executors are also exposed at `globalThis.__hashlineToolExecutors`.
 - `limit`
 - `summary`
 - `scope: "symbol"`
+- `scopeContext` — context lines around each match within the enclosing symbol (requires `scope: "symbol"`)
 
 ## `edit` operations
 - `set_line`
@@ -477,6 +517,11 @@ The same executors are also exposed at `globalThis.__hashlineToolExecutors`.
 - `limit` — max entries
 - `type` — entry type filter (`"file"`, `"dir"`, `"any"`)
 - `maxDepth` — max directory depth
+- `regex` — treat `pattern` as a JavaScript regex against the basename
+- `sortBy` — `"name"` (default), `"mtime"`, or `"size"`
+- `reverse` — reverse the sort order; useful with `sortBy: "mtime"` / `"size"`
+- `modifiedSince` — keep entries modified strictly after a relative or ISO timestamp
+- `minSize` / `maxSize` — inclusive file size bounds; numbers are bytes, strings accept `B` / `K` / `KB` / `M` / `MB` / `G` / `GB`
 
 ## Project Structure
 ```text
@@ -522,13 +567,18 @@ npm run typecheck
 ```
 
 As of the current repository state, the suite passes with:
-- **150** test files
-- **747** tests
+- **216** test files
+- **1064** tests
 
 ### Local development notes
-This repository is intended to be used as a pi extension workspace. In local development, changes can take effect immediately when the extension is installed from the local checkout.
-
+This repository is intended to be used as a pi extension workspace. New agent sessions pick up local extension edits from the checkout, but running sessions do not hot-reload the module graph. Restart the agent session after changing extension code.
 For project-specific development workflow details, see [AGENTS.md](AGENTS.md).
+
+## Troubleshooting
+
+### "I edited the extension but nothing changed."
+
+Restart the agent session. New sessions pick up the latest extension code; running sessions load the module graph once at startup and do not hot-reload.
 
 ## Publishing
 ```bash
@@ -542,6 +592,7 @@ The published package includes:
 - `prompts/`
 - `LICENSE`
 - `README.md`
+- `CHANGELOG.md`
 
 ## When to choose this package
 Install `pi-hashline-readmap` if you want pi to be stronger at:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.5.3",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.5.3",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {
@@ -29,7 +29,8 @@
     "src/",
     "prompts/",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "test": "vitest run",

--- a/src/find.ts
+++ b/src/find.ts
@@ -9,6 +9,7 @@ import { resolveToCwd } from "./path-utils.js";
 import * as findStat from "./find-stat.js";
 import { parseRelativeOrIsoDate, parseSize } from "./find-parsers.js";
 import { buildPtcError } from "./ptc-value.js";
+import { coerceObviousBase10Int } from "./coerce-obvious-int.js";
 
 const MAX_BYTES = 50 * 1024; // 50 KB
 const DEFAULT_LIMIT = 1000;
@@ -369,6 +370,38 @@ export function registerFindTool(pi: ExtensionAPI) {
       const limit = params.limit ?? DEFAULT_LIMIT;
       const type = params.type ?? "file";
       const pattern = params.pattern;
+      const maxDepthCoerced = coerceObviousBase10Int(params.maxDepth, "maxDepth");
+      if (!maxDepthCoerced.ok) {
+        const message = `Error: ${maxDepthCoerced.message}`;
+        return {
+          content: [{ type: "text" as const, text: message }],
+          isError: true,
+          details: {
+            ptcValue: {
+              tool: "find" as const,
+              ok: false,
+              path: params.path ?? searchPath,
+              error: buildPtcError("invalid-params-combo", maxDepthCoerced.message),
+            },
+          },
+        };
+      }
+      if (maxDepthCoerced.value !== undefined && maxDepthCoerced.value < 0) {
+        const message = `Invalid maxDepth: expected a non-negative integer, received ${maxDepthCoerced.value}.`;
+        return {
+          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          isError: true,
+          details: {
+            ptcValue: {
+              tool: "find" as const,
+              ok: false,
+              path: params.path ?? searchPath,
+              error: buildPtcError("invalid-params-combo", message),
+            },
+          },
+        };
+      }
+      params = { ...params, maxDepth: maxDepthCoerced.value };
 
       // Check if path exists
       try {

--- a/src/ls.ts
+++ b/src/ls.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { resolveToCwd } from "./path-utils.js";
 import { buildPtcError } from "./ptc-value.js";
+import { coerceObviousBase10Int } from "./coerce-obvious-int.js";
 
 const MAX_BYTES = 50 * 1024; // 50 KB
 const DEFAULT_LIMIT = 500;
@@ -66,6 +67,30 @@ function formatOutput(entries: LsEntry[], totalCount: number, truncated: boolean
   return text;
 }
 
+function validateGlobBalance(glob: string): string | null {
+  let brackets = 0;
+  let braces = 0;
+  for (let i = 0; i < glob.length; i++) {
+    const ch = glob[i];
+    if (ch === "\\") {
+      i++;
+      continue;
+    }
+    if (ch === "[") brackets++;
+    else if (ch === "]") {
+      if (brackets === 0) return "Unmatched ']'.";
+      brackets--;
+    } else if (ch === "{") braces++;
+    else if (ch === "}") {
+      if (braces === 0) return "Unmatched '}'.";
+      braces--;
+    }
+  }
+  if (brackets !== 0) return "Unterminated character class.";
+  if (braces !== 0) return "Unterminated brace expansion.";
+  return null;
+}
+
 export function registerLsTool(pi: ExtensionAPI) {
   const tool: Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof LS_PTC } = {
     name: "ls",
@@ -74,20 +99,54 @@ export function registerLsTool(pi: ExtensionAPI) {
     ptc: LS_PTC,
     parameters: Type.Object({
       path: Type.Optional(Type.String({ description: "Directory to list (default: cwd)" })),
-      limit: Type.Optional(Type.Number({ description: "Max entries to return (default: 500)" })),
+      limit: Type.Optional(
+        Type.Union(
+          [Type.Number(), Type.String()],
+          { description: "Max entries to return (default: 500)" },
+        ),
+      ),
       glob: Type.Optional(Type.String({ description: "Filter entries by glob pattern (e.g. '*.ts')" })),
     }),
-
     async execute(
       _toolCallId: string,
-      params: { path?: string; limit?: number; glob?: string },
+      params: { path?: string; limit?: number | string; glob?: string },
       _signal: AbortSignal | undefined,
       _onUpdate: any,
       ctx: any,
     ) {
       const cwd: string = ctx?.cwd ?? process.cwd();
       const targetPath = params.path ? resolveToCwd(params.path, cwd) : cwd;
-      const limit = params.limit ?? DEFAULT_LIMIT;
+      const limitCoerced = coerceObviousBase10Int(params.limit, "limit");
+      if (!limitCoerced.ok) {
+        return {
+          content: [{ type: "text" as const, text: limitCoerced.message }],
+          isError: true,
+          details: {
+            ptcValue: {
+              tool: "ls" as const,
+              ok: false,
+              path: params.path ?? targetPath,
+              error: buildPtcError("invalid-limit", limitCoerced.message),
+            },
+          },
+        };
+      }
+      if (limitCoerced.value !== undefined && limitCoerced.value < 1) {
+        const message = `Invalid limit: expected a positive integer, received ${limitCoerced.value}.`;
+        return {
+          content: [{ type: "text" as const, text: message }],
+          isError: true,
+          details: {
+            ptcValue: {
+              tool: "ls" as const,
+              ok: false,
+              path: params.path ?? targetPath,
+              error: buildPtcError("invalid-limit", message),
+            },
+          },
+        };
+      }
+      const limit = limitCoerced.value ?? DEFAULT_LIMIT;
 
       // Check if path exists and is a directory
       let pathStat;
@@ -151,6 +210,22 @@ export function registerLsTool(pi: ExtensionAPI) {
 
       // Apply glob filter
       if (params.glob) {
+        const balanceError = validateGlobBalance(params.glob);
+        if (balanceError) {
+          const message = `Invalid glob ${JSON.stringify(params.glob)}: ${balanceError}`;
+          return {
+            content: [{ type: "text" as const, text: message }],
+            isError: true,
+            details: {
+              ptcValue: {
+                tool: "ls" as const,
+                ok: false,
+                path: params.path ?? targetPath,
+                error: buildPtcError("invalid-params-combo", message),
+              },
+            },
+          };
+        }
         const picomatch = (await import("picomatch" as any)).default;
         const isMatch = picomatch(params.glob);
         allEntries = allEntries.filter((e) => isMatch(e.name));

--- a/src/read.ts
+++ b/src/read.ts
@@ -147,6 +147,25 @@ export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}
 				offset: offset.value,
 				limit: limit.value,
 			};
+			if (rawParams.symbol !== undefined) {
+				const trimmedSymbol = typeof rawParams.symbol === "string" ? rawParams.symbol.trim() : "";
+				if (trimmedSymbol.length === 0) {
+					const message = "Invalid symbol: expected a non-empty string.";
+					return {
+						content: [{ type: "text", text: message }],
+						isError: true,
+						details: {
+							ptcValue: {
+								tool: "read",
+								ok: false,
+								path: rawParams.path,
+								error: buildPtcError("invalid-params-combo", message),
+							},
+						},
+					};
+				}
+				p.symbol = trimmedSymbol;
+			}
 			const rawPath = p.path.replace(/^@/, "");
 			const absolutePath = resolveToCwd(rawPath, ctx.cwd);
 			const succeed = <T extends AgentToolResult<any>>(result: T): T => {

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -116,6 +116,54 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
       args.push(searchPath);
 
       try {
+        await fsStat(searchPath);
+      } catch (err: any) {
+        if (err?.code === "ENOENT") {
+          const message = `Error: path '${p.path ?? "."}' does not exist`;
+          return {
+            content: [{ type: "text", text: message }],
+            isError: true,
+            details: {
+              ptcValue: {
+                tool: "ast_search",
+                ok: false,
+                path: p.path ?? searchPath,
+                error: buildPtcError("path-not-found", message),
+              },
+            },
+          };
+        }
+        if (err?.code === "EACCES" || err?.code === "EPERM") {
+          const message = `Error: permission denied for path '${p.path ?? "."}'`;
+          return {
+            content: [{ type: "text", text: message }],
+            isError: true,
+            details: {
+              ptcValue: {
+                tool: "ast_search",
+                ok: false,
+                path: p.path ?? searchPath,
+                error: buildPtcError("permission-denied", message),
+              },
+            },
+          };
+        }
+        const message = `Error: could not access path '${p.path ?? "."}': ${err?.message ?? String(err)}`;
+        return {
+          content: [{ type: "text", text: message }],
+          isError: true,
+          details: {
+            ptcValue: {
+              tool: "ast_search",
+              ok: false,
+              path: p.path ?? searchPath,
+              error: buildPtcError("fs-error", message, undefined, { fsCode: err?.code, fsMessage: err?.message }),
+            },
+          },
+        };
+      }
+
+      try {
         const { stdout } = await execFileText("sg", args, {
           cwd: ctx.cwd,
           signal,

--- a/src/write.ts
+++ b/src/write.ts
@@ -31,6 +31,58 @@ export interface WriteToolOptions {
   onFileAnchored?: (absolutePath: string) => void;
 }
 
+type MappedFsError = {
+  code: "permission-denied" | "path-is-directory" | "fs-error";
+  message: string;
+  includeMeta: boolean;
+};
+
+function mapFsWriteError(err: any, path: string): MappedFsError {
+  const phase: "mkdir" | "write" | undefined = err?.__phase;
+  const fsCode = err?.code as string | undefined;
+
+  if (fsCode === "EACCES" || fsCode === "EPERM") {
+    return {
+      code: "permission-denied",
+      message: `Permission denied — cannot write: ${path}`,
+      includeMeta: false,
+    };
+  }
+  if (fsCode === "EISDIR") {
+    return {
+      code: "path-is-directory",
+      message: `Path is a directory — cannot overwrite: ${path}`,
+      includeMeta: false,
+    };
+  }
+  if (fsCode === "ENOENT" && phase === "mkdir") {
+    return {
+      code: "fs-error",
+      message: `Cannot create parent directories for ${path}: ${err?.message ?? String(err)}`,
+      includeMeta: true,
+    };
+  }
+  if (fsCode === "ENOSPC") {
+    return {
+      code: "fs-error",
+      message: `No space left on device — cannot write: ${path}`,
+      includeMeta: true,
+    };
+  }
+  if (fsCode === "EROFS") {
+    return {
+      code: "fs-error",
+      message: `Read-only filesystem — cannot write: ${path}`,
+      includeMeta: true,
+    };
+  }
+  return {
+    code: "fs-error",
+    message: `Error writing ${path}: ${err?.message ?? String(err)}`,
+    includeMeta: true,
+  };
+}
+
 export async function executeWrite(opts: {
   path: string;
   content: string;
@@ -42,10 +94,19 @@ export async function executeWrite(opts: {
   const { path: filePath, content, map: requestMap, cwd } = opts;
 
   // Create parent directories
-  mkdirSync(dirname(filePath), { recursive: true });
-
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+  } catch (err: any) {
+    err.__phase = "mkdir";
+    throw err;
+  }
   // Write file
-  writeFileSync(filePath, content, "utf-8");
+  try {
+    writeFileSync(filePath, content, "utf-8");
+  } catch (err: any) {
+    err.__phase = "write";
+    throw err;
+  }
 
   const warnings: string[] = [];
   const ptcWarnings: PtcWarning[] = [];
@@ -134,12 +195,37 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
     async execute(_toolCallId: string, params: { path: string; content: string; map?: boolean }, _signal: AbortSignal | undefined, _onUpdate: any, ctx: any) {
       const cwd = ctx?.cwd ?? process.cwd();
       const absolutePath = resolveToCwd(params.path, cwd);
-      const result = await executeWrite({
-        path: absolutePath,
-        content: params.content,
-        map: params.map,
-        cwd,
-      });
+      let result: WriteResult;
+      try {
+        result = await executeWrite({
+          path: absolutePath,
+          content: params.content,
+          map: params.map,
+          cwd,
+        });
+      } catch (err: any) {
+        const mapped = mapFsWriteError(err, absolutePath);
+        return {
+          content: [{ type: "text" as const, text: mapped.message }],
+          isError: true,
+          details: {
+            ptcValue: {
+              tool: "write" as const,
+              path: absolutePath,
+              lines: [] as PtcLine[],
+              warnings: [] as PtcWarning[],
+              ok: false,
+              error: buildPtcError(
+                mapped.code,
+                mapped.message,
+                undefined,
+                mapped.includeMeta ? { fsCode: err?.code, fsMessage: err?.message } : undefined,
+              ),
+            },
+            warnings: [] as string[],
+          },
+        };
+      }
 
       if (result.ptcValue.lines.length > 0) {
         options.onFileAnchored?.(absolutePath);

--- a/tests/find-max-depth-validation.test.ts
+++ b/tests/find-max-depth-validation.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as cp from "node:child_process";
+import { _testable, isFdAvailable } from "../src/find.js";
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, execFile: vi.fn(actual.execFile), execFileSync: vi.fn(actual.execFileSync) };
+});
+
+const _originalIsFdAvailable = isFdAvailable;
+
+async function getFindTool() {
+  const { registerFindTool } = await import("../src/find.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerFindTool(mockPi as any);
+  if (!captured) throw new Error("find tool was not registered");
+  return captured;
+}
+
+function text(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("find maxDepth validation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    _testable.isFdAvailable = _originalIsFdAvailable;
+  });
+
+  it("rejects negative maxDepth with validator-style message", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "find-maxdepth-neg-"));
+    try {
+      writeFileSync(join(dir, "a.ts"), "");
+      const tool = await getFindTool();
+      const execFileSpy = vi.spyOn(cp, "execFile");
+      const result = await tool.execute(
+        "tc",
+        { pattern: "*.ts", maxDepth: -1 },
+        new AbortController().signal,
+        undefined,
+        { cwd: dir },
+      );
+      expect(result.isError).toBe(true);
+      expect(text(result)).toContain("Invalid maxDepth: expected a non-negative integer, received -1.");
+      expect(result.details?.ptcValue?.ok).toBe(false);
+      expect(result.details?.ptcValue?.error?.code).toBe("invalid-params-combo");
+      expect(execFileSpy).not.toHaveBeenCalled();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects string '-1' maxDepth via coerceObviousBase10Int parity", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "find-maxdepth-str-"));
+    try {
+      writeFileSync(join(dir, "a.ts"), "");
+      const tool = await getFindTool();
+      const result = await tool.execute(
+        "tc",
+        { pattern: "*.ts", maxDepth: "-1" as any },
+        new AbortController().signal,
+        undefined,
+        { cwd: dir },
+      );
+      expect(result.isError).toBe(true);
+      expect(text(result)).toContain("Invalid maxDepth: expected a non-negative integer, received -1.");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects non-numeric maxDepth like 'abc'", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "find-maxdepth-abc-"));
+    try {
+      writeFileSync(join(dir, "a.ts"), "");
+      const tool = await getFindTool();
+      const result = await tool.execute(
+        "tc",
+        { pattern: "*.ts", maxDepth: "abc" as any },
+        new AbortController().signal,
+        undefined,
+        { cwd: dir },
+      );
+      expect(result.isError).toBe(true);
+      expect(text(result)).toContain("Invalid maxDepth: expected a base-10 integer, received");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects fractional maxDepth like 1.5", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "find-maxdepth-frac-"));
+    try {
+      writeFileSync(join(dir, "a.ts"), "");
+      const tool = await getFindTool();
+      const result = await tool.execute(
+        "tc",
+        { pattern: "*.ts", maxDepth: 1.5 as any },
+        new AbortController().signal,
+        undefined,
+        { cwd: dir },
+      );
+      expect(result.isError).toBe(true);
+      expect(text(result)).toContain("Invalid maxDepth: expected a base-10 integer, received 1.5.");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts maxDepth=0 and maxDepth=3 (regression — valid inputs unchanged)", async () => {
+    _testable.isFdAvailable = () => false;
+    const dir = mkdtempSync(join(tmpdir(), "find-maxdepth-ok-"));
+    try {
+      writeFileSync(join(dir, "a.ts"), "");
+      const tool = await getFindTool();
+      const ok0 = await tool.execute("tc", { pattern: "*.ts", maxDepth: 0 }, new AbortController().signal, undefined, { cwd: dir });
+      expect(ok0.isError).toBeFalsy();
+      const ok3 = await tool.execute("tc", { pattern: "*.ts", maxDepth: 3 }, new AbortController().signal, undefined, { cwd: dir });
+      expect(ok3.isError).toBeFalsy();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/ls-glob-validation.test.ts
+++ b/tests/ls-glob-validation.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+async function getLsTool() {
+  const { registerLsTool } = await import("../src/ls.js");
+  let captured: any = null;
+  registerLsTool({ registerTool(def: any) { captured = def; } } as any);
+  if (!captured) throw new Error("ls tool was not registered");
+  return captured;
+}
+
+function text(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+function makeDir() {
+  const dir = mkdtempSync(join(tmpdir(), "ls-glob-"));
+  writeFileSync(join(dir, "a.ts"), "");
+  writeFileSync(join(dir, "b.ts"), "");
+  return dir;
+}
+
+describe("ls glob validation", () => {
+  it("rejects unterminated character class '[invalid' on a non-empty dir", async () => {
+    const dir = makeDir();
+    try {
+      const tool = await getLsTool();
+      const result = await tool.execute("tc", { path: dir, glob: "[invalid" },
+        new AbortController().signal, undefined, { cwd: process.cwd() });
+      expect(result.isError).toBe(true);
+      expect(text(result)).toContain(`Invalid glob "[invalid"`);
+      expect(text(result)).not.toBe("(empty directory)");
+      expect(result.details?.ptcValue?.error?.code).toBe("invalid-params-combo");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("rejects unterminated brace expansion '{unmatched'", async () => {
+    const dir = makeDir();
+    try {
+      const tool = await getLsTool();
+      const result = await tool.execute("tc", { path: dir, glob: "{unmatched" },
+        new AbortController().signal, undefined, { cwd: process.cwd() });
+      expect(result.isError).toBe(true);
+      expect(text(result)).toContain(`Invalid glob "{unmatched"`);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("regression: valid glob '*.ts' still filters", async () => {
+    const dir = makeDir();
+    try {
+      writeFileSync(join(dir, "c.md"), "");
+      const tool = await getLsTool();
+      const result = await tool.execute("tc", { path: dir, glob: "*.ts" },
+        new AbortController().signal, undefined, { cwd: process.cwd() });
+      expect(result.isError).toBeFalsy();
+      const entries = result.details?.ptcValue?.entries ?? [];
+      expect(entries.map((e: any) => e.name).sort()).toEqual(["a.ts", "b.ts"]);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("regression: valid bracket glob '[ab].ts' matches a.ts and b.ts", async () => {
+    const dir = makeDir();
+    try {
+      const tool = await getLsTool();
+      const result = await tool.execute("tc", { path: dir, glob: "[ab].ts" },
+        new AbortController().signal, undefined, { cwd: process.cwd() });
+      expect(result.isError).toBeFalsy();
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+});

--- a/tests/ls-limit-validation.test.ts
+++ b/tests/ls-limit-validation.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+async function getLsTool() {
+  const { registerLsTool } = await import("../src/ls.js");
+  let captured: any = null;
+  registerLsTool({ registerTool(def: any) { captured = def; } } as any);
+  if (!captured) throw new Error("ls tool was not registered");
+  return captured;
+}
+
+function text(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+function makeDir() {
+  const dir = mkdtempSync(join(tmpdir(), "ls-limit-"));
+  writeFileSync(join(dir, "a.ts"), "");
+  writeFileSync(join(dir, "b.ts"), "");
+  return dir;
+}
+
+describe("ls limit validation", () => {
+  it("rejects limit: 0", async () => {
+    const dir = makeDir();
+    try {
+      const tool = await getLsTool();
+      const result = await tool.execute("tc", { path: dir, limit: 0 },
+        new AbortController().signal, undefined, { cwd: process.cwd() });
+      expect(result.isError).toBe(true);
+      expect(text(result)).toContain("Invalid limit: expected a positive integer, received 0.");
+      expect(result.details?.ptcValue?.error?.code).toBe("invalid-limit");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("rejects limit: -5", async () => {
+    const dir = makeDir();
+    try {
+      const tool = await getLsTool();
+      const result = await tool.execute("tc", { path: dir, limit: -5 },
+        new AbortController().signal, undefined, { cwd: process.cwd() });
+      expect(result.isError).toBe(true);
+      expect(text(result)).toContain("Invalid limit: expected a positive integer, received -5.");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("rejects non-numeric limit 'abc'", async () => {
+    const dir = makeDir();
+    try {
+      const tool = await getLsTool();
+      const result = await tool.execute("tc", { path: dir, limit: "abc" as any },
+        new AbortController().signal, undefined, { cwd: process.cwd() });
+      expect(result.isError).toBe(true);
+      expect(text(result)).toContain("Invalid limit: expected a base-10 integer, received");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("regression: limit: 1 still caps and returns one entry", async () => {
+    const dir = makeDir();
+    try {
+      const tool = await getLsTool();
+      const result = await tool.execute("tc", { path: dir, limit: 1 },
+        new AbortController().signal, undefined, { cwd: process.cwd() });
+      expect(result.isError).toBeFalsy();
+      expect(result.details?.ptcValue?.entries?.length).toBe(1);
+      expect(result.details?.ptcValue?.truncated).toBe(true);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+});

--- a/tests/read-symbol-empty.test.ts
+++ b/tests/read-symbol-empty.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { registerReadTool } from "../src/read.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+function captureReadTool() {
+  let captured: any;
+  registerReadTool({ registerTool(def: any) { captured = def; } } as any);
+  return captured;
+}
+
+function textOf(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("read symbol validation", () => {
+  it.each([
+    ["empty string", ""],
+    ["spaces only", "   "],
+    ["tab only", "\t"],
+    ["newline only", "\n"],
+  ])("rejects %s symbol with a validator-prefixed error", async (_label, sym) => {
+    const tool = captureReadTool();
+    const result = await tool.execute(
+      "read-empty",
+      { path: resolve(fixturesDir, "small.ts"), symbol: sym },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("Invalid symbol: expected a non-empty string.");
+    expect(result.details?.ptcValue?.ok).toBe(false);
+    expect(result.details?.ptcValue?.error?.code).toBe("invalid-params-combo");
+  });
+
+  it("regression: omitted symbol still returns full file output", async () => {
+    const tool = captureReadTool();
+    const result = await tool.execute(
+      "read-no-symbol",
+      { path: resolve(fixturesDir, "small.ts") },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+    expect(result.isError).toBeFalsy();
+    expect(textOf(result)).toMatch(/^1:[0-9a-f]{3}\|/m);
+  });
+
+  it("regression: whitespace-trimmed real symbol resolves via the lookup path (not the validator)", async () => {
+    const tool = captureReadTool();
+    const result = await tool.execute(
+      "read-real-symbol",
+      { path: resolve(fixturesDir, "small.ts"), symbol: "  createDemoDirectory  " },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+    expect(textOf(result)).not.toContain("Invalid symbol: expected a non-empty string.");
+  });
+});

--- a/tests/sg-path-validation.test.ts
+++ b/tests/sg-path-validation.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as cp from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
+}));
+
+async function getSgTool() {
+  const { registerSgTool } = await import("../src/sg.js");
+  let captured: any = null;
+  registerSgTool({ registerTool(def: any) { captured = def; } } as any);
+  if (!captured) throw new Error("sg tool was not registered");
+  return captured;
+}
+
+function text(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("ast_search path validation", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns path-not-found error for non-existent path and does not spawn ast-grep", async () => {
+    const tool = await getSgTool();
+    const execFileSpy = vi.mocked(cp.execFile);
+    execFileSpy.mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, "[]", "");
+      return {} as any;
+    });
+    const result = await tool.execute(
+      "tc",
+      { pattern: "console.log($X)", path: "/this/path/definitely/does/not/exist", lang: "typescript" },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+    expect(result.isError).toBe(true);
+    expect(text(result)).toBe(
+      "Error: path '/this/path/definitely/does/not/exist' does not exist",
+    );
+    expect(result.details?.ptcValue?.ok).toBe(false);
+    expect(result.details?.ptcValue?.error?.code).toBe("path-not-found");
+    expect(execFileSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/sg.path-resolution.test.ts
+++ b/tests/sg.path-resolution.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import * as cp from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 vi.mock("node:child_process", () => ({
   execFile: vi.fn(),
@@ -18,23 +21,29 @@ describe("sg path resolution", () => {
   afterEach(() => vi.restoreAllMocks());
 
   it("resolves params.path relative to ctx.cwd", async () => {
-    const tool = await getSgTool();
+    const dir = mkdtempSync(join(tmpdir(), "sg-path-resolution-"));
+    mkdirSync(join(dir, "src"));
+    try {
+      const tool = await getSgTool();
 
-    let capturedArgs: string[] = [];
-    vi.mocked(cp.execFile).mockImplementation((_cmd: any, args: any, _opts: any, cb: any) => {
-      capturedArgs = args;
-      cb(null, "[]", "");
-      return {} as any;
-    });
+      let capturedArgs: string[] = [];
+      vi.mocked(cp.execFile).mockImplementation((_cmd: any, args: any, _opts: any, cb: any) => {
+        capturedArgs = args;
+        cb(null, "[]", "");
+        return {} as any;
+      });
 
-    await tool.execute(
-      "tc",
-      { pattern: "p", path: "src" },
-      new AbortController().signal,
-      () => {},
-      { cwd: "/my/project" },
-    );
+      await tool.execute(
+        "tc",
+        { pattern: "p", path: "src" },
+        new AbortController().signal,
+        () => {},
+        { cwd: dir },
+      );
 
-    expect(capturedArgs[capturedArgs.length - 1]).toBe("/my/project/src");
+      expect(capturedArgs[capturedArgs.length - 1]).toBe(join(dir, "src"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/write-fs-errors.test.ts
+++ b/tests/write-fs-errors.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+async function getWriteTool(fsOverrides?: Partial<typeof import("node:fs")>) {
+  vi.resetModules();
+  if (fsOverrides) {
+    vi.doMock("node:fs", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs")>();
+      return { ...actual, ...fsOverrides };
+    });
+  } else {
+    vi.doUnmock("node:fs");
+  }
+
+  const { registerWriteTool } = await import("../src/write.js");
+  let captured: any = null;
+  registerWriteTool({ registerTool(def: any) { captured = def; } } as any);
+  if (!captured) throw new Error("write tool was not registered");
+  return captured;
+}
+
+function text(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+function fsErr(code: string, msg: string): NodeJS.ErrnoException {
+  const e: any = new Error(msg);
+  e.code = code;
+  return e;
+}
+
+describe("write fs-error mapping", () => {
+  afterEach(() => {
+    vi.doUnmock("node:fs");
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("EACCES on writeFile -> 'Permission denied — cannot write: <path>'", async () => {
+    const tool = await getWriteTool({
+      mkdirSync: (() => undefined) as any,
+      writeFileSync: (() => {
+        throw fsErr("EACCES", "EACCES: permission denied, open '/root/locked.txt'");
+      }) as any,
+    });
+    const result = await tool.execute(
+      "tc", { path: "/root/locked.txt", content: "hi" },
+      new AbortController().signal, undefined, { cwd: process.cwd() },
+    );
+    expect(result.isError).toBe(true);
+    expect(text(result)).toBe("Permission denied — cannot write: /root/locked.txt");
+    expect(result.details?.ptcValue?.error?.code).toBe("permission-denied");
+  });
+
+  it("EPERM on writeFile -> same permission-denied mapping", async () => {
+    const tool = await getWriteTool({
+      mkdirSync: (() => undefined) as any,
+      writeFileSync: (() => {
+        throw fsErr("EPERM", "EPERM: operation not permitted");
+      }) as any,
+    });
+    const result = await tool.execute(
+      "tc", { path: "/root/locked2.txt", content: "hi" },
+      new AbortController().signal, undefined, { cwd: process.cwd() },
+    );
+    expect(text(result)).toBe("Permission denied — cannot write: /root/locked2.txt");
+    expect(result.details?.ptcValue?.error?.code).toBe("permission-denied");
+  });
+
+  it("EISDIR on writeFile -> 'Path is a directory — cannot overwrite: <path>'", async () => {
+    const tool = await getWriteTool({
+      mkdirSync: (() => undefined) as any,
+      writeFileSync: (() => {
+        throw fsErr("EISDIR", "EISDIR: illegal operation on a directory");
+      }) as any,
+    });
+    const result = await tool.execute(
+      "tc", { path: "/tmp/somedir", content: "hi" },
+      new AbortController().signal, undefined, { cwd: process.cwd() },
+    );
+    expect(text(result)).toBe("Path is a directory — cannot overwrite: /tmp/somedir");
+    expect(result.details?.ptcValue?.error?.code).toBe("path-is-directory");
+  });
+
+  it("ENOENT on mkdirSync -> 'Cannot create parent directories for <path>: <reason>'", async () => {
+    const tool = await getWriteTool({
+      mkdirSync: (() => {
+        throw fsErr("ENOENT", "ENOENT: parent does not exist");
+      }) as any,
+    });
+    const result = await tool.execute(
+      "tc", { path: "/no/such/parent/file.txt", content: "hi" },
+      new AbortController().signal, undefined, { cwd: process.cwd() },
+    );
+    expect(text(result)).toContain("Cannot create parent directories for /no/such/parent/file.txt");
+    expect(text(result)).toContain("ENOENT: parent does not exist");
+    expect(result.details?.ptcValue?.error?.code).toBe("fs-error");
+  });
+
+  it("ENOSPC on writeFile -> 'No space left on device — cannot write: <path>'", async () => {
+    const tool = await getWriteTool({
+      mkdirSync: (() => undefined) as any,
+      writeFileSync: (() => {
+        throw fsErr("ENOSPC", "ENOSPC: no space left");
+      }) as any,
+    });
+    const result = await tool.execute(
+      "tc", { path: "/tmp/full.txt", content: "hi" },
+      new AbortController().signal, undefined, { cwd: process.cwd() },
+    );
+    expect(text(result)).toBe("No space left on device — cannot write: /tmp/full.txt");
+    expect(result.details?.ptcValue?.error?.code).toBe("fs-error");
+  });
+
+  it("EROFS on writeFile -> 'Read-only filesystem — cannot write: <path>'", async () => {
+    const tool = await getWriteTool({
+      mkdirSync: (() => undefined) as any,
+      writeFileSync: (() => {
+        throw fsErr("EROFS", "EROFS: read-only file system");
+      }) as any,
+    });
+    const result = await tool.execute(
+      "tc", { path: "/readonly/file.txt", content: "hi" },
+      new AbortController().signal, undefined, { cwd: process.cwd() },
+    );
+    expect(text(result)).toBe("Read-only filesystem — cannot write: /readonly/file.txt");
+    expect(result.details?.ptcValue?.error?.code).toBe("fs-error");
+  });
+
+  it("regression: successful write still returns hashlined output", async () => {
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = mkdtempSync(join(tmpdir(), "write-ok-"));
+    try {
+      const tool = await getWriteTool();
+      const result = await tool.execute(
+        "tc", { path: join(dir, "ok.txt"), content: "hello\nworld" },
+        new AbortController().signal, undefined, { cwd: process.cwd() },
+      );
+      expect(result.isError).toBeFalsy();
+      expect(text(result)).toMatch(/^1:[0-9a-f]{3}\|hello$/m);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes validation gaps in find, read, ls, ast_search, and write, corrects the AGENTS.md extension-loading description, and cuts the 0.7.0 release.

## Changes

### Validation fixes
- find: validate maxDepth >= 0 before spawning fd (#112)
- read: reject empty / whitespace-only symbol (#113)
- ls: validate limit > 0 and surface invalid-glob errors (#114)
- ast_search: report path does not exist instead of silent "No matches" (#115)
- write: map EACCES/EPERM/EISDIR/ENOENT/ENOSPC/EROFS to friendly messages (#116)

### Docs
- AGENTS.md: correct extension-loading description (#117)
- README.md: document persistent map cache, scopeContext, new find filters, PI_RTK_BYPASS, edit semantic summaries, and fuzzy-symbol confirmation banners (#118)
- CHANGELOG.md: add [0.7.0] entry covering PRs #42-#52

### Release
- Bump package.json to 0.7.0

## Verification
- npm run typecheck: pass
- npm test: 216 test files, 1064 tests passing
- npm pack --dry-run: pass
