### PR TITLE
fix: preserve blank-line separators in replace_lines wrapped-line restoration

### DIFF
--- a/src/hashline.ts
+++ b/src/hashline.ts
@@ -309,11 +309,12 @@ function restoreOldWrappedLines(oldLines: string[], newLines: string[]): string[
 		if (bucket) bucket.count++;
 		else canonToOld.set(canon, { line, count: 1 });
 	}
-
 	const candidates: { start: number; len: number; replacement: string; canon: string }[] = [];
 	for (let start = 0; start < newLines.length; start++) {
 		for (let len = 2; len <= 10 && start + len <= newLines.length; len++) {
-			const canonSpan = stripAllWhitespace(newLines.slice(start, start + len).join(""));
+			const span = newLines.slice(start, start + len);
+			if (span.some((line) => line.trim().length === 0)) continue;
+			const canonSpan = stripAllWhitespace(span.join(""));
 			const old = canonToOld.get(canonSpan);
 			if (old && old.count === 1 && canonSpan.length >= 6) {
 				candidates.push({ start, len, replacement: old.line, canon: canonSpan });
@@ -321,16 +322,12 @@ function restoreOldWrappedLines(oldLines: string[], newLines: string[]): string[
 		}
 	}
 	if (candidates.length === 0) return newLines;
-
-	// Keep only spans whose canonical match is unique in the new output.
 	const canonCounts = new Map<string, number>();
 	for (const c of candidates) {
 		canonCounts.set(c.canon, (canonCounts.get(c.canon) ?? 0) + 1);
 	}
 	const uniqueCandidates = candidates.filter((c) => (canonCounts.get(c.canon) ?? 0) === 1);
 	if (uniqueCandidates.length === 0) return newLines;
-
-	// Apply replacements back-to-front so indices remain stable.
 	uniqueCandidates.sort((a, b) => b.start - a.start);
 	const out = [...newLines];
 	for (const c of uniqueCandidates) {

--- a/tests/repro-125-replace-lines-blank-collapse.test.ts
+++ b/tests/repro-125-replace-lines-blank-collapse.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { applyHashlineEdits, computeLineHash, ensureHashInit } from "../src/hashline.js";
+
+describe("issue 125: replace_lines blank-line collapse in new_text", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("preserves explicit blank paragraph separator in new_text", () => {
+    const origContent = [
+      "Some intro.",
+      "    Previously, the system did X.",
+      "End.",
+    ].join("\n");
+
+    const anchor = `2:${computeLineHash(2, "    Previously, the system did X.")}`;
+    const newText = ["", "Previously, the system did X."].join("\n");
+
+    const result = applyHashlineEdits(origContent, [
+      { replace_lines: { start_anchor: anchor, end_anchor: anchor, new_text: newText } },
+    ]);
+
+    const expected = [
+      "Some intro.",
+      "",
+      "Previously, the system did X.",
+      "End.",
+    ].join("\n");
+
+    expect(result.content).toBe(expected);
+  });
+
+  it("does not steal leading whitespace from replaced old line", () => {
+    const origContent = [
+      "Heading",
+      "        Old line with lots of leading whitespace.",
+    ].join("\n");
+
+    const anchor = `2:${computeLineHash(2, "        Old line with lots of leading whitespace.")}`;
+    const newText = ["", "Old line with lots of leading whitespace."].join("\n");
+
+    const result = applyHashlineEdits(origContent, [
+      { replace_lines: { start_anchor: anchor, end_anchor: anchor, new_text: newText } },
+    ]);
+
+    const expected = [
+      "Heading",
+      "",
+      "Old line with lots of leading whitespace.",
+    ].join("\n");
+
+    expect(result.content).toBe(expected);
+  });
+
+  it("multi-paragraph new_text with shared paragraph text keeps blank separators", () => {
+    const origContent = [
+      "A",
+      "    Previously, things worked.",
+      "B",
+    ].join("\n");
+
+    const anchor = `2:${computeLineHash(2, "    Previously, things worked.")}`;
+    const newText = [
+      "Now, things work differently.",
+      "",
+      "Previously, things worked.",
+    ].join("\n");
+
+    const result = applyHashlineEdits(origContent, [
+      { replace_lines: { start_anchor: anchor, end_anchor: anchor, new_text: newText } },
+    ]);
+
+    const expected = [
+      "A",
+      "Now, things work differently.",
+      "",
+      "Previously, things worked.",
+      "B",
+    ].join("\n");
+
+    expect(result.content).toBe(expected);
+  });
+
+  it("keeps the blank separator in a mixed batch where another edit succeeds", () => {
+    const origContent = [
+      "const one = 1;",
+      "    Previously, the system did X.",
+      "Tail",
+    ].join("\n");
+
+    const anchor1 = `1:${computeLineHash(1, "const one = 1;")}`;
+    const anchor2 = `2:${computeLineHash(2, "    Previously, the system did X.")}`;
+
+    const result = applyHashlineEdits(origContent, [
+      { set_line: { anchor: anchor1, new_text: "const one = 11;" } },
+      {
+        replace_lines: {
+          start_anchor: anchor2,
+          end_anchor: anchor2,
+          new_text: ["", "Previously, the system did X."].join("\n"),
+        },
+      },
+    ]);
+
+    expect(result.noopEdits).toBeUndefined();
+    expect(result.content).toBe([
+      "const one = 11;",
+      "",
+      "Previously, the system did X.",
+      "Tail",
+    ].join("\n"));
+  });
+
+  it("still restores a true soft wrap when no blank lines are involved", () => {
+    const origContent = [
+      "const summary = alpha + beta + gamma;",
+      "tail();",
+    ].join("\n");
+
+    const anchor = `1:${computeLineHash(1, "const summary = alpha + beta + gamma;")}`;
+    const newText = [
+      "const summary = alpha + beta +",
+      "gamma;",
+    ].join("\n");
+
+    const result = applyHashlineEdits(origContent, [
+      { replace_lines: { start_anchor: anchor, end_anchor: anchor, new_text: newText } },
+    ]);
+
+    expect(result.content).toBe(origContent);
+    expect(result.noopEdits).toEqual([
+      {
+        editIndex: 0,
+        loc: anchor,
+        currentContent: "const summary = alpha + beta + gamma;",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
Fix a longstanding `replace_lines` bug where explicit blank paragraph separators in `new_text` could be collapsed back into the old indented line.

Before this change, `restoreOldWrappedLines` treated any multi-line span whose whitespace-stripped text matched a single old line as soft-wrap noise. That was wrong for spans containing intentional blank lines, so edits like:

```text
""
"Previously, the system did X."
```

could be rewritten to:

```text
"    Previously, the system did X."
```

which both removed the blank paragraph break and reintroduced the old indentation.

## Root cause
`src/hashline.ts::restoreOldWrappedLines(oldLines: string[], newLines: string[])` canonicalized candidate spans with:

- `newLines.slice(start, start + len).join("")`
- `stripAllWhitespace(...)`

Because blank lines contribute nothing to that canonical form, a real paragraph break could collide with the canonical text of an old single line and be collapsed as if it were only wrapping.

## What changed
- Skip wrapped-line restoration candidates that contain an explicit blank line.
- Keep the existing wrapped-line restoration behavior for true soft-wrap cases with no blank lines.
- Expand regression coverage for:
  - minimal blank-line paragraph preservation
  - no leading-whitespace theft from the replaced line
  - multi-paragraph `new_text` with shared paragraph text
  - mixed batches where another edit succeeds
  - true soft-wrap non-regression

## Files changed
- `src/hashline.ts`
- `tests/repro-125-replace-lines-blank-collapse.test.ts`

## Verification
### Focused regression suite
- `npx vitest run tests/repro-125-replace-lines-blank-collapse.test.ts`
- Result: `5 passed`

### Full suite
- `npm test`
- Result: `217/217` test files passed, `1069/1069` tests passed

### Runtime repro
Re-ran the original symptom directly through `applyHashlineEdits(...)`.

Observed after the fix:
- minimal case preserves the blank separator
- mixed batch no longer silently normalizes the blank-line edit away

## Risk / compatibility
The change is intentionally narrow: it only excludes candidate spans containing blank lines from the wrapped-line restoration heuristic. Non-blank soft-wrap restoration remains covered by regression tests.

Resolves #125
