### PR TITLE
feat: add context hygiene stale records and rehydrate metadata

### DIFF
--- a/src/context-hygiene.ts
+++ b/src/context-hygiene.ts
@@ -57,17 +57,207 @@ export type ContextHygieneResource =
   | ContextHygieneSymbolResource
   | ContextHygieneCommandResource;
 
+export interface ContextHygieneReadRehydrateInput {
+  path: string;
+  offset?: number | string;
+  limit?: number | string;
+  symbol?: string;
+  map?: true;
+  bundle?: "local";
+}
+
+export interface ContextHygieneGrepRehydrateInput {
+  pattern: string;
+  path?: string;
+  glob?: string;
+  literal?: true;
+  ignoreCase?: true;
+  context?: number | string;
+  summary?: true;
+  scope?: "symbol";
+  scopeContext?: number | string;
+}
+
+export interface ContextHygieneAstSearchRehydrateInput {
+  pattern: string;
+  lang?: string;
+  path?: string;
+}
+
+export interface ContextHygieneReadRehydrateDescriptor {
+  tool: "read";
+  input: ContextHygieneReadRehydrateInput;
+}
+
+export interface ContextHygieneGrepRehydrateDescriptor {
+  tool: "grep";
+  input: ContextHygieneGrepRehydrateInput;
+}
+
+export interface ContextHygieneAstSearchRehydrateDescriptor {
+  tool: "ast_search";
+  input: ContextHygieneAstSearchRehydrateInput;
+}
+
+export type ContextHygieneRehydrateDescriptor =
+  | ContextHygieneReadRehydrateDescriptor
+  | ContextHygieneGrepRehydrateDescriptor
+  | ContextHygieneAstSearchRehydrateDescriptor;
+
+export type ContextHygieneStaleInvalidationReason = "mutation-after-read";
+
+export interface ContextHygieneStaleRecord {
+  status: "stale";
+  originalTool: string;
+  originalEventId?: number;
+  originalResultId?: string;
+  staleResourceKeys: string[];
+  invalidatingMutationEventId: number;
+  invalidatingMutationResultId?: string;
+  reason: ContextHygieneStaleInvalidationReason;
+  rehydrate?: ContextHygieneRehydrateDescriptor;
+}
+
+export interface BuildStaleContextRecordInput {
+  originalTool: string;
+  originalEventId?: number;
+  originalResultId?: string;
+  staleResourceKeys: readonly string[];
+  invalidatingMutationEventId: number;
+  invalidatingMutationResultId?: string;
+  reason?: ContextHygieneStaleInvalidationReason;
+  rehydrate?: ContextHygieneRehydrateDescriptor;
+}
+
+export function cloneContextHygieneRehydrateDescriptor(
+  descriptor: ContextHygieneRehydrateDescriptor,
+): ContextHygieneRehydrateDescriptor {
+  switch (descriptor.tool) {
+    case "read":
+      return { tool: "read", input: { ...descriptor.input } };
+    case "grep":
+      return { tool: "grep", input: { ...descriptor.input } };
+    case "ast_search":
+      return { tool: "ast_search", input: { ...descriptor.input } };
+  }
+}
+
+export function buildStaleContextRecord(input: BuildStaleContextRecordInput): ContextHygieneStaleRecord {
+  const record: ContextHygieneStaleRecord = {
+    status: "stale",
+    originalTool: input.originalTool,
+    staleResourceKeys: sortResourceKeys(new Set(input.staleResourceKeys)),
+    invalidatingMutationEventId: input.invalidatingMutationEventId,
+    reason: input.reason ?? "mutation-after-read",
+  };
+  if (input.originalEventId !== undefined) record.originalEventId = input.originalEventId;
+  if (input.originalResultId) record.originalResultId = input.originalResultId;
+  if (input.invalidatingMutationResultId) record.invalidatingMutationResultId = input.invalidatingMutationResultId;
+  if (input.rehydrate) record.rehydrate = cloneContextHygieneRehydrateDescriptor(input.rehydrate);
+  return record;
+}
+
+export function renderStaleReadPlaceholder(): string {
+  return "[Stale read context: file content changed after this result. Re-run read to refresh.]";
+}
+
+export function renderStaleGrepPlaceholder(): string {
+  return "[Stale grep context: matched file content changed after this result. Re-run grep to refresh.]";
+}
+
+export function renderStaleAstSearchPlaceholder(): string {
+  return "[Stale ast_search context: matched file content changed after this result. Re-run ast_search to refresh.]";
+}
+
+export function renderStaleContextPlaceholder(record: ContextHygieneStaleRecord): string {
+  switch (record.originalTool) {
+    case "read":
+      return renderStaleReadPlaceholder();
+    case "grep":
+      return renderStaleGrepPlaceholder();
+    case "ast_search":
+      return renderStaleAstSearchPlaceholder();
+    default:
+      return "[Stale tool context: resource content changed after this result. Re-run the original tool to refresh.]";
+  }
+}
+
+export interface BuildReadRehydrateDescriptorInput {
+  path: string;
+  offset?: number | string;
+  limit?: number | string;
+  symbol?: string;
+  map?: boolean;
+  bundle?: "local";
+}
+
+export function buildReadRehydrateDescriptor(
+  input: BuildReadRehydrateDescriptorInput,
+): ContextHygieneReadRehydrateDescriptor {
+  const descriptorInput: ContextHygieneReadRehydrateInput = { path: input.path };
+  if (input.offset !== undefined) descriptorInput.offset = input.offset;
+  if (input.limit !== undefined) descriptorInput.limit = input.limit;
+  if (input.symbol !== undefined) descriptorInput.symbol = input.symbol;
+  if (input.map === true) descriptorInput.map = true;
+  if (input.bundle !== undefined) descriptorInput.bundle = input.bundle;
+  return { tool: "read", input: descriptorInput };
+}
+
+export interface BuildGrepRehydrateDescriptorInput {
+  pattern: string;
+  path?: string;
+  glob?: string;
+  literal?: boolean;
+  ignoreCase?: boolean;
+  context?: number | string;
+  summary?: boolean;
+  scope?: "symbol";
+  scopeContext?: number | string;
+}
+
+export function buildGrepRehydrateDescriptor(
+  input: BuildGrepRehydrateDescriptorInput,
+): ContextHygieneGrepRehydrateDescriptor {
+  const descriptorInput: ContextHygieneGrepRehydrateInput = { pattern: input.pattern };
+  if (input.path !== undefined) descriptorInput.path = input.path;
+  if (input.glob !== undefined) descriptorInput.glob = input.glob;
+  if (input.literal === true) descriptorInput.literal = true;
+  if (input.ignoreCase === true) descriptorInput.ignoreCase = true;
+  if (input.context !== undefined) descriptorInput.context = input.context;
+  if (input.summary === true) descriptorInput.summary = true;
+  if (input.scope !== undefined) descriptorInput.scope = input.scope;
+  if (input.scopeContext !== undefined) descriptorInput.scopeContext = input.scopeContext;
+  return { tool: "grep", input: descriptorInput };
+}
+
+export interface BuildAstSearchRehydrateDescriptorInput {
+  pattern: string;
+  lang?: string;
+  path?: string;
+}
+
+export function buildAstSearchRehydrateDescriptor(
+  input: BuildAstSearchRehydrateDescriptorInput,
+): ContextHygieneAstSearchRehydrateDescriptor {
+  const descriptorInput: ContextHygieneAstSearchRehydrateInput = { pattern: input.pattern };
+  if (input.lang !== undefined) descriptorInput.lang = input.lang;
+  if (input.path !== undefined) descriptorInput.path = input.path;
+  return { tool: "ast_search", input: descriptorInput };
+}
+
 export interface ContextHygieneMetadata {
   schemaVersion: typeof CONTEXT_HYGIENE_SCHEMA_VERSION;
   tool: string;
   classification: ContextHygieneClassification;
   resources: ContextHygieneResource[];
+  rehydrate?: ContextHygieneRehydrateDescriptor;
 }
 
 export interface BuildContextHygieneMetadataInput {
   tool: string;
   classification: ContextHygieneClassification;
   resources?: readonly (ContextHygieneResource | null | undefined)[];
+  rehydrate?: ContextHygieneRehydrateDescriptor | null;
 }
 
 export function normalizePathForContextHygiene(path: string): string {
@@ -194,12 +384,14 @@ export function buildContextHygieneMetadata(
     resources.push({ ...resource } as ContextHygieneResource);
   }
 
-  return {
+  const metadata: ContextHygieneMetadata = {
     schemaVersion: CONTEXT_HYGIENE_SCHEMA_VERSION,
     tool: input.tool,
     classification: input.classification,
     resources,
   };
+  if (input.rehydrate) metadata.rehydrate = cloneContextHygieneRehydrateDescriptor(input.rehydrate);
+  return metadata;
 }
 
 export interface ContextHygieneRecordOptions {
@@ -212,6 +404,7 @@ export interface ContextHygieneEvent {
   tool: string;
   classification: ContextHygieneClassification;
   resources: ContextHygieneResource[];
+  rehydrate?: ContextHygieneRehydrateDescriptor;
 }
 
 export interface ContextHygieneReuseReportEntry {
@@ -232,6 +425,7 @@ export interface ContextHygieneStaleCandidateReportEntry {
   staleEventIds: number[];
   mutationEventId: number;
   reason: "mutation-after-read";
+  staleResults: ContextHygieneStaleRecord[];
 }
 
 export interface ContextHygieneRetirementCandidateReportEntry {
@@ -315,6 +509,15 @@ function resultIdsForEvents(events: ContextHygieneEvent[]): string[] {
   return events.map((event) => event.resultId).filter((resultId): resultId is string => Boolean(resultId));
 }
 
+function cloneContextHygieneEvent(event: ContextHygieneEvent): ContextHygieneEvent {
+  const cloned: ContextHygieneEvent = {
+    ...event,
+    resources: event.resources.map((resource) => ({ ...resource } as ContextHygieneResource)),
+  };
+  if (event.rehydrate) cloned.rehydrate = cloneContextHygieneRehydrateDescriptor(event.rehydrate);
+  return cloned;
+}
+
 function compareStable(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
 }
@@ -349,9 +552,10 @@ class DefaultContextHygieneTracker implements ContextHygieneTracker {
       resources: metadata.resources.map((resource) => ({ ...resource } as ContextHygieneResource)),
     };
     if (options.resultId) event.resultId = options.resultId;
+    if (metadata.rehydrate) event.rehydrate = cloneContextHygieneRehydrateDescriptor(metadata.rehydrate);
     this.events.push(event);
     if (this.events.length > this.maxEvents) this.events.splice(0, this.events.length - this.maxEvents);
-    return { ...event, resources: event.resources.map((resource) => ({ ...resource } as ContextHygieneResource)) };
+    return cloneContextHygieneEvent(event);
   }
 
   generateReport(): ContextHygieneReport {
@@ -409,7 +613,8 @@ class DefaultContextHygieneTracker implements ContextHygieneTracker {
       const reads = readEventsByResource.get(resourceKey) ?? [];
       const mutations = mutationEventsByResource.get(resourceKey) ?? [];
       for (const mutation of mutations) {
-        const priorReadIds = reads.filter((read) => read.id < mutation.id).map((read) => read.id);
+        const priorReads = reads.filter((read) => read.id < mutation.id);
+        const priorReadIds = priorReads.map((read) => read.id);
         if (priorReadIds.length === 0) continue;
         mutationAfterRead.push({ resourceKey, readEventIds: priorReadIds, mutationEventId: mutation.id });
         staleCandidates.push({
@@ -417,6 +622,16 @@ class DefaultContextHygieneTracker implements ContextHygieneTracker {
           staleEventIds: priorReadIds,
           mutationEventId: mutation.id,
           reason: "mutation-after-read",
+          staleResults: priorReads.map((read) => buildStaleContextRecord({
+            originalTool: read.tool,
+            originalEventId: read.id,
+            originalResultId: read.resultId,
+            staleResourceKeys: [resourceKey],
+            invalidatingMutationEventId: mutation.id,
+            invalidatingMutationResultId: mutation.resultId,
+            reason: "mutation-after-read",
+            rehydrate: read.rehydrate,
+          })),
         });
       }
     }

--- a/src/grep-output.ts
+++ b/src/grep-output.ts
@@ -10,6 +10,7 @@ import {
   buildFileResource,
   buildSymbolResource,
   type ContextHygieneMetadata,
+  type ContextHygieneRehydrateDescriptor,
   type ContextHygieneResource,
 } from "./context-hygiene.js";
 
@@ -64,6 +65,7 @@ export interface BuildGrepOutputInput {
   scopeMode?: "symbol";
   scopeWarnings?: GrepScopeWarning[];
   passthroughLines?: string[];
+  rehydrate?: ContextHygieneRehydrateDescriptor | null;
 }
 
 export interface GrepOutputResult {
@@ -185,6 +187,7 @@ export function buildGrepOutput(input: BuildGrepOutputInput): GrepOutputResult {
     tool: "grep",
     classification: "search-context",
     resources: contextHygieneResources,
+    rehydrate: input.rehydrate ?? undefined,
   });
   return {
     text,

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -9,6 +9,7 @@ import { looksLikeBinary } from "./binary-detect";
 import { ensureHashInit, formatHashlineDisplay, escapeControlCharsForDisplay } from "./hashline";
 import { buildPtcError, buildPtcLine } from "./ptc-value.js";
 import { buildGrepOutput } from "./grep-output.js";
+import { buildGrepRehydrateDescriptor } from "./context-hygiene.js";
 import { getOrGenerateMap } from "./map-cache.js";
 import { scopeGrepGroupsToSymbols } from "./grep-symbol-scope.js";
 import { resolveToCwd } from "./path-utils";
@@ -660,6 +661,17 @@ if (p.scope === "symbol" && !summary) {
 				scopeMode: p.scope === "symbol" && !summary ? "symbol" : undefined,
 				scopeWarnings,
 				passthroughLines,
+				rehydrate: buildGrepRehydrateDescriptor({
+					pattern: p.pattern,
+					path: p.path,
+					glob: p.glob,
+					literal: p.literal,
+					ignoreCase: p.ignoreCase,
+					context: p.context,
+					summary: p.summary,
+					scope: p.scope,
+					scopeContext: p.scopeContext,
+				}),
 			});
 
 			if (!summary && ptcRecords.length > 0) {

--- a/src/read-output.ts
+++ b/src/read-output.ts
@@ -10,6 +10,7 @@ import {
   buildFileResource,
   buildSymbolResource,
   type ContextHygieneMetadata,
+  type ContextHygieneRehydrateDescriptor,
   type ContextHygieneResource,
 } from "./context-hygiene.js";
 
@@ -63,6 +64,7 @@ export interface ReadOutputInput {
   symbol?: ReadSymbolMetadata | null;
   map?: ReadMapMetadata;
   bundle?: ReadBundleMetadata | null;
+  rehydrate?: ContextHygieneRehydrateDescriptor | null;
 }
 
 export interface ReadOutputResult {
@@ -196,6 +198,7 @@ export function buildReadOutput(input: ReadOutputInput): ReadOutputResult {
     tool: "read",
     classification: "read-context",
     resources: contextHygieneResources,
+    rehydrate: input.rehydrate ?? undefined,
   });
 
   return {

--- a/src/read.ts
+++ b/src/read.ts
@@ -19,6 +19,7 @@ import { getOrGenerateMap } from "./map-cache";
 import { formatFileMapWithBudget } from "./readmap/formatter.js";
 import { findSymbol, type SymbolMatch } from "./readmap/symbol-lookup.js";
 import { buildReadOutput } from "./read-output.js";
+import { buildReadRehydrateDescriptor } from "./context-hygiene.js";
 import { buildLocalBundle } from "./read-local-bundle.js";
 import { coerceObviousBase10Int } from "./coerce-obvious-int.js";
 import { Text } from "@mariozechner/pi-tui";
@@ -573,6 +574,14 @@ const readOutput = buildReadOutput({
 		text: mapText,
 	},
 	...(bundleMetadata ? { bundle: bundleMetadata } : {}),
+	rehydrate: buildReadRehydrateDescriptor({
+		path: p.path,
+		offset: p.offset,
+		limit: p.limit,
+		symbol: p.symbol,
+		map: p.map,
+		bundle: p.bundle,
+	}),
 });
 
 return succeed({

--- a/src/sg-output.ts
+++ b/src/sg-output.ts
@@ -4,6 +4,7 @@ import {
   buildFileResource,
   buildSymbolResource,
   type ContextHygieneMetadata,
+  type ContextHygieneRehydrateDescriptor,
   type ContextHygieneResource,
 } from "./context-hygiene.js";
 
@@ -18,6 +19,7 @@ export interface SgOutputFile {
 export interface BuildSgOutputInput {
   pattern: string;
   files: SgOutputFile[];
+  rehydrate?: ContextHygieneRehydrateDescriptor | null;
 }
 
 export interface SgOutputResult {
@@ -45,6 +47,7 @@ export function buildSgOutput(input: BuildSgOutputInput): SgOutputResult {
         tool: "ast_search",
         classification: "search-context",
         resources: [],
+        rehydrate: input.rehydrate ?? undefined,
       }),
     };
   }
@@ -79,6 +82,7 @@ export function buildSgOutput(input: BuildSgOutputInput): SgOutputResult {
       tool: "ast_search",
       classification: "search-context",
       resources: contextHygieneResources,
+      rehydrate: input.rehydrate ?? undefined,
     }),
   };
 }

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -11,7 +11,7 @@ import { buildPtcError, buildPtcLine } from "./ptc-value.js";
 import { resolveToCwd } from "./path-utils.js";
 import type { FileSymbol } from "./readmap/types.js";
 import { buildSgOutput } from "./sg-output.js";
-import { isContextHygieneDebugEnabled } from "./context-hygiene.js";
+import { buildAstSearchRehydrateDescriptor, isContextHygieneDebugEnabled } from "./context-hygiene.js";
 
 type SgParams = { pattern: string; lang?: string; path?: string };
 const CONTEXT_HYGIENE_SG_SYMBOL_FILE_CAP = 20;
@@ -150,6 +150,11 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       await ensureHashInit();
       const p = params as SgParams;
+      const rehydrate = buildAstSearchRehydrateDescriptor({
+        pattern: p.pattern,
+        lang: p.lang,
+        path: p.path,
+      });
       const args = ["run", "--json", "-p", p.pattern];
       if (p.lang) args.push("-l", p.lang);
 
@@ -213,7 +218,7 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
 
         const matches = JSON.parse(stdout);
         if (!Array.isArray(matches) || matches.length === 0) {
-          const emptyOutput = buildSgOutput({ pattern: p.pattern, files: [] });
+          const emptyOutput = buildSgOutput({ pattern: p.pattern, files: [], rehydrate });
           return {
             content: [{ type: "text", text: emptyOutput.text }],
             details: {
@@ -291,7 +296,7 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
         }
 
         if (blocks.length === 0) {
-          const emptyOutput = buildSgOutput({ pattern: p.pattern, files: [] });
+          const emptyOutput = buildSgOutput({ pattern: p.pattern, files: [], rehydrate });
           return {
             content: [{ type: "text", text: emptyOutput.text }],
             details: {
@@ -304,6 +309,7 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
         const builtOutput = buildSgOutput({
           pattern: p.pattern,
           files: ptcFiles,
+          rehydrate,
         });
         for (const ptcFile of ptcFiles) {
           if (ptcFile.lines.length > 0) {

--- a/tests/context-hygiene-debug-tool.test.ts
+++ b/tests/context-hygiene-debug-tool.test.ts
@@ -4,6 +4,7 @@ import {
   buildCommandResource,
   buildContextHygieneMetadata,
   buildFileResource,
+  buildReadRehydrateDescriptor,
   getContextHygieneTracker,
 } from "../src/context-hygiene.js";
 
@@ -71,12 +72,14 @@ describe("context_hygiene_report debug tool", () => {
     const fileResource = buildFileResource("tmp/context-hygiene-debug-tool-task9.ts");
     const commandResource = buildCommandResource("npm test -- --context-hygiene-debug-tool-task9");
     const tracker = getContextHygieneTracker();
+    const readRehydrate = buildReadRehydrateDescriptor({ path: "tmp/context-hygiene-debug-tool-task9.ts" });
 
     const readEvent = tracker.record(
       buildContextHygieneMetadata({
         tool: "read",
         classification: "read-context",
         resources: [fileResource],
+        rehydrate: readRehydrate,
       }),
       { resultId: "debug-tool-read-task9" },
     );
@@ -118,6 +121,19 @@ describe("context_hygiene_report debug tool", () => {
       staleEventIds: [readEvent.id],
       mutationEventId: mutationEvent.id,
       reason: "mutation-after-read",
+      staleResults: [
+        {
+          status: "stale",
+          originalTool: "read",
+          originalEventId: readEvent.id,
+          originalResultId: "debug-tool-read-task9",
+          staleResourceKeys: [fileResource.key],
+          invalidatingMutationEventId: mutationEvent.id,
+          invalidatingMutationResultId: "debug-tool-mutation-task9",
+          reason: "mutation-after-read",
+          rehydrate: readRehydrate,
+        },
+      ],
     });
     expect(result.details.ptcValue.retirementCandidates).toContainEqual({
       resourceKey: commandResource.key,

--- a/tests/context-hygiene-grep.test.ts
+++ b/tests/context-hygiene-grep.test.ts
@@ -74,6 +74,7 @@ describe("grep contextHygiene metadata", () => {
       path: filePath,
       literal: true,
       scope: "symbol",
+      scopeContext: 0,
     });
 
     expect(result.details?.contextHygiene).toEqual({
@@ -84,6 +85,16 @@ describe("grep contextHygiene metadata", () => {
         buildFileResource(filePath),
         buildSymbolResource(filePath, "createDemoDirectory", "function"),
       ],
+      rehydrate: {
+        tool: "grep",
+        input: {
+          pattern: "createDemoDirectory",
+          path: filePath,
+          literal: true,
+          scope: "symbol",
+          scopeContext: 0,
+        },
+      },
     });
     expect((result.details?.ptcValue as any).contextHygiene).toBeUndefined();
     expect(result.details?.ptcValue.scopes.groups[0].symbol).toMatchObject({
@@ -92,5 +103,33 @@ describe("grep contextHygiene metadata", () => {
       startLine: 45,
       endLine: 49,
     });
+  });
+
+  it("grep tool preserves optional call inputs in rehydrate metadata", async () => {
+    const result = await callGrepTool({
+      pattern: "createdemodirectory",
+      path: fixturesDir,
+      glob: "small.ts",
+      literal: true,
+      ignoreCase: true,
+      context: 1,
+      summary: true,
+      limit: 20,
+    });
+
+    expect(result.details?.contextHygiene.rehydrate).toEqual({
+      tool: "grep",
+      input: {
+        pattern: "createdemodirectory",
+        path: fixturesDir,
+        glob: "small.ts",
+        literal: true,
+        ignoreCase: true,
+        context: 1,
+        summary: true,
+      },
+    });
+    expect((result.details?.contextHygiene.rehydrate.input as any).limit).toBeUndefined();
+    expect((result.details?.ptcValue as any).contextHygiene).toBeUndefined();
   });
 });

--- a/tests/context-hygiene-read.test.ts
+++ b/tests/context-hygiene-read.test.ts
@@ -10,7 +10,14 @@ import { registerReadTool } from "../src/read.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixturesDir = resolve(__dirname, "fixtures");
 
-async function callReadTool(params: { path: string; offset?: number; limit?: number; symbol?: string; map?: boolean }) {
+async function callReadTool(params: {
+  path: string;
+  offset?: number;
+  limit?: number;
+  symbol?: string;
+  map?: boolean;
+  bundle?: "local";
+}) {
   let capturedTool: any = null;
   const mockPi = { registerTool(def: any) { capturedTool = def; } };
   registerReadTool(mockPi as any);
@@ -110,7 +117,11 @@ describe("read contextHygiene metadata", () => {
 
   it("read tool attaches contextHygiene beside ptcValue without changing rendered text", async () => {
     const filePath = resolve(fixturesDir, "small.ts");
-    const result = await callReadTool({ path: filePath, symbol: "createDemoDirectory" });
+    const result = await callReadTool({
+      path: filePath,
+      symbol: "createDemoDirectory",
+      bundle: "local",
+    });
 
     expect(result.details?.contextHygiene).toEqual({
       schemaVersion: 1,
@@ -119,7 +130,12 @@ describe("read contextHygiene metadata", () => {
       resources: [
         buildFileResource(filePath),
         buildSymbolResource(filePath, "createDemoDirectory", "function"),
+        buildSymbolResource(filePath, "addUser", "method"),
       ],
+      rehydrate: {
+        tool: "read",
+        input: { path: filePath, symbol: "createDemoDirectory", bundle: "local" },
+      },
     });
     expect(result.details?.ptcValue.symbol).toEqual({
       query: "createDemoDirectory",
@@ -130,6 +146,19 @@ describe("read contextHygiene metadata", () => {
       endLine: 49,
     });
     expect((result.details?.ptcValue as any).contextHygiene).toBeUndefined();
-    expect(getTextContent(result)).toMatch(/^\[Symbol: createDemoDirectory \(function\), lines 45-49 of 49\]/);
+    expect(getTextContent(result)).toContain("## Requested symbol");
+    expect(getTextContent(result)).toContain("[Symbol: createDemoDirectory (function), lines 45-49 of 49]");
+  });
+
+  it("read tool preserves optional call inputs in rehydrate metadata", async () => {
+    const filePath = resolve(fixturesDir, "small.ts");
+    const result = await callReadTool({ path: filePath, offset: 2, limit: 3, map: true });
+
+    expect(result.details?.contextHygiene.rehydrate).toEqual({
+      tool: "read",
+      input: { path: filePath, offset: 2, limit: 3, map: true },
+    });
+    expect((result.details?.ptcValue as any).contextHygiene).toBeUndefined();
+    expect(getTextContent(result)).toContain("2:");
   });
 });

--- a/tests/context-hygiene-rehydrate-grep.test.ts
+++ b/tests/context-hygiene-rehydrate-grep.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { buildGrepRehydrateDescriptor } from "../src/context-hygiene.js";
+
+describe("grep rehydrate descriptors", () => {
+  it("preserves safe grep inputs deterministically and omits undefined defaults", () => {
+    expect(buildGrepRehydrateDescriptor({
+      pattern: "TODO",
+      literal: false,
+      ignoreCase: false,
+      summary: false,
+      context: undefined,
+      scopeContext: undefined,
+    })).toEqual({
+      tool: "grep",
+      input: { pattern: "TODO" },
+    });
+
+    const descriptor = buildGrepRehydrateDescriptor({
+      pattern: "createDemoDirectory",
+      path: "tests/fixtures",
+      glob: "**/*.ts",
+      literal: true,
+      ignoreCase: true,
+      context: 0,
+      summary: true,
+      scope: "symbol",
+      scopeContext: 2,
+      limit: 100,
+      signal: new AbortController().signal,
+      cwd: { value: process.cwd() },
+      renderedOutput: "rendered grep output",
+    } as any);
+
+    expect(descriptor).toEqual({
+      tool: "grep",
+      input: {
+        pattern: "createDemoDirectory",
+        path: "tests/fixtures",
+        glob: "**/*.ts",
+        literal: true,
+        ignoreCase: true,
+        context: 0,
+        summary: true,
+        scope: "symbol",
+        scopeContext: 2,
+      },
+    });
+    expect(buildGrepRehydrateDescriptor({
+      pattern: "createDemoDirectory",
+      path: "tests/fixtures",
+      glob: "**/*.ts",
+      literal: true,
+      ignoreCase: true,
+      context: 0,
+      summary: true,
+      scope: "symbol",
+      scopeContext: 2,
+    })).toEqual(descriptor);
+    expect(JSON.parse(JSON.stringify(descriptor))).toEqual(descriptor);
+    expect((descriptor.input as any).limit).toBeUndefined();
+    expect((descriptor.input as any).signal).toBeUndefined();
+    expect((descriptor.input as any).cwd).toBeUndefined();
+    expect((descriptor.input as any).renderedOutput).toBeUndefined();
+  });
+});

--- a/tests/context-hygiene-rehydrate-metadata.test.ts
+++ b/tests/context-hygiene-rehydrate-metadata.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildContextHygieneMetadata,
+  buildFileResource,
+  buildReadRehydrateDescriptor,
+  createContextHygieneTracker,
+} from "../src/context-hygiene.js";
+
+describe("context hygiene rehydrate metadata", () => {
+  it("carries optional rehydrate descriptors beside required metadata fields", () => {
+    const resource = buildFileResource("src/read.ts");
+    const descriptor = buildReadRehydrateDescriptor({ path: "src/read.ts", offset: 1 });
+
+    const metadata = buildContextHygieneMetadata({
+      tool: "read",
+      classification: "read-context",
+      resources: [resource],
+      rehydrate: descriptor,
+    });
+
+    expect(metadata).toEqual({
+      schemaVersion: 1,
+      tool: "read",
+      classification: "read-context",
+      resources: [resource],
+      rehydrate: { tool: "read", input: { path: "src/read.ts", offset: 1 } },
+    });
+    expect((metadata as any).ptcValue).toBeUndefined();
+
+    descriptor.input.path = "src/other.ts";
+    expect(metadata.rehydrate).toEqual({ tool: "read", input: { path: "src/read.ts", offset: 1 } });
+
+    const tracker = createContextHygieneTracker();
+    const event = tracker.record(metadata, { resultId: "read-result-1" });
+    expect(event.rehydrate).toEqual({ tool: "read", input: { path: "src/read.ts", offset: 1 } });
+  });
+});

--- a/tests/context-hygiene-rehydrate-read.test.ts
+++ b/tests/context-hygiene-rehydrate-read.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { buildReadRehydrateDescriptor } from "../src/context-hygiene.js";
+
+describe("read rehydrate descriptors", () => {
+  it("preserves safe read inputs deterministically and omits undefined defaults", () => {
+    expect(buildReadRehydrateDescriptor({
+      path: "src/read.ts",
+      offset: undefined,
+      limit: undefined,
+      map: false,
+    })).toEqual({
+      tool: "read",
+      input: { path: "src/read.ts" },
+    });
+
+    const ranged = buildReadRehydrateDescriptor({
+      path: "src/read.ts",
+      offset: 10,
+      limit: 5,
+    });
+    expect(ranged).toEqual({
+      tool: "read",
+      input: { path: "src/read.ts", offset: 10, limit: 5 },
+    });
+    expect(buildReadRehydrateDescriptor({ path: "src/read.ts", offset: 10, limit: 5 })).toEqual(ranged);
+    expect(JSON.parse(JSON.stringify(ranged))).toEqual(ranged);
+
+    expect(buildReadRehydrateDescriptor({
+      path: "src/read-output.ts",
+      symbol: "buildReadOutput",
+      bundle: "local",
+    })).toEqual({
+      tool: "read",
+      input: { path: "src/read-output.ts", symbol: "buildReadOutput", bundle: "local" },
+    });
+
+    expect(buildReadRehydrateDescriptor({
+      path: "src/read-output.ts",
+      map: true,
+      signal: new AbortController().signal,
+      cwd: { value: process.cwd() },
+      renderedOutput: "1:abc|content",
+    } as any)).toEqual({
+      tool: "read",
+      input: { path: "src/read-output.ts", map: true },
+    });
+  });
+});

--- a/tests/context-hygiene-rehydrate-sg.test.ts
+++ b/tests/context-hygiene-rehydrate-sg.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { buildAstSearchRehydrateDescriptor } from "../src/context-hygiene.js";
+
+describe("ast_search rehydrate descriptors", () => {
+  it("preserves safe ast_search inputs deterministically and omits undefined defaults", () => {
+    expect(buildAstSearchRehydrateDescriptor({
+      pattern: "console.log($A)",
+      lang: undefined,
+      path: undefined,
+    })).toEqual({
+      tool: "ast_search",
+      input: { pattern: "console.log($A)" },
+    });
+
+    const descriptor = buildAstSearchRehydrateDescriptor({
+      pattern: "export function $NAME($$$ARGS) { $$$BODY }",
+      lang: "typescript",
+      path: "src",
+      signal: new AbortController().signal,
+      cwd: { value: process.cwd() },
+      renderedOutput: "rendered ast_search output",
+    } as any);
+
+    expect(descriptor).toEqual({
+      tool: "ast_search",
+      input: {
+        pattern: "export function $NAME($$$ARGS) { $$$BODY }",
+        lang: "typescript",
+        path: "src",
+      },
+    });
+    expect(buildAstSearchRehydrateDescriptor({
+      pattern: "export function $NAME($$$ARGS) { $$$BODY }",
+      lang: "typescript",
+      path: "src",
+    })).toEqual(descriptor);
+    expect(JSON.parse(JSON.stringify(descriptor))).toEqual(descriptor);
+    expect((descriptor.input as any).signal).toBeUndefined();
+    expect((descriptor.input as any).cwd).toBeUndefined();
+    expect((descriptor.input as any).renderedOutput).toBeUndefined();
+  });
+});

--- a/tests/context-hygiene-sg.test.ts
+++ b/tests/context-hygiene-sg.test.ts
@@ -92,6 +92,7 @@ describe("ast_search contextHygiene metadata", () => {
 
     const result = await callSgTool({
       pattern: "export function $NAME($$$PARAMS) { $$$BODY }",
+      lang: "typescript",
       path: filePath,
     });
 
@@ -100,6 +101,14 @@ describe("ast_search contextHygiene metadata", () => {
       tool: "ast_search",
       classification: "search-context",
       resources: [buildFileResource(filePath)],
+      rehydrate: {
+        tool: "ast_search",
+        input: {
+          pattern: "export function $NAME($$$PARAMS) { $$$BODY }",
+          lang: "typescript",
+          path: filePath,
+        },
+      },
     });
     expect((result.details?.ptcValue as any).contextHygiene).toBeUndefined();
     expect(result.details?.ptcValue.files[0]).toMatchObject({

--- a/tests/context-hygiene-stale-contract.test.ts
+++ b/tests/context-hygiene-stale-contract.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { buildStaleContextRecord } from "../src/context-hygiene.js";
+
+describe("context hygiene stale result contract", () => {
+  it("builds an explicit stale invalidation record with original and mutation metadata", () => {
+    const rehydrate = {
+      tool: "read" as const,
+      input: { path: "src/read.ts", offset: 10, limit: 5 },
+    };
+
+    const record = buildStaleContextRecord({
+      originalTool: "read",
+      originalResultId: "read-result-1",
+      staleResourceKeys: ["file:src/read.ts", "file:src/read.ts"],
+      invalidatingMutationEventId: 42,
+      invalidatingMutationResultId: "edit-result-1",
+      rehydrate,
+    });
+
+    expect(record).toEqual({
+      status: "stale",
+      originalTool: "read",
+      originalResultId: "read-result-1",
+      staleResourceKeys: ["file:src/read.ts"],
+      invalidatingMutationEventId: 42,
+      invalidatingMutationResultId: "edit-result-1",
+      reason: "mutation-after-read",
+      rehydrate,
+    });
+    expect((record as any).state).toBeUndefined();
+    expect((record as any).retired).toBeUndefined();
+  });
+});

--- a/tests/context-hygiene-stale-placeholders.test.ts
+++ b/tests/context-hygiene-stale-placeholders.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { buildStaleContextRecord, renderStaleContextPlaceholder } from "../src/context-hygiene.js";
+
+describe("context hygiene stale placeholders", () => {
+  it("renders deterministic stale placeholders for read grep and ast_search records", () => {
+    const records = [
+      buildStaleContextRecord({
+        originalTool: "read",
+        originalResultId: "read-result-1",
+        staleResourceKeys: ["file:src/read.ts"],
+        invalidatingMutationEventId: 7,
+        invalidatingMutationResultId: "edit-result-1",
+      }),
+      buildStaleContextRecord({
+        originalTool: "grep",
+        originalResultId: "grep-result-1",
+        staleResourceKeys: ["file:src/grep.ts"],
+        invalidatingMutationEventId: 8,
+        invalidatingMutationResultId: "write-result-1",
+      }),
+      buildStaleContextRecord({
+        originalTool: "ast_search",
+        originalResultId: "sg-result-1",
+        staleResourceKeys: ["file:src/sg.ts"],
+        invalidatingMutationEventId: 9,
+      }),
+    ];
+
+    const firstRender = records.map(renderStaleContextPlaceholder);
+    const secondRender = records.map(renderStaleContextPlaceholder);
+
+    expect(firstRender).toEqual([
+      "[Stale read context: file content changed after this result. Re-run read to refresh.]",
+      "[Stale grep context: matched file content changed after this result. Re-run grep to refresh.]",
+      "[Stale ast_search context: matched file content changed after this result. Re-run ast_search to refresh.]",
+    ]);
+    expect(secondRender).toEqual(firstRender);
+
+    for (const placeholder of firstRender) {
+      expect(placeholder.toLowerCase()).toContain("stale");
+      expect(placeholder.toLowerCase()).not.toContain("retired");
+      expect(placeholder).not.toContain("read-result-1");
+      expect(placeholder).not.toContain("grep-result-1");
+      expect(placeholder).not.toContain("sg-result-1");
+      expect(placeholder).not.toMatch(/\b\d{4}-\d{2}-\d{2}\b/);
+      expect(placeholder).not.toMatch(/\bmutation event\b/i);
+    }
+  });
+});

--- a/tests/context-hygiene-tracker.test.ts
+++ b/tests/context-hygiene-tracker.test.ts
@@ -3,6 +3,7 @@ import {
   buildCommandResource,
   buildContextHygieneMetadata,
   buildFileResource,
+  buildReadRehydrateDescriptor,
   createContextHygieneTracker,
   getContextHygieneTracker,
   resetContextHygieneTracker,
@@ -12,6 +13,7 @@ describe("context hygiene telemetry tracker", () => {
   it("reports reuse, reruns, mutation staleness, retirement candidates, and churn deterministically", () => {
     const fileResource = buildFileResource("src/read.ts");
     const commandResource = buildCommandResource("npm test");
+    const readRehydrate = buildReadRehydrateDescriptor({ path: "src/read.ts", symbol: "buildReadOutput" });
     const tracker = createContextHygieneTracker();
 
     tracker.record(
@@ -19,6 +21,7 @@ describe("context hygiene telemetry tracker", () => {
         tool: "read",
         classification: "read-context",
         resources: [fileResource],
+        rehydrate: readRehydrate,
       }),
       { resultId: "read-1" },
     );
@@ -87,6 +90,29 @@ describe("context hygiene telemetry tracker", () => {
           staleEventIds: [1, 2],
           mutationEventId: 3,
           reason: "mutation-after-read",
+          staleResults: [
+            {
+              status: "stale",
+              originalTool: "read",
+              originalEventId: 1,
+              originalResultId: "read-1",
+              staleResourceKeys: ["file:src/read.ts"],
+              invalidatingMutationEventId: 3,
+              invalidatingMutationResultId: "edit-1",
+              reason: "mutation-after-read",
+              rehydrate: readRehydrate,
+            },
+            {
+              status: "stale",
+              originalTool: "read",
+              originalEventId: 2,
+              originalResultId: "read-2",
+              staleResourceKeys: ["file:src/read.ts"],
+              invalidatingMutationEventId: 3,
+              invalidatingMutationResultId: "edit-1",
+              reason: "mutation-after-read",
+            },
+          ],
         },
       ],
       retirementCandidates: [

--- a/tests/read-output.test.ts
+++ b/tests/read-output.test.ts
@@ -100,6 +100,10 @@ describe("buildReadOutput", () => {
         appended: false,
         text: null,
       },
+      rehydrate: {
+        tool: "read",
+        input: { path: filePath },
+      },
     });
     expect(getTextContent(result)).toBe(built.text);
     expect(result.details?.ptcValue).toEqual(built.ptcValue);


### PR DESCRIPTION
## Summary

This PR implements the Phase 1 Batch A foundation for context hygiene semantic invalidation.

It adds explicit stale-result metadata and safe rehydration metadata for file-context tools, without changing live rendered output or existing `ptcValue` contracts. This prepares later batches to replace or annotate stale prior context after same-file mutations.

## What changed

- Added typed stale-result records for mutation-after-read invalidation:
  - original tool/result metadata
  - stale resource keys
  - invalidating mutation event/result metadata
  - explicit `status: "stale"`
  - optional rehydrate descriptor

- Added deterministic stale placeholder rendering for:
  - `read`
  - `grep`
  - `ast_search`

- Added safe rehydrate descriptor builders for:
  - `read`: `path`, `offset`, `limit`, `symbol`, `map`, `bundle`
  - `grep`: `pattern`, `path`, `glob`, `literal`, `ignoreCase`, `context`, `summary`, `scope`, `scopeContext`
  - `ast_search`: `pattern`, `lang`, `path`

- Attached rehydrate metadata through `details.contextHygiene` for successful `read`, `grep`, and `ast_search` results.

- Extended the debug-only `context_hygiene_report` output so stale candidates can include full stale records and rehydrate metadata when available.

## Compatibility notes

- `CONTEXT_HYGIENE_SCHEMA_VERSION` remains `1`; this is an additive metadata change.
- Existing rendered output for `read`, `grep`, and `ast_search` is unchanged.
- Existing `ptcValue` contracts are unchanged.
- Context hygiene metadata remains beside `ptcValue`, not nested inside it.
- No automatic stale replacement, context mutation, or tool re-running is introduced in this PR.

## Verification

- `npm test`
- `npm run typecheck`

Both pass.

## Follow-up work

This PR only defines and carries the stale/rehydrate contract. Later Phase 1 batches will use this foundation to:

- mark prior `read`, `grep`, and `ast_search` results stale after same-file mutations
- wire stale records into the Pi context replacement boundary
- add transcript-level regression coverage and user-facing docs

Closes #126  
Closes #127