### PR TITLE
feat: Phase 0 context-hygiene foundation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,14 @@ import { registerFindTool } from "./src/find.js";
 import { filterBashOutput } from "./src/rtk/bash-filter.js";
 import { stripAnsi } from "./src/rtk/ansi.js";
 import {
+  buildCommandResource,
+  buildContextHygieneMetadata,
+  getContextHygieneTracker,
+  registerContextHygieneDebugTool,
+  resetContextHygieneTracker,
+  type ContextHygieneMetadata,
+} from "./src/context-hygiene.js";
+import {
   consumeDoomLoopWarning,
   createDoomLoopState,
   formatDoomLoopMessage,
@@ -19,12 +27,48 @@ import {
 function isBashToolResult(event: unknown): event is {
   toolName: string;
   toolCallId: string;
-  input: { command?: string };
+  input?: unknown;
   content: Array<{ type: string; text?: string }>;
   isError?: boolean;
   details?: unknown;
 } {
   return !!event && typeof event === "object" && (event as { toolName?: unknown }).toolName === "bash";
+}
+
+function isContextHygieneResource(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const resource = value as { kind?: unknown; key?: unknown };
+  return (
+    (resource.kind === "file" || resource.kind === "symbol" || resource.kind === "command") &&
+    typeof resource.key === "string"
+  );
+}
+
+function isContextHygieneMetadata(value: unknown): value is ContextHygieneMetadata {
+  if (!value || typeof value !== "object") return false;
+  const metadata = value as Partial<ContextHygieneMetadata>;
+  return (
+    metadata.schemaVersion === 1 &&
+    typeof metadata.tool === "string" &&
+    (metadata.classification === "read-context" ||
+      metadata.classification === "search-context" ||
+      metadata.classification === "command-output" ||
+      metadata.classification === "mutation") &&
+    Array.isArray(metadata.resources) &&
+    metadata.resources.every(isContextHygieneResource)
+  );
+}
+
+function contextHygieneFromDetails(details: unknown): ContextHygieneMetadata | undefined {
+  if (!details || typeof details !== "object") return undefined;
+  const metadata = (details as { contextHygiene?: unknown }).contextHygiene;
+  return isContextHygieneMetadata(metadata) ? metadata : undefined;
+}
+
+function recordContextHygiene(metadata: ContextHygieneMetadata, toolCallId: unknown): void {
+  getContextHygieneTracker().record(metadata, {
+    resultId: typeof toolCallId === "string" ? toolCallId : undefined,
+  });
 }
 
 export {
@@ -69,6 +113,7 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
   const readTurns = new Map<string, number>();
   let currentTurn = 0;
   const doomLoopState = createDoomLoopState();
+  resetContextHygieneTracker();
   const noteRead = (absolutePath: string) => {
     currentTurn += 1;
     readTurns.set(absolutePath, currentTurn);
@@ -88,6 +133,7 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
   const writeTool = registerWriteTool(pi, { onFileAnchored: noteRead });
   const lsTool = registerLsTool(pi);
   const findTool = registerFindTool(pi);
+  const contextHygieneDebugTool = registerContextHygieneDebugTool(pi);
   const toolExecutors = {
     read: readTool,
     edit: editTool,
@@ -97,6 +143,7 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
     ls: lsTool,
     find: findTool,
     ...(nuTool ? { nu: nuTool } : {}),
+    ...(contextHygieneDebugTool ? { context_hygiene_report: contextHygieneDebugTool } : {}),
   };
 
   (globalThis as any).__hashlineToolExecutors = toolExecutors;
@@ -115,6 +162,8 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
   pi.on("tool_result", (event: any) => {
     const doomLoop = consumeDoomLoopWarning(doomLoopState, event.toolCallId);
     if (!isBashToolResult(event)) {
+      const contextHygiene = contextHygieneFromDetails(event.details);
+      if (contextHygiene) recordContextHygiene(contextHygiene, event.toolCallId);
       if (!doomLoop || !Array.isArray(event.content)) {
         return undefined;
       }
@@ -147,7 +196,16 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
           .join("\n")
       : "";
 
-    const command = (event.input as { command?: string }).command ?? "";
+    const command =
+      event.input && typeof event.input === "object" && typeof (event.input as { command?: unknown }).command === "string"
+        ? (event.input as { command: string }).command
+        : "";
+    const contextHygiene = buildContextHygieneMetadata({
+      tool: "bash",
+      classification: "command-output",
+      resources: command ? [buildCommandResource(command)] : [],
+    });
+    recordContextHygiene(contextHygiene, event.toolCallId);
     const applyWarning = (body: string): string => {
       if (!doomLoop) return body;
       const prefix = `${formatDoomLoopMessage(doomLoop)}\n\n---\n`;
@@ -157,7 +215,9 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
       const stripped = stripAnsi(originalText);
       const text = applyWarning(stripped);
       if (text === originalText) return undefined;
-      return { content: [{ type: "text" as const, text }] };
+      const existingDetails =
+        event.details && typeof event.details === "object" ? (event.details as Record<string, unknown>) : {};
+      return { content: [{ type: "text" as const, text }], details: { ...existingDetails, contextHygiene } };
     }
     const { output, savedChars, info } = filterBashOutput(command, originalText);
     if (process.env.PI_RTK_SAVINGS === "1") {
@@ -169,7 +229,7 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
       event.details && typeof event.details === "object" ? (event.details as Record<string, unknown>) : {};
     return {
       content: [{ type: "text" as const, text: applyWarning(body) }],
-      details: { ...existingDetails, compressionInfo: info }
+      details: { ...existingDetails, compressionInfo: info, contextHygiene },
     };
   });
 }

--- a/src/context-hygiene.ts
+++ b/src/context-hygiene.ts
@@ -1,0 +1,466 @@
+/**
+ * Phase 0 context-hygiene metadata.
+ *
+ * This module defines a small, additive metadata contract that tool outputs can
+ * attach beside existing details such as `ptcValue`. The metadata is intended
+ * for deterministic telemetry and future stale/retirement reasoning only; it
+ * must not require parsing rendered display text and it must not change current
+ * tool behavior.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+
+export const CONTEXT_HYGIENE_SCHEMA_VERSION = 1 as const;
+export const DEFAULT_CONTEXT_HYGIENE_MAX_EVENTS = 1000;
+
+export type ContextHygieneClassification =
+  | "read-context"
+  | "search-context"
+  | "command-output"
+  | "mutation";
+
+export type ContextHygieneResourceKind = "file" | "symbol" | "command";
+
+export type ContextHygieneCommandKind =
+  | "test"
+  | "typecheck"
+  | "build"
+  | "lint"
+  | "vcs"
+  | "install"
+  | "other";
+
+export interface ContextHygieneFileResource {
+  kind: "file";
+  key: string;
+  path: string;
+}
+
+export interface ContextHygieneSymbolResource {
+  kind: "symbol";
+  key: string;
+  path: string;
+  symbolName: string;
+  symbolKind?: string;
+}
+
+export interface ContextHygieneCommandResource {
+  kind: "command";
+  key: string;
+  command: string;
+  commandKind: ContextHygieneCommandKind;
+}
+
+export type ContextHygieneResource =
+  | ContextHygieneFileResource
+  | ContextHygieneSymbolResource
+  | ContextHygieneCommandResource;
+
+export interface ContextHygieneMetadata {
+  schemaVersion: typeof CONTEXT_HYGIENE_SCHEMA_VERSION;
+  tool: string;
+  classification: ContextHygieneClassification;
+  resources: ContextHygieneResource[];
+}
+
+export interface BuildContextHygieneMetadataInput {
+  tool: string;
+  classification: ContextHygieneClassification;
+  resources?: readonly (ContextHygieneResource | null | undefined)[];
+}
+
+export function normalizePathForContextHygiene(path: string): string {
+  if (path === "") return "";
+
+  const slashPath = path.replace(/\\+/g, "/");
+  const isAbsolute = slashPath.startsWith("/");
+  const parts: string[] = [];
+
+  for (const part of slashPath.split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      if (parts.length > 0 && parts[parts.length - 1] !== "..") {
+        parts.pop();
+      } else if (!isAbsolute) {
+        parts.push(part);
+      }
+      continue;
+    }
+    parts.push(part);
+  }
+
+  const normalized = `${isAbsolute ? "/" : ""}${parts.join("/")}`;
+  return normalized || (isAbsolute ? "/" : ".");
+}
+
+export function buildFileResource(path: string): ContextHygieneFileResource {
+  const normalizedPath = normalizePathForContextHygiene(path);
+  return {
+    kind: "file",
+    key: `file:${normalizedPath}`,
+    path: normalizedPath,
+  };
+}
+
+export function buildSymbolResource(
+  path: string,
+  symbolName: string,
+  symbolKind?: string,
+): ContextHygieneSymbolResource {
+  const normalizedPath = normalizePathForContextHygiene(path);
+  const normalizedKind = symbolKind?.trim();
+  const keyPayload = JSON.stringify([normalizedPath, normalizedKind ?? "", symbolName]);
+  const resource: ContextHygieneSymbolResource = {
+    kind: "symbol",
+    key: `symbol:${keyPayload}`,
+    path: normalizedPath,
+    symbolName,
+  };
+  if (normalizedKind) resource.symbolKind = normalizedKind;
+  return resource;
+}
+
+export function normalizeCommandForContextHygiene(command: string): string {
+  let normalized = "";
+  let quote: "'" | '"' | null = null;
+  let pendingWhitespace = false;
+
+  for (const char of command.trim()) {
+    if (quote) {
+      normalized += char;
+      if (char === quote) quote = null;
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      if (pendingWhitespace && normalized.length > 0) {
+        normalized += " ";
+        pendingWhitespace = false;
+      }
+      quote = char;
+      normalized += char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      pendingWhitespace = normalized.length > 0;
+      continue;
+    }
+
+    if (pendingWhitespace) {
+      normalized += " ";
+      pendingWhitespace = false;
+    }
+    normalized += char;
+  }
+
+  return normalized;
+}
+
+export function classifyCommandForContextHygiene(command: string): ContextHygieneCommandKind {
+  const normalized = normalizeCommandForContextHygiene(command);
+
+  if (/^(git|gh)\b/.test(normalized)) return "vcs";
+  if (/\b(install|ci|add)\b/.test(normalized) && /^(npm|pnpm|yarn|bun)\b/.test(normalized)) return "install";
+  if (/\b(typecheck|tsc\b)/.test(normalized)) return "typecheck";
+  if (/\b(test|vitest|jest|mocha|tap)\b/.test(normalized)) return "test";
+  if (/\b(lint|eslint|biome|prettier)\b/.test(normalized)) return "lint";
+  if (/\b(build|tsup|vite build|rollup|webpack|make)\b/.test(normalized)) return "build";
+
+  return "other";
+}
+
+export function buildCommandResource(command: string): ContextHygieneCommandResource {
+  const normalizedCommand = normalizeCommandForContextHygiene(command);
+  const commandKind = classifyCommandForContextHygiene(normalizedCommand);
+  return {
+    kind: "command",
+    key: `command:${commandKind}:${normalizedCommand}`,
+    command: normalizedCommand,
+    commandKind,
+  };
+}
+
+export function buildContextHygieneMetadata(
+  input: BuildContextHygieneMetadataInput,
+): ContextHygieneMetadata {
+  const resources: ContextHygieneResource[] = [];
+  const seenResourceKeys = new Set<string>();
+
+  for (const resource of input.resources ?? []) {
+    if (!resource || seenResourceKeys.has(resource.key)) continue;
+    seenResourceKeys.add(resource.key);
+    resources.push({ ...resource } as ContextHygieneResource);
+  }
+
+  return {
+    schemaVersion: CONTEXT_HYGIENE_SCHEMA_VERSION,
+    tool: input.tool,
+    classification: input.classification,
+    resources,
+  };
+}
+
+export interface ContextHygieneRecordOptions {
+  resultId?: string;
+}
+
+export interface ContextHygieneEvent {
+  id: number;
+  resultId?: string;
+  tool: string;
+  classification: ContextHygieneClassification;
+  resources: ContextHygieneResource[];
+}
+
+export interface ContextHygieneReuseReportEntry {
+  resourceKey: string;
+  count: number;
+  eventIds: number[];
+  resultIds: string[];
+}
+
+export interface ContextHygieneMutationAfterReadReportEntry {
+  resourceKey: string;
+  readEventIds: number[];
+  mutationEventId: number;
+}
+
+export interface ContextHygieneStaleCandidateReportEntry {
+  resourceKey: string;
+  staleEventIds: number[];
+  mutationEventId: number;
+  reason: "mutation-after-read";
+}
+
+export interface ContextHygieneRetirementCandidateReportEntry {
+  resourceKey: string;
+  eventIds: number[];
+  supersededByEventId: number;
+  reason: "command-rerun";
+}
+
+export interface ContextHygieneReport {
+  eventCount: number;
+  resourceCount: number;
+  readReuse: ContextHygieneReuseReportEntry[];
+  commandReruns: ContextHygieneReuseReportEntry[];
+  mutationAfterRead: ContextHygieneMutationAfterReadReportEntry[];
+  staleCandidates: ContextHygieneStaleCandidateReportEntry[];
+  retirementCandidates: ContextHygieneRetirementCandidateReportEntry[];
+  churn: {
+    byClassification: Record<ContextHygieneClassification, number>;
+    byTool: Record<string, number>;
+    uniqueResourcesSeen: number;
+  };
+}
+
+export interface ContextHygieneTracker {
+  record(metadata: ContextHygieneMetadata, options?: ContextHygieneRecordOptions): ContextHygieneEvent;
+  generateReport(): ContextHygieneReport;
+}
+
+export interface CreateContextHygieneTrackerOptions {
+  maxEvents?: number;
+}
+
+export interface RegisterContextHygieneDebugToolOptions {
+  tracker?: ContextHygieneTracker;
+  enabled?: boolean;
+}
+
+const CONTEXT_HYGIENE_DEBUG_TOOL_PTC = {
+  callable: true,
+  enabled: true,
+  policy: "read-only" as const,
+  readOnly: true,
+  pythonName: "context_hygiene_report",
+  defaultExposure: "safe-by-default" as const,
+};
+
+export function isContextHygieneDebugEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.PI_CONTEXT_HYGIENE_DEBUG === "1";
+}
+
+export function registerContextHygieneDebugTool(
+  pi: ExtensionAPI,
+  options: RegisterContextHygieneDebugToolOptions = {},
+) {
+  const enabled = options.enabled ?? isContextHygieneDebugEnabled();
+  if (!enabled) return undefined;
+
+  const tracker = options.tracker ?? getContextHygieneTracker();
+  const tool = {
+    name: "context_hygiene_report",
+    label: "Context Hygiene Report",
+    description:
+      "Debug-only read-only tool. Returns Phase 0 context-hygiene telemetry, stale candidates, and retirement candidates without mutating tracker state.",
+    parameters: Type.Object({}),
+    ptc: CONTEXT_HYGIENE_DEBUG_TOOL_PTC,
+    async execute() {
+      const report = tracker.generateReport();
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(report, null, 2) }],
+        details: { ptcValue: report },
+      };
+    },
+  } satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof CONTEXT_HYGIENE_DEBUG_TOOL_PTC };
+
+  pi.registerTool(tool);
+  return tool;
+}
+
+function resultIdsForEvents(events: ContextHygieneEvent[]): string[] {
+  return events.map((event) => event.resultId).filter((resultId): resultId is string => Boolean(resultId));
+}
+
+function compareStable(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function sortResourceKeys(keys: Iterable<string>): string[] {
+  return [...keys].sort(compareStable);
+}
+
+function createEmptyClassificationCounts(): Record<ContextHygieneClassification, number> {
+  return {
+    "command-output": 0,
+    mutation: 0,
+    "read-context": 0,
+    "search-context": 0,
+  };
+}
+
+class DefaultContextHygieneTracker implements ContextHygieneTracker {
+  private readonly events: ContextHygieneEvent[] = [];
+  private readonly maxEvents: number;
+  private nextEventId = 1;
+
+  constructor(options: CreateContextHygieneTrackerOptions = {}) {
+    this.maxEvents = Math.max(1, Math.floor(options.maxEvents ?? DEFAULT_CONTEXT_HYGIENE_MAX_EVENTS));
+  }
+
+  record(metadata: ContextHygieneMetadata, options: ContextHygieneRecordOptions = {}): ContextHygieneEvent {
+    const event: ContextHygieneEvent = {
+      id: this.nextEventId++,
+      tool: metadata.tool,
+      classification: metadata.classification,
+      resources: metadata.resources.map((resource) => ({ ...resource } as ContextHygieneResource)),
+    };
+    if (options.resultId) event.resultId = options.resultId;
+    this.events.push(event);
+    if (this.events.length > this.maxEvents) this.events.splice(0, this.events.length - this.maxEvents);
+    return { ...event, resources: event.resources.map((resource) => ({ ...resource } as ContextHygieneResource)) };
+  }
+
+  generateReport(): ContextHygieneReport {
+    const eventsByResource = new Map<string, ContextHygieneEvent[]>();
+    const readEventsByResource = new Map<string, ContextHygieneEvent[]>();
+    const commandEventsByResource = new Map<string, ContextHygieneEvent[]>();
+    const mutationEventsByResource = new Map<string, ContextHygieneEvent[]>();
+    const byClassification = createEmptyClassificationCounts();
+    const byTool: Record<string, number> = {};
+
+    for (const event of this.events) {
+      byClassification[event.classification] += 1;
+      byTool[event.tool] = (byTool[event.tool] ?? 0) + 1;
+
+      for (const resource of event.resources) {
+        const bucket = eventsByResource.get(resource.key) ?? [];
+        bucket.push(event);
+        eventsByResource.set(resource.key, bucket);
+
+        if (event.classification === "read-context" || event.classification === "search-context") {
+          const readBucket = readEventsByResource.get(resource.key) ?? [];
+          readBucket.push(event);
+          readEventsByResource.set(resource.key, readBucket);
+        }
+        if (event.classification === "command-output" && resource.kind === "command") {
+          const commandBucket = commandEventsByResource.get(resource.key) ?? [];
+          commandBucket.push(event);
+          commandEventsByResource.set(resource.key, commandBucket);
+        }
+        if (event.classification === "mutation") {
+          const mutationBucket = mutationEventsByResource.get(resource.key) ?? [];
+          mutationBucket.push(event);
+          mutationEventsByResource.set(resource.key, mutationBucket);
+        }
+      }
+    }
+
+    const readReuse = sortResourceKeys(readEventsByResource.keys()).flatMap((resourceKey) => {
+      const events = readEventsByResource.get(resourceKey) ?? [];
+      if (events.length < 2) return [];
+      return [{ resourceKey, count: events.length, eventIds: events.map((event) => event.id), resultIds: resultIdsForEvents(events) }];
+    });
+
+    const commandReruns = sortResourceKeys(commandEventsByResource.keys()).flatMap((resourceKey) => {
+      const events = commandEventsByResource.get(resourceKey) ?? [];
+      if (events.length < 2) return [];
+      return [{ resourceKey, count: events.length, eventIds: events.map((event) => event.id), resultIds: resultIdsForEvents(events) }];
+    });
+
+    const mutationAfterRead: ContextHygieneMutationAfterReadReportEntry[] = [];
+    const staleCandidates: ContextHygieneStaleCandidateReportEntry[] = [];
+    const retirementCandidates: ContextHygieneRetirementCandidateReportEntry[] = [];
+
+    for (const resourceKey of sortResourceKeys(mutationEventsByResource.keys())) {
+      const reads = readEventsByResource.get(resourceKey) ?? [];
+      const mutations = mutationEventsByResource.get(resourceKey) ?? [];
+      for (const mutation of mutations) {
+        const priorReadIds = reads.filter((read) => read.id < mutation.id).map((read) => read.id);
+        if (priorReadIds.length === 0) continue;
+        mutationAfterRead.push({ resourceKey, readEventIds: priorReadIds, mutationEventId: mutation.id });
+        staleCandidates.push({
+          resourceKey,
+          staleEventIds: priorReadIds,
+          mutationEventId: mutation.id,
+          reason: "mutation-after-read",
+        });
+      }
+    }
+
+    for (const resourceKey of sortResourceKeys(commandEventsByResource.keys())) {
+      const commands = commandEventsByResource.get(resourceKey) ?? [];
+      for (let index = 1; index < commands.length; index += 1) {
+        retirementCandidates.push({
+          resourceKey,
+          eventIds: commands.slice(0, index).map((event) => event.id),
+          supersededByEventId: commands[index].id,
+          reason: "command-rerun",
+        });
+      }
+    }
+
+    return {
+      eventCount: this.events.length,
+      resourceCount: eventsByResource.size,
+      readReuse,
+      commandReruns,
+      mutationAfterRead,
+      staleCandidates,
+      retirementCandidates,
+      churn: {
+        byClassification,
+        byTool: Object.fromEntries(Object.entries(byTool).sort(([left], [right]) => compareStable(left, right))),
+        uniqueResourcesSeen: eventsByResource.size,
+      },
+    };
+  }
+}
+
+export function createContextHygieneTracker(options: CreateContextHygieneTrackerOptions = {}): ContextHygieneTracker {
+  return new DefaultContextHygieneTracker(options);
+}
+
+let globalContextHygieneTracker = createContextHygieneTracker();
+
+export function resetContextHygieneTracker(options: CreateContextHygieneTrackerOptions = {}): ContextHygieneTracker {
+  globalContextHygieneTracker = createContextHygieneTracker(options);
+  return globalContextHygieneTracker;
+}
+
+export function getContextHygieneTracker(): ContextHygieneTracker {
+  return globalContextHygieneTracker;
+}

--- a/src/edit-output.ts
+++ b/src/edit-output.ts
@@ -1,5 +1,6 @@
 import { countEditTypes, parseDiffStats } from "./edit-render-helpers.js";
 import { buildPtcEditResult, type SemanticSummary } from "./ptc-value.js";
+import { buildContextHygieneMetadata, buildFileResource, type ContextHygieneMetadata } from "./context-hygiene.js";
 export interface BuildEditOutputInput {
   path: string;
   displayPath: string;
@@ -13,6 +14,7 @@ export interface BuildEditOutputInput {
 export interface EditOutputResult {
   text: string;
   ptcValue: ReturnType<typeof buildPtcEditResult>;
+  contextHygiene: ContextHygieneMetadata;
 }
 function getVisibleDiffStats(diff: string): { added: number; removed: number } {
   const stats = parseDiffStats(diff);
@@ -79,6 +81,11 @@ export function buildEditOutput(input: BuildEditOutputInput): EditOutputResult {
       warnings: input.warnings,
       noopEdits: input.noopEdits,
       ...(input.semanticSummary ? { semanticSummary: input.semanticSummary } : {}),
+    }),
+    contextHygiene: buildContextHygieneMetadata({
+      tool: "edit",
+      classification: "mutation",
+      resources: [buildFileResource(input.path)],
     }),
   };
 }

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -499,6 +499,7 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 					diff: diffResult.diff,
 					firstChangedLine: anchorResult.firstChangedLine ?? diffResult.firstChangedLine,
 					ptcValue: builtOutput.ptcValue,
+					contextHygiene: builtOutput.contextHygiene,
 				} as EditToolDetails & {
 					ptcValue: {
 						tool: string;

--- a/src/grep-output.ts
+++ b/src/grep-output.ts
@@ -5,6 +5,13 @@ import {
   formatSize,
   truncateHead,
 } from "@mariozechner/pi-coding-agent";
+import {
+  buildContextHygieneMetadata,
+  buildFileResource,
+  buildSymbolResource,
+  type ContextHygieneMetadata,
+  type ContextHygieneResource,
+} from "./context-hygiene.js";
 
 export interface GrepOutputRecord extends PtcLine {
   path: string;
@@ -79,6 +86,7 @@ export interface GrepOutputResult {
       warnings: GrepScopeWarning[];
     };
   };
+  contextHygiene: ContextHygieneMetadata;
 }
 
 function renderEntry(displayPath: string, entry: GrepOutputEntry): string {
@@ -163,8 +171,24 @@ export function buildGrepOutput(input: BuildGrepOutputInput): GrepOutputResult {
   if (!input.summary && input.scopeMode === "symbol") {
     ptcValue.scopes = buildScopeMetadata(input.groups, input.scopeWarnings ?? []);
   }
+
+  const contextHygieneResources: ContextHygieneResource[] = [];
+  for (const record of input.records) {
+    contextHygieneResources.push(buildFileResource(record.path));
+  }
+  for (const group of input.groups) {
+    if (!group.scope) continue;
+    contextHygieneResources.push(buildFileResource(group.absolutePath));
+    contextHygieneResources.push(buildSymbolResource(group.absolutePath, group.scope.symbol.name, group.scope.symbol.kind));
+  }
+  const contextHygiene = buildContextHygieneMetadata({
+    tool: "grep",
+    classification: "search-context",
+    resources: contextHygieneResources,
+  });
   return {
     text,
     ptcValue,
+    contextHygiene,
   };
 }

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -682,6 +682,7 @@ if (p.scope === "symbol" && !summary) {
 				details: {
 					...compactDetails,
 					ptcValue: builtOutput.ptcValue,
+					contextHygiene: builtOutput.contextHygiene,
 				},
 			};
 		},

--- a/src/read-output.ts
+++ b/src/read-output.ts
@@ -5,6 +5,13 @@ import {
   truncateHead,
 } from "@mariozechner/pi-coding-agent";
 import { buildPtcLines, renderPtcLines, type PtcLine, type PtcWarning } from "./ptc-value.js";
+import {
+  buildContextHygieneMetadata,
+  buildFileResource,
+  buildSymbolResource,
+  type ContextHygieneMetadata,
+  type ContextHygieneResource,
+} from "./context-hygiene.js";
 
 export interface ReadSymbolMetadata {
   query: string;
@@ -91,6 +98,7 @@ export interface ReadOutputResult {
       warnings: PtcWarning[];
     };
   };
+  contextHygiene: ContextHygieneMetadata;
 }
 
 export function buildReadOutput(input: ReadOutputInput): ReadOutputResult {
@@ -175,9 +183,25 @@ export function buildReadOutput(input: ReadOutputInput): ReadOutputResult {
     };
   }
 
+  const contextHygieneResources: ContextHygieneResource[] = [buildFileResource(input.path)];
+  if (input.symbol) {
+    contextHygieneResources.push(buildSymbolResource(input.path, input.symbol.name, input.symbol.kind));
+  }
+  if (input.bundle?.applied) {
+    for (const support of input.bundle.localSupport) {
+      contextHygieneResources.push(buildSymbolResource(input.path, support.symbol.name, support.symbol.kind));
+    }
+  }
+  const contextHygiene = buildContextHygieneMetadata({
+    tool: "read",
+    classification: "read-context",
+    resources: contextHygieneResources,
+  });
+
   return {
     text,
     lines,
     ptcValue,
+    contextHygiene,
   };
 }

--- a/src/read.ts
+++ b/src/read.ts
@@ -580,6 +580,7 @@ return succeed({
 	details: {
 		truncation: truncation.truncated ? truncation : undefined,
 		ptcValue: readOutput.ptcValue,
+		contextHygiene: readOutput.contextHygiene,
 	},
 });
 		},

--- a/src/sg-output.ts
+++ b/src/sg-output.ts
@@ -1,10 +1,18 @@
 import type { PtcLine, PtcRange } from "./ptc-value.js";
+import {
+  buildContextHygieneMetadata,
+  buildFileResource,
+  buildSymbolResource,
+  type ContextHygieneMetadata,
+  type ContextHygieneResource,
+} from "./context-hygiene.js";
 
 export interface SgOutputFile {
   displayPath: string;
   path: string;
   ranges: PtcRange[];
   lines: PtcLine[];
+  symbols?: Array<{ name: string; kind?: string }>;
 }
 
 export interface BuildSgOutputInput {
@@ -22,6 +30,7 @@ export interface SgOutputResult {
       lines: PtcLine[];
     }>;
   };
+  contextHygiene: ContextHygieneMetadata;
 }
 
 export function buildSgOutput(input: BuildSgOutputInput): SgOutputResult {
@@ -32,6 +41,11 @@ export function buildSgOutput(input: BuildSgOutputInput): SgOutputResult {
         tool: "ast_search",
         files: [],
       },
+      contextHygiene: buildContextHygieneMetadata({
+        tool: "ast_search",
+        classification: "search-context",
+        resources: [],
+      }),
     };
   }
 
@@ -40,6 +54,14 @@ export function buildSgOutput(input: BuildSgOutputInput): SgOutputResult {
     blocks.push(`--- ${file.displayPath} ---`);
     for (const line of file.lines) {
       blocks.push(`>>${line.anchor}|${line.display}`);
+    }
+  }
+
+  const contextHygieneResources: ContextHygieneResource[] = [];
+  for (const file of input.files) {
+    contextHygieneResources.push(buildFileResource(file.path));
+    for (const symbol of file.symbols ?? []) {
+      contextHygieneResources.push(buildSymbolResource(file.path, symbol.name, symbol.kind));
     }
   }
 
@@ -53,5 +75,10 @@ export function buildSgOutput(input: BuildSgOutputInput): SgOutputResult {
         lines: file.lines.map((line) => ({ ...line })),
       })),
     },
+    contextHygiene: buildContextHygieneMetadata({
+      tool: "ast_search",
+      classification: "search-context",
+      resources: contextHygieneResources,
+    }),
   };
 }

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -9,9 +9,12 @@ import { normalizeToLF, stripBom } from "./edit-diff.js";
 import { ensureHashInit } from "./hashline.js";
 import { buildPtcError, buildPtcLine } from "./ptc-value.js";
 import { resolveToCwd } from "./path-utils.js";
+import type { FileSymbol } from "./readmap/types.js";
 import { buildSgOutput } from "./sg-output.js";
+import { isContextHygieneDebugEnabled } from "./context-hygiene.js";
 
 type SgParams = { pattern: string; lang?: string; path?: string };
+const CONTEXT_HYGIENE_SG_SYMBOL_FILE_CAP = 20;
 
 type SgMatch = {
   file: string;
@@ -21,6 +24,11 @@ type SgMatch = {
 export interface SgRange {
   startLine: number;
   endLine: number;
+}
+
+export interface SgEnclosingSymbol {
+  name: string;
+  kind: string;
 }
 
 export function mergeRanges(ranges: SgRange[]): SgRange[] {
@@ -42,6 +50,39 @@ export function mergeRanges(ranges: SgRange[]): SgRange[] {
   }
 
   return merged;
+}
+
+function collectFileSymbols(symbols: FileSymbol[]): FileSymbol[] {
+  return symbols.flatMap((symbol) => [symbol, ...collectFileSymbols(symbol.children ?? [])]);
+}
+
+export async function findEnclosingSgSymbols(absPath: string, ranges: SgRange[]): Promise<SgEnclosingSymbol[]> {
+  let fileMap: Awaited<ReturnType<typeof import("./map-cache.js").getOrGenerateMap>>;
+  try {
+    const { getOrGenerateMap } = await import("./map-cache.js");
+    fileMap = await getOrGenerateMap(absPath);
+  } catch {
+    return [];
+  }
+  if (!fileMap) return [];
+
+  const allSymbols = collectFileSymbols(fileMap.symbols);
+  const found: SgEnclosingSymbol[] = [];
+  const seenKeys = new Set<string>();
+
+  for (const range of ranges) {
+    const enclosing = allSymbols
+      .filter((symbol) => symbol.startLine <= range.startLine && symbol.endLine >= range.endLine)
+      .sort((a, b) => (a.endLine - a.startLine) - (b.endLine - b.startLine) || a.startLine - b.startLine)[0];
+    if (!enclosing) continue;
+
+    const key = `${enclosing.kind}:${enclosing.name}`;
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+    found.push({ name: enclosing.name, kind: enclosing.kind });
+  }
+
+  return found;
 }
 
 const SG_PROMPT = readFileSync(new URL("../prompts/sg.md", import.meta.url), "utf-8").trim();
@@ -177,6 +218,7 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
             content: [{ type: "text", text: emptyOutput.text }],
             details: {
               ptcValue: emptyOutput.ptcValue,
+              contextHygiene: emptyOutput.contextHygiene,
             },
           };
         }
@@ -217,7 +259,9 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
           path: string;
           ranges: SgRange[];
           lines: ReturnType<typeof buildPtcLine>[];
+          symbols?: SgEnclosingSymbol[];
         }> = [];
+        const enrichContextHygieneSymbols = isContextHygieneDebugEnabled() && grouped.size <= CONTEXT_HYGIENE_SG_SYMBOL_FILE_CAP;
         for (const [display, { abs, matches: fileMatches }] of grouped) {
           const lines = await getFileLines(abs);
           if (!lines) continue;
@@ -232,6 +276,7 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
             path: abs,
             ranges: mergedRanges.map((range) => ({ ...range })),
             lines: [] as ReturnType<typeof buildPtcLine>[],
+            symbols: [] as SgEnclosingSymbol[],
           };
           for (const range of mergedRanges) {
             for (let ln = range.startLine; ln <= range.endLine; ln++) {
@@ -241,6 +286,7 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
               ptcFile.lines.push(built);
             }
           }
+          ptcFile.symbols = enrichContextHygieneSymbols ? await findEnclosingSgSymbols(abs, ranges) : [];
           ptcFiles.push(ptcFile);
         }
 
@@ -250,6 +296,7 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
             content: [{ type: "text", text: emptyOutput.text }],
             details: {
               ptcValue: emptyOutput.ptcValue,
+              contextHygiene: emptyOutput.contextHygiene,
             },
           };
         }
@@ -267,6 +314,7 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
           content: [{ type: "text", text: builtOutput.text }],
           details: {
             ptcValue: builtOutput.ptcValue,
+            contextHygiene: builtOutput.contextHygiene,
           },
         };
       } catch (err: any) {

--- a/src/write.ts
+++ b/src/write.ts
@@ -9,6 +9,7 @@ import { buildPtcError, buildPtcLine, buildPtcWarning, type PtcLine, type PtcWar
 import { looksLikeBinary } from "./binary-detect.js";
 import { getOrGenerateMap } from "./map-cache.js";
 import { formatFileMapWithBudget } from "./readmap/formatter.js";
+import { buildContextHygieneMetadata, buildFileResource, type ContextHygieneMetadata } from "./context-hygiene.js";
 
 const MAX_LINES = 2000;
 const MAX_BYTES = 50 * 1024;
@@ -25,6 +26,7 @@ export interface WriteResult {
     warnings: PtcWarning[];
     map?: { appended: boolean };
   };
+  contextHygiene: ContextHygieneMetadata;
 }
 
 export interface WriteToolOptions {
@@ -110,6 +112,11 @@ export async function executeWrite(opts: {
 
   const warnings: string[] = [];
   const ptcWarnings: PtcWarning[] = [];
+  const contextHygiene = buildContextHygieneMetadata({
+    tool: "write",
+    classification: "mutation",
+    resources: [buildFileResource(filePath)],
+  });
 
   // Binary detection
   if (looksLikeBinary(Buffer.from(content, "utf-8"))) {
@@ -124,6 +131,7 @@ export async function executeWrite(opts: {
         lines: [],
         warnings: ptcWarnings,
       },
+      contextHygiene,
     };
   }
 
@@ -179,6 +187,7 @@ export async function executeWrite(opts: {
       warnings: ptcWarnings,
       ...(requestMap !== undefined ? { map: { appended: mapAppended } } : {}),
     },
+    contextHygiene,
   };
 }
 
@@ -192,7 +201,7 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
       content: Type.String({ description: "Content to write to the file" }),
       map: Type.Optional(Type.Boolean({ description: "Append structural map to output" })),
     }),
-    async execute(_toolCallId: string, params: { path: string; content: string; map?: boolean }, _signal: AbortSignal | undefined, _onUpdate: any, ctx: any) {
+    async execute(_toolCallId: string, params: { path: string; content: string; map?: boolean }, _signal: AbortSignal | undefined, _onUpdate: any, ctx: any): Promise<any> {
       const cwd = ctx?.cwd ?? process.cwd();
       const absolutePath = resolveToCwd(params.path, cwd);
       let result: WriteResult;
@@ -247,6 +256,7 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
               error: buildPtcError("binary-content", binaryWarning.message),
             },
             warnings: result.warnings,
+            contextHygiene: result.contextHygiene,
           },
         };
       }
@@ -256,6 +266,7 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
         details: {
           ptcValue: result.ptcValue,
           warnings: result.warnings,
+          contextHygiene: result.contextHygiene,
         },
       };
     },

--- a/tests/context-hygiene-bash.test.ts
+++ b/tests/context-hygiene-bash.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import init from "../index.js";
+import {
+  buildCommandResource,
+  buildContextHygieneMetadata,
+  buildFileResource,
+  getContextHygieneTracker,
+} from "../src/context-hygiene.js";
+
+function createHarness() {
+  const handlers: Record<string, Function> = {};
+
+  init(
+    {
+      registerTool() {},
+      on(event: string, handler: Function) {
+        handlers[event] = handler;
+      },
+      events: { emit() {}, on() {} },
+    } as any,
+  );
+
+  return handlers;
+}
+
+describe("bash contextHygiene metadata", () => {
+  it("attaches command-output metadata, records reruns, and preserves rendered output plus compressionInfo", async () => {
+    const handlers = createHarness();
+    const command = "npm test -- --context-hygiene-bash-task8";
+    const expectedContextHygiene = {
+      schemaVersion: 1,
+      tool: "bash",
+      classification: "command-output",
+      resources: [buildCommandResource(command)],
+    };
+
+    const first = await handlers.tool_result(
+      {
+        type: "tool_result" as const,
+        toolName: "bash",
+        toolCallId: "bash-hygiene-1",
+        input: { command },
+        content: [{ type: "text" as const, text: "\u001b[32mPASS\u001b[0m" }],
+        isError: false,
+        details: { existing: "kept" },
+      },
+      {},
+    );
+    const second = await handlers.tool_result(
+      {
+        type: "tool_result" as const,
+        toolName: "bash",
+        toolCallId: "bash-hygiene-2",
+        input: { command },
+        content: [{ type: "text" as const, text: "PASS" }],
+        isError: false,
+      },
+      {},
+    );
+
+    expect(first).toBeDefined();
+    expect(first.content).toEqual([{ type: "text", text: "PASS" }]);
+    expect(first.details).toMatchObject({
+      existing: "kept",
+      compressionInfo: { technique: "test-output" },
+    });
+    expect(first.details.contextHygiene).toEqual(expectedContextHygiene);
+    expect((first.details.ptcValue as any)?.contextHygiene).toBeUndefined();
+
+    expect(second.details.contextHygiene).toEqual(expectedContextHygiene);
+
+    const commandRerun = getContextHygieneTracker()
+      .generateReport()
+      .commandReruns.find((entry) => entry.resourceKey === buildCommandResource(command).key);
+
+    expect(commandRerun).toEqual({
+      resourceKey: "command:test:npm test -- --context-hygiene-bash-task8",
+      count: 2,
+      eventIds: expect.any(Array),
+      resultIds: ["bash-hygiene-1", "bash-hygiene-2"],
+    });
+    expect(commandRerun?.eventIds).toHaveLength(2);
+  });
+
+  it("records contextHygiene metadata from non-bash tool_result events without changing the event", async () => {
+    const handlers = createHarness();
+    const metadata = buildContextHygieneMetadata({
+      tool: "read",
+      classification: "read-context",
+      resources: [buildFileResource("tmp/context-hygiene-bash-non-bash.ts")],
+    });
+
+    const first = await handlers.tool_result(
+      {
+        type: "tool_result" as const,
+        toolName: "read",
+        toolCallId: "read-hygiene-1",
+        input: { path: "tmp/context-hygiene-bash-non-bash.ts" },
+        content: [{ type: "text" as const, text: "plain output" }],
+        isError: false,
+        details: { contextHygiene: metadata },
+      },
+      {},
+    );
+    const second = await handlers.tool_result(
+      {
+        type: "tool_result" as const,
+        toolName: "read",
+        toolCallId: "read-hygiene-2",
+        input: { path: "tmp/context-hygiene-bash-non-bash.ts" },
+        content: [{ type: "text" as const, text: "plain output" }],
+        isError: false,
+        details: { contextHygiene: metadata },
+      },
+      {},
+    );
+
+    expect(first).toBeUndefined();
+    expect(second).toBeUndefined();
+
+    const readReuse = getContextHygieneTracker()
+      .generateReport()
+      .readReuse.find((entry) => entry.resourceKey === "file:tmp/context-hygiene-bash-non-bash.ts");
+
+    expect(readReuse).toEqual({
+      resourceKey: "file:tmp/context-hygiene-bash-non-bash.ts",
+      count: 2,
+      eventIds: expect.any(Array),
+      resultIds: ["read-hygiene-1", "read-hygiene-2"],
+    });
+    expect(readReuse?.eventIds).toHaveLength(2);
+  });
+
+
+  it("handles bash tool_result events without input safely", async () => {
+    const handlers = createHarness();
+
+    expect(() => handlers.tool_result({
+      type: "tool_result" as const,
+      toolName: "bash",
+      toolCallId: "bash-missing-input",
+      content: [{ type: "text" as const, text: "plain output" }],
+      isError: false,
+    })).not.toThrow();
+
+    const result = handlers.tool_result({
+      type: "tool_result" as const,
+      toolName: "bash",
+      toolCallId: "bash-missing-input-2",
+      content: [{ type: "text" as const, text: "plain output" }],
+      isError: false,
+    });
+
+    expect(result).toMatchObject({
+      content: [{ type: "text", text: "plain output" }],
+      details: {
+        contextHygiene: {
+          schemaVersion: 1,
+          tool: "bash",
+          classification: "command-output",
+          resources: [],
+        },
+      },
+  });
+  });
+
+
+  it("ignores malformed non-bash contextHygiene metadata without polluting reports", async () => {
+    const handlers = createHarness();
+    const malformedMetadata = {
+      schemaVersion: 1,
+      tool: "read",
+      classification: "read-context",
+      resources: [null],
+    };
+
+    await handlers.tool_result({
+      type: "tool_result" as const,
+      toolName: "read",
+      toolCallId: "malformed-hygiene-1",
+      input: { path: "tmp/malformed.ts" },
+      content: [{ type: "text" as const, text: "plain output" }],
+      isError: false,
+      details: { contextHygiene: malformedMetadata },
+    });
+    await handlers.tool_result({
+      type: "tool_result" as const,
+      toolName: "read",
+      toolCallId: "malformed-hygiene-2",
+      input: { path: "tmp/malformed.ts" },
+      content: [{ type: "text" as const, text: "plain output" }],
+      isError: false,
+      details: { contextHygiene: malformedMetadata },
+    });
+
+    const report = getContextHygieneTracker().generateReport();
+    expect(report.readReuse.some((entry) => (entry as any).resourceKey === undefined)).toBe(false);
+  });
+});

--- a/tests/context-hygiene-debug-tool.test.ts
+++ b/tests/context-hygiene-debug-tool.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it } from "vitest";
+import init from "../index.js";
+import {
+  buildCommandResource,
+  buildContextHygieneMetadata,
+  buildFileResource,
+  getContextHygieneTracker,
+} from "../src/context-hygiene.js";
+
+function withDebugEnv<T>(value: string | undefined, fn: () => T): T {
+  const previous = process.env.PI_CONTEXT_HYGIENE_DEBUG;
+  if (value === undefined) delete process.env.PI_CONTEXT_HYGIENE_DEBUG;
+  else process.env.PI_CONTEXT_HYGIENE_DEBUG = value;
+  try {
+    return fn();
+  } finally {
+    if (previous === undefined) delete process.env.PI_CONTEXT_HYGIENE_DEBUG;
+    else process.env.PI_CONTEXT_HYGIENE_DEBUG = previous;
+  }
+}
+
+function createHarness(debugEnv?: string) {
+  return withDebugEnv(debugEnv, () => {
+    const handlers: Record<string, Function> = {};
+    const tools = new Map<string, any>();
+
+    init(
+      {
+        registerTool(tool: any) {
+          tools.set(tool.name, tool);
+        },
+        on(event: string, handler: Function) {
+          handlers[event] = handler;
+        },
+        events: { emit() {}, on() {} },
+      } as any,
+    );
+
+    return { handlers, tools };
+  });
+}
+
+afterEach(() => {
+  delete (globalThis as any).__hashlineToolExecutors;
+});
+
+describe("context_hygiene_report debug tool", () => {
+  it("is not registered by default", () => {
+    const { tools } = createHarness(undefined);
+
+    expect(tools.has("context_hygiene_report")).toBe(false);
+    expect((globalThis as any).__hashlineToolExecutors?.context_hygiene_report).toBeUndefined();
+  });
+
+  it("is registered only when PI_CONTEXT_HYGIENE_DEBUG is explicitly 1", () => {
+    const disabled = createHarness("0");
+    expect(disabled.tools.has("context_hygiene_report")).toBe(false);
+
+    const enabled = createHarness("1");
+    expect(enabled.tools.has("context_hygiene_report")).toBe(true);
+    expect((globalThis as any).__hashlineToolExecutors.context_hygiene_report).toBe(
+      enabled.tools.get("context_hygiene_report"),
+    );
+  });
+
+  it("returns deterministic stale and retirement fields without mutating tracker state", async () => {
+    const { tools } = createHarness("1");
+    const reportTool = tools.get("context_hygiene_report");
+    expect(reportTool).toBeDefined();
+
+    const fileResource = buildFileResource("tmp/context-hygiene-debug-tool-task9.ts");
+    const commandResource = buildCommandResource("npm test -- --context-hygiene-debug-tool-task9");
+    const tracker = getContextHygieneTracker();
+
+    const readEvent = tracker.record(
+      buildContextHygieneMetadata({
+        tool: "read",
+        classification: "read-context",
+        resources: [fileResource],
+      }),
+      { resultId: "debug-tool-read-task9" },
+    );
+    const firstCommandEvent = tracker.record(
+      buildContextHygieneMetadata({
+        tool: "bash",
+        classification: "command-output",
+        resources: [commandResource],
+      }),
+      { resultId: "debug-tool-command-task9-a" },
+    );
+    const secondCommandEvent = tracker.record(
+      buildContextHygieneMetadata({
+        tool: "bash",
+        classification: "command-output",
+        resources: [commandResource],
+      }),
+      { resultId: "debug-tool-command-task9-b" },
+    );
+    const mutationEvent = tracker.record(
+      buildContextHygieneMetadata({
+        tool: "edit",
+        classification: "mutation",
+        resources: [fileResource],
+      }),
+      { resultId: "debug-tool-mutation-task9" },
+    );
+
+    const before = tracker.generateReport();
+    const result = await reportTool.execute("context-hygiene-report-task9", {}, undefined, undefined, {});
+    const after = tracker.generateReport();
+
+    expect(after).toEqual(before);
+    expect(result.content).toEqual([{ type: "text", text: JSON.stringify(before, null, 2) }]);
+    expect(result.details.ptcValue).toEqual(before);
+
+    expect(result.details.ptcValue.staleCandidates).toContainEqual({
+      resourceKey: fileResource.key,
+      staleEventIds: [readEvent.id],
+      mutationEventId: mutationEvent.id,
+      reason: "mutation-after-read",
+    });
+    expect(result.details.ptcValue.retirementCandidates).toContainEqual({
+      resourceKey: commandResource.key,
+      eventIds: [firstCommandEvent.id],
+      supersededByEventId: secondCommandEvent.id,
+      reason: "command-rerun",
+    });
+  });
+});

--- a/tests/context-hygiene-edit.test.ts
+++ b/tests/context-hygiene-edit.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { buildFileResource } from "../src/context-hygiene.js";
+import { buildEditOutput } from "../src/edit-output.js";
+import { computeLineHash, ensureHashInit } from "../src/hashline.js";
+
+async function callEditTool(params: Record<string, unknown>) {
+  const { registerEditTool } = await import("../src/edit.js");
+  let capturedTool: any = null;
+  registerEditTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  if (!capturedTool) throw new Error("edit tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function makeFixtureFile(): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "pi-context-hygiene-edit-"));
+  const filePath = resolve(dir, "sample.ts");
+  writeFileSync(filePath, [
+    "const one = 1;",
+    "const two = 2;",
+    "const three = 3;",
+  ].join("\n"), "utf-8");
+  return filePath;
+}
+
+describe("edit contextHygiene metadata", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("buildEditOutput returns mutation metadata for the edited file", () => {
+    const output = buildEditOutput({
+      path: "/tmp/sample.ts",
+      displayPath: "sample.ts",
+      diff: "@@ -1 +1 @@\n-const x = 1;\n+const x = 2;",
+      firstChangedLine: 1,
+      warnings: [],
+      noopEdits: [],
+      edits: [{ set_line: { anchor: "1:abc", new_text: "const x = 2;" } }],
+    });
+
+    expect((output as any).contextHygiene).toEqual({
+      schemaVersion: 1,
+      tool: "edit",
+      classification: "mutation",
+      resources: [buildFileResource("/tmp/sample.ts")],
+    });
+    expect((output.ptcValue as any).contextHygiene).toBeUndefined();
+    expect(output.ptcValue).toMatchObject({
+      tool: "edit",
+      ok: true,
+      path: "/tmp/sample.ts",
+      summary: "Updated sample.ts",
+      firstChangedLine: 1,
+      warnings: [],
+      noopEdits: [],
+    });
+  });
+
+  it("edit tool attaches contextHygiene beside ptcValue without changing ptcValue", async () => {
+    const filePath = makeFixtureFile();
+    const originalLines = readFileSync(filePath, "utf-8").split("\n");
+    const anchor = `2:${computeLineHash(2, originalLines[1])}`;
+
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ set_line: { anchor, new_text: "const two = 22;" } }],
+    });
+
+    expect(result.details?.contextHygiene).toEqual({
+      schemaVersion: 1,
+      tool: "edit",
+      classification: "mutation",
+      resources: [buildFileResource(filePath)],
+    });
+    expect((result.details?.ptcValue as any).contextHygiene).toBeUndefined();
+    expect(result.details?.ptcValue).toMatchObject({
+      tool: "edit",
+      ok: true,
+      path: filePath,
+      summary: `Updated ${filePath}`,
+      firstChangedLine: 2,
+      warnings: [],
+      noopEdits: [],
+    });
+  });
+});

--- a/tests/context-hygiene-grep.test.ts
+++ b/tests/context-hygiene-grep.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildFileResource, buildSymbolResource } from "../src/context-hygiene.js";
+import { ensureHashInit } from "../src/hashline.js";
+import { buildPtcLine } from "../src/ptc-value.js";
+import { buildGrepOutput } from "../src/grep-output.js";
+import { registerGrepTool } from "../src/grep.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function callGrepTool(params: Record<string, unknown>) {
+  let capturedTool: any = null;
+  registerGrepTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  if (!capturedTool) throw new Error("grep tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+describe("grep contextHygiene metadata", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("buildGrepOutput returns search-context metadata for matched files and scoped symbols", () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const matchLine = buildPtcLine(45, "export function createDemoDirectory(): UserDirectory {");
+    const symbol = {
+      name: "createDemoDirectory",
+      kind: "function",
+      startLine: 45,
+      endLine: 49,
+    };
+
+    const output = buildGrepOutput({
+      summary: false,
+      totalMatches: 1,
+      records: [{ path: filePath, kind: "match", ...matchLine }],
+      groups: [
+        {
+          displayPath: "small.ts",
+          absolutePath: filePath,
+          matchCount: 1,
+          entries: [{ kind: "match", line: matchLine }],
+          scope: {
+            mode: "symbol",
+            symbol,
+            matchLines: [45],
+          },
+        },
+      ],
+      scopeMode: "symbol",
+    });
+
+    expect((output as any).contextHygiene).toEqual({
+      schemaVersion: 1,
+      tool: "grep",
+      classification: "search-context",
+      resources: [
+        buildFileResource(filePath),
+        buildSymbolResource(filePath, "createDemoDirectory", "function"),
+      ],
+    });
+    expect((output.ptcValue as any).contextHygiene).toBeUndefined();
+    expect(output.ptcValue.records).toEqual([
+      { path: filePath, line: 45, anchor: matchLine.anchor, kind: "match" },
+    ]);
+  });
+
+  it("grep tool attaches contextHygiene beside ptcValue without changing ptcValue", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const result = await callGrepTool({
+      pattern: "createDemoDirectory",
+      path: filePath,
+      literal: true,
+      scope: "symbol",
+    });
+
+    expect(result.details?.contextHygiene).toEqual({
+      schemaVersion: 1,
+      tool: "grep",
+      classification: "search-context",
+      resources: [
+        buildFileResource(filePath),
+        buildSymbolResource(filePath, "createDemoDirectory", "function"),
+      ],
+    });
+    expect((result.details?.ptcValue as any).contextHygiene).toBeUndefined();
+    expect(result.details?.ptcValue.scopes.groups[0].symbol).toMatchObject({
+      name: "createDemoDirectory",
+      kind: "function",
+      startLine: 45,
+      endLine: 49,
+    });
+  });
+});

--- a/tests/context-hygiene-read.test.ts
+++ b/tests/context-hygiene-read.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildFileResource, buildSymbolResource } from "../src/context-hygiene.js";
+import { ensureHashInit } from "../src/hashline.js";
+import { buildReadOutput } from "../src/read-output.js";
+import { registerReadTool } from "../src/read.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function callReadTool(params: { path: string; offset?: number; limit?: number; symbol?: string; map?: boolean }) {
+  let capturedTool: any = null;
+  const mockPi = { registerTool(def: any) { capturedTool = def; } };
+  registerReadTool(mockPi as any);
+  if (!capturedTool) throw new Error("read tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function getTextContent(result: any): string {
+  return result.content.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("read contextHygiene metadata", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("buildReadOutput returns additive read-context metadata for file and symbol resources", () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const selectedLines = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n").split("\n").slice(44);
+    const symbol = {
+      query: "createDemoDirectory",
+      name: "createDemoDirectory",
+      kind: "function",
+      parentName: undefined,
+      startLine: 45,
+      endLine: 49,
+    };
+
+    const built = buildReadOutput({
+      path: filePath,
+      startLine: 45,
+      endLine: 49,
+      totalLines: 49,
+      selectedLines,
+      symbol,
+    });
+
+    expect((built as any).contextHygiene).toEqual({
+      schemaVersion: 1,
+      tool: "read",
+      classification: "read-context",
+      resources: [
+        buildFileResource(filePath),
+        buildSymbolResource(filePath, "createDemoDirectory", "function"),
+      ],
+    });
+    expect(built.text).toMatch(/^\[Symbol: createDemoDirectory \(function\), lines 45-49 of 49\]/);
+    expect((built.ptcValue as any).contextHygiene).toBeUndefined();
+    expect(built.ptcValue.symbol).toEqual(symbol);
+  });
+
+
+  it("buildReadOutput includes applied local bundle support symbols in hygiene resources", () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const selectedLines = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n").split("\n").slice(44);
+    const symbol = {
+      query: "createDemoDirectory",
+      name: "createDemoDirectory",
+      kind: "function",
+      parentName: undefined,
+      startLine: 45,
+      endLine: 49,
+    };
+
+    const built = buildReadOutput({
+      path: filePath,
+      startLine: 45,
+      endLine: 49,
+      totalLines: 49,
+      selectedLines,
+      symbol,
+      bundle: {
+        mode: "local",
+        applied: true,
+        localSupport: [
+          {
+            symbol: {
+              query: "UserDirectory",
+              name: "UserDirectory",
+              kind: "class",
+              startLine: 13,
+              endLine: 38,
+            },
+            lines: ["export class UserDirectory {"],
+          },
+        ],
+      },
+    });
+
+    expect(built.contextHygiene.resources).toEqual([
+      buildFileResource(filePath),
+      buildSymbolResource(filePath, "createDemoDirectory", "function"),
+      buildSymbolResource(filePath, "UserDirectory", "class"),
+    ]);
+    expect((built.ptcValue as any).contextHygiene).toBeUndefined();
+  });
+
+  it("read tool attaches contextHygiene beside ptcValue without changing rendered text", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const result = await callReadTool({ path: filePath, symbol: "createDemoDirectory" });
+
+    expect(result.details?.contextHygiene).toEqual({
+      schemaVersion: 1,
+      tool: "read",
+      classification: "read-context",
+      resources: [
+        buildFileResource(filePath),
+        buildSymbolResource(filePath, "createDemoDirectory", "function"),
+      ],
+    });
+    expect(result.details?.ptcValue.symbol).toEqual({
+      query: "createDemoDirectory",
+      name: "createDemoDirectory",
+      kind: "function",
+      parentName: undefined,
+      startLine: 45,
+      endLine: 49,
+    });
+    expect((result.details?.ptcValue as any).contextHygiene).toBeUndefined();
+    expect(getTextContent(result)).toMatch(/^\[Symbol: createDemoDirectory \(function\), lines 45-49 of 49\]/);
+  });
+});

--- a/tests/context-hygiene-resource-keys.test.ts
+++ b/tests/context-hygiene-resource-keys.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCommandResource,
+  buildContextHygieneMetadata,
+  buildFileResource,
+  buildSymbolResource,
+  normalizeCommandForContextHygiene,
+} from "../src/context-hygiene.js";
+
+describe("context hygiene resource keys", () => {
+  it("builds deterministic file resources from paths", () => {
+    expect(buildFileResource("src/read.ts")).toEqual({
+      kind: "file",
+      key: "file:src/read.ts",
+      path: "src/read.ts",
+    });
+
+    expect(buildFileResource("src\\read.ts")).toEqual(buildFileResource("src/read.ts"));
+    expect(buildFileResource("./src/read.ts")).toEqual(buildFileResource("src/read.ts"));
+    expect(buildFileResource("src/../src/read.ts")).toEqual(buildFileResource("src/read.ts"));
+    expect(buildFileResource("src//read.ts")).toEqual(buildFileResource("src/read.ts"));
+  });
+
+  it("builds deterministic symbol resources scoped to files", () => {
+    expect(buildSymbolResource("src/read.ts", "buildReadOutput", "function")).toEqual({
+      kind: "symbol",
+      key: 'symbol:["src/read.ts","function","buildReadOutput"]',
+      path: "src/read.ts",
+      symbolName: "buildReadOutput",
+      symbolKind: "function",
+    });
+
+
+    expect(buildSymbolResource("src/a.ts", "function:parse").key).not.toBe(
+      buildSymbolResource("src/a.ts", "parse", "function").key,
+    );
+  });
+
+  it("normalizes commands and classifies command resources", () => {
+    expect(normalizeCommandForContextHygiene("  npm   test  ")).toBe("npm test");
+    expect(normalizeCommandForContextHygiene("printf 'a  b'")).toBe("printf 'a  b'");
+
+    expect(buildCommandResource("  npm   test  ")).toEqual({
+      kind: "command",
+      key: "command:test:npm test",
+      command: "npm test",
+      commandKind: "test",
+    });
+
+    expect(buildCommandResource("npm run typecheck").commandKind).toBe("typecheck");
+    expect(buildCommandResource("git status --short").commandKind).toBe("vcs");
+    expect(buildCommandResource("node script.js").commandKind).toBe("other");
+  });
+
+  it("builds additive metadata without mutating resources", () => {
+    const fileResource = buildFileResource("src/read.ts");
+    const metadata = buildContextHygieneMetadata({
+      tool: "read",
+      classification: "read-context",
+      resources: [fileResource, fileResource],
+    });
+
+    expect(metadata).toEqual({
+      schemaVersion: 1,
+      tool: "read",
+      classification: "read-context",
+      resources: [fileResource],
+    });
+    expect(fileResource).toEqual({
+      kind: "file",
+      key: "file:src/read.ts",
+      path: "src/read.ts",
+    });
+  });
+});

--- a/tests/context-hygiene-sg.test.ts
+++ b/tests/context-hygiene-sg.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, beforeAll, afterEach, vi } from "vitest";
+import * as cp from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildFileResource, buildSymbolResource } from "../src/context-hygiene.js";
+import { ensureHashInit } from "../src/hashline.js";
+import { buildPtcLine } from "../src/ptc-value.js";
+import { buildSgOutput } from "../src/sg-output.js";
+import { findEnclosingSgSymbols, registerSgTool } from "../src/sg.js";
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  execFile: vi.fn(),
+}));
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+async function callSgTool(params: Record<string, unknown>, debugEnv?: string) {
+  const previous = process.env.PI_CONTEXT_HYGIENE_DEBUG;
+  if (debugEnv === undefined) delete process.env.PI_CONTEXT_HYGIENE_DEBUG;
+  else process.env.PI_CONTEXT_HYGIENE_DEBUG = debugEnv;
+  try {
+    let capturedTool: any = null;
+    registerSgTool({ registerTool(def: any) { capturedTool = def; } } as any);
+    if (!capturedTool) throw new Error("ast_search tool was not registered");
+    return await capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+  } finally {
+    if (previous === undefined) delete process.env.PI_CONTEXT_HYGIENE_DEBUG;
+    else process.env.PI_CONTEXT_HYGIENE_DEBUG = previous;
+  }
+}
+
+describe("ast_search contextHygiene metadata", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("buildSgOutput returns search-context metadata for matched files and enclosing symbols", () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const matchLine = buildPtcLine(45, "export function createDemoDirectory(): UserDirectory {");
+
+    const output = buildSgOutput({
+      pattern: "export function $NAME($$$PARAMS) { $$$BODY }",
+      files: [
+        {
+          displayPath: "tests/fixtures/small.ts",
+          path: filePath,
+          ranges: [{ startLine: 45, endLine: 49 }],
+          lines: [matchLine],
+          symbols: [{ name: "createDemoDirectory", kind: "function" }],
+        },
+      ],
+    });
+
+    expect((output as any).contextHygiene).toEqual({
+      schemaVersion: 1,
+      tool: "ast_search",
+      classification: "search-context",
+      resources: [
+        buildFileResource(filePath),
+        buildSymbolResource(filePath, "createDemoDirectory", "function"),
+      ],
+    });
+    expect((output.ptcValue as any).contextHygiene).toBeUndefined();
+    expect(output.ptcValue.files[0]).toEqual({
+      path: filePath,
+      ranges: [{ startLine: 45, endLine: 49 }],
+      lines: [matchLine],
+    });
+  });
+
+  it("findEnclosingSgSymbols derives real symbols from readmap metadata", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+
+    await expect(findEnclosingSgSymbols(filePath, [{ startLine: 45, endLine: 49 }])).resolves.toEqual([
+      { name: "createDemoDirectory", kind: "function" },
+    ]);
+  });
+
+  it("ast_search tool attaches contextHygiene beside ptcValue without changing ptcValue", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+
+    vi.mocked(cp.execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, JSON.stringify([
+        { file: filePath, range: { start: { line: 44, column: 0 }, end: { line: 48, column: 0 } } },
+      ]), "");
+      return {} as any;
+    });
+
+    const result = await callSgTool({
+      pattern: "export function $NAME($$$PARAMS) { $$$BODY }",
+      path: filePath,
+    });
+
+    expect(result.details?.contextHygiene).toEqual({
+      schemaVersion: 1,
+      tool: "ast_search",
+      classification: "search-context",
+      resources: [buildFileResource(filePath)],
+    });
+    expect((result.details?.ptcValue as any).contextHygiene).toBeUndefined();
+    expect(result.details?.ptcValue.files[0]).toMatchObject({
+      path: filePath,
+      ranges: [{ startLine: 45, endLine: 49 }],
+    });
+  });
+
+  it("ast_search tool derives enclosing symbols before display range merging", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+
+    vi.mocked(cp.execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, JSON.stringify([
+        { file: filePath, range: { start: { line: 19, column: 0 }, end: { line: 32, column: 0 } } },
+        { file: filePath, range: { start: { line: 34, column: 0 }, end: { line: 36, column: 0 } } },
+      ]), "");
+      return {} as any;
+    });
+
+    const result = await callSgTool({
+      pattern: "$METHOD($$$ARGS) { $$$BODY }",
+      path: filePath,
+    }, "1");
+
+    expect(result.details?.contextHygiene.resources).toEqual([
+      buildFileResource(filePath),
+      buildSymbolResource(filePath, "addUser", "method"),
+      buildSymbolResource(filePath, "getUser", "method"),
+    ]);
+    expect(result.details?.ptcValue.files[0].ranges).toEqual([{ startLine: 20, endLine: 37 }]);
+  });
+});

--- a/tests/context-hygiene-tracker.test.ts
+++ b/tests/context-hygiene-tracker.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCommandResource,
+  buildContextHygieneMetadata,
+  buildFileResource,
+  createContextHygieneTracker,
+  getContextHygieneTracker,
+  resetContextHygieneTracker,
+} from "../src/context-hygiene.js";
+
+describe("context hygiene telemetry tracker", () => {
+  it("reports reuse, reruns, mutation staleness, retirement candidates, and churn deterministically", () => {
+    const fileResource = buildFileResource("src/read.ts");
+    const commandResource = buildCommandResource("npm test");
+    const tracker = createContextHygieneTracker();
+
+    tracker.record(
+      buildContextHygieneMetadata({
+        tool: "read",
+        classification: "read-context",
+        resources: [fileResource],
+      }),
+      { resultId: "read-1" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({
+        tool: "read",
+        classification: "read-context",
+        resources: [fileResource],
+      }),
+      { resultId: "read-2" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({
+        tool: "edit",
+        classification: "mutation",
+        resources: [fileResource],
+      }),
+      { resultId: "edit-1" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({
+        tool: "bash",
+        classification: "command-output",
+        resources: [commandResource],
+      }),
+      { resultId: "bash-1" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({
+        tool: "bash",
+        classification: "command-output",
+        resources: [commandResource],
+      }),
+      { resultId: "bash-2" },
+    );
+
+    expect(tracker.generateReport()).toEqual({
+      eventCount: 5,
+      resourceCount: 2,
+      readReuse: [
+        {
+          resourceKey: "file:src/read.ts",
+          count: 2,
+          eventIds: [1, 2],
+          resultIds: ["read-1", "read-2"],
+        },
+      ],
+      commandReruns: [
+        {
+          resourceKey: "command:test:npm test",
+          count: 2,
+          eventIds: [4, 5],
+          resultIds: ["bash-1", "bash-2"],
+        },
+      ],
+      mutationAfterRead: [
+        {
+          resourceKey: "file:src/read.ts",
+          readEventIds: [1, 2],
+          mutationEventId: 3,
+        },
+      ],
+      staleCandidates: [
+        {
+          resourceKey: "file:src/read.ts",
+          staleEventIds: [1, 2],
+          mutationEventId: 3,
+          reason: "mutation-after-read",
+        },
+      ],
+      retirementCandidates: [
+        {
+          resourceKey: "command:test:npm test",
+          eventIds: [4],
+          supersededByEventId: 5,
+          reason: "command-rerun",
+        },
+      ],
+      churn: {
+        byClassification: {
+          "command-output": 2,
+          mutation: 1,
+          "read-context": 2,
+          "search-context": 0,
+        },
+        byTool: {
+          bash: 2,
+          edit: 1,
+          read: 2,
+        },
+        uniqueResourcesSeen: 2,
+      },
+    });
+  });
+
+  it("returns a shared global tracker", () => {
+    expect(getContextHygieneTracker()).toBe(getContextHygieneTracker());
+  });
+
+
+  it("bounds retained event history and can reset the shared tracker", () => {
+    const tracker = createContextHygieneTracker({ maxEvents: 2 });
+    const resource = buildFileResource("src/read.ts");
+    const metadata = buildContextHygieneMetadata({
+      tool: "read",
+      classification: "read-context",
+      resources: [resource],
+    });
+
+    tracker.record(metadata, { resultId: "read-1" });
+    tracker.record(metadata, { resultId: "read-2" });
+    tracker.record(metadata, { resultId: "read-3" });
+
+    expect(tracker.generateReport().readReuse).toEqual([
+      {
+        resourceKey: resource.key,
+        count: 2,
+        eventIds: [2, 3],
+        resultIds: ["read-2", "read-3"],
+      },
+    ]);
+
+    const reset = resetContextHygieneTracker({ maxEvents: 2 });
+    expect(getContextHygieneTracker()).toBe(reset);
+    expect(reset.generateReport().eventCount).toBe(0);
+  });
+});

--- a/tests/context-hygiene-write.test.ts
+++ b/tests/context-hygiene-write.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { buildFileResource } from "../src/context-hygiene.js";
+import { executeWrite, registerWriteTool } from "../src/write.js";
+
+async function callWriteTool(params: Record<string, unknown>) {
+  let capturedTool: any = null;
+  registerWriteTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  if (!capturedTool) throw new Error("write tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+describe("write contextHygiene metadata", () => {
+  it("executeWrite returns mutation metadata for the written file without changing ptcValue", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-context-hygiene-write-"));
+    const filePath = resolve(dir, "sample.ts");
+
+    const result = await executeWrite({ path: filePath, content: "const value = 1;" });
+
+    expect((result as any).contextHygiene).toEqual({
+      schemaVersion: 1,
+      tool: "write",
+      classification: "mutation",
+      resources: [buildFileResource(filePath)],
+    });
+    expect((result.ptcValue as any).contextHygiene).toBeUndefined();
+    expect(result.ptcValue).toMatchObject({
+      tool: "write",
+      path: filePath,
+      warnings: [],
+    });
+    expect(result.text).toMatch(/^1:[0-9a-f]{3}\|const value = 1;$/m);
+  });
+
+  it("executeWrite returns mutation metadata for binary writes without changing ptcValue", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-context-hygiene-write-bin-"));
+    const filePath = resolve(dir, "sample.bin");
+
+    const result = await executeWrite({ path: filePath, content: "hello\u0000world" });
+
+    expect((result as any).contextHygiene).toEqual({
+      schemaVersion: 1,
+      tool: "write",
+      classification: "mutation",
+      resources: [buildFileResource(filePath)],
+    });
+    expect((result.ptcValue as any).contextHygiene).toBeUndefined();
+    expect(result.ptcValue).toMatchObject({
+      tool: "write",
+      path: filePath,
+      lines: [],
+    });
+    expect(result.ptcValue.warnings.map((warning) => warning.code)).toContain("binary-content");
+  });
+
+  it("write tool attaches contextHygiene beside ptcValue for successful and binary writes", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-context-hygiene-write-tool-"));
+    const filePath = resolve(dir, "sample.ts");
+    const binaryPath = resolve(dir, "sample.bin");
+
+    const result = await callWriteTool({ path: filePath, content: "alpha\nbeta" });
+    const binaryResult = await callWriteTool({ path: binaryPath, content: "hello\u0000world" });
+
+    expect(result.details?.contextHygiene).toEqual({
+      schemaVersion: 1,
+      tool: "write",
+      classification: "mutation",
+      resources: [buildFileResource(filePath)],
+    });
+    expect((result.details?.ptcValue as any).contextHygiene).toBeUndefined();
+    expect(result.details?.ptcValue).toMatchObject({
+      tool: "write",
+      path: relative(process.cwd(), filePath),
+      warnings: [],
+    });
+
+    expect(binaryResult.details?.contextHygiene).toEqual({
+      schemaVersion: 1,
+      tool: "write",
+      classification: "mutation",
+      resources: [buildFileResource(binaryPath)],
+    });
+    expect((binaryResult.details?.ptcValue as any).contextHygiene).toBeUndefined();
+    expect(binaryResult.isError).toBe(true);
+    expect(binaryResult.details?.ptcValue?.error?.code).toBe("binary-content");
+  });
+});


### PR DESCRIPTION
Add deterministic, additive `contextHygiene` metadata to `read`, `grep`, `ast_search`, `edit`, `write`, and Bash tool results without changing rendered output or `ptcValue` contracts.

### New module: `src/context-hygiene.ts`
- Resource identity builders: `buildFileResource`, `buildSymbolResource`, `buildCommandResource`
- `buildContextHygieneMetadata` — constructs additive metadata, dedupes resources
- Telemetry tracker: `createContextHygieneTracker` (bounded retention), `getContextHygieneTracker`, `resetContextHygieneTracker`
- Deterministic `generateReport` with reuse, reruns, mutation-after-read, stale candidates, retirement candidates, and churn
- Debug-only `context_hygiene_report` tool gated by `PI_CONTEXT_HYGIENE_DEBUG=1`

### Tool integrations
- `read` → `read-context` metadata (file + symbol + bundle support symbols)
- `grep` → `search-context` metadata (file + scoped symbols)
- `ast_search` → `search-context` metadata (file); symbol enrichment gated behind debug mode + file cap
- `edit` / `write` → `mutation` metadata (file resource)
- Bash → `command-output` metadata (command resource); preserves RTK compression, bypass, doom-loop

### Safety
- No rendered text changes unless debug mode is explicitly enabled
- Existing `details.ptcValue` fields remain backward compatible
- Anchor-based workflows unchanged
- No live masking, retirement, or summarization

### Verification
- `npm test` passed: 226 files / 1102 tests
- `npm run typecheck` passed

Closes #121
Closes #122
Closes #123
Closes #124