### PR TITLE
feat: stricter configurable grep output budgets (#136)

### DIFF
--- a/src/grep-budget.ts
+++ b/src/grep-budget.ts
@@ -1,0 +1,67 @@
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "@mariozechner/pi-coding-agent";
+
+const POSITIVE_BASE10_INT = /^[1-9][0-9]*$/;
+
+/**
+ * Strict positive base-10 integer parser used by hashline env knobs.
+ *
+ * Accepts: trimmed strings matching /^[1-9][0-9]*$/ that parse to a finite
+ * positive integer.
+ *
+ * Rejects: undefined, empty, whitespace-only, "0", negative, signed, hex
+ * ("0x10"), exponent ("1e3"), decimal ("3.14"), separators ("1,000" /
+ * "1_000"), embedded whitespace ("5 5").
+ *
+ * Returns `undefined` on rejection; never throws.
+ */
+export function parsePositiveBase10Int(raw: string | undefined | null): number | undefined {
+	if (raw === undefined || raw === null) return undefined;
+	const trimmed = String(raw).trim();
+	if (!POSITIVE_BASE10_INT.test(trimmed)) return undefined;
+	const parsed = Number.parseInt(trimmed, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+	return parsed;
+}
+
+export interface GrepOutputBudget {
+	maxLines: number;
+	maxBytes: number;
+}
+
+/**
+ * Effective grep-output ceilings used as clamp upper bounds and as the
+ * fallback defaults when env vars are unset/invalid.
+ *
+ * The bytes ceiling is the already-tightened 50 KiB used by `buildGrepOutput`
+ * today, NOT the unclamped `DEFAULT_MAX_BYTES`.
+ */
+export const GREP_OUTPUT_DEFAULT_MAX_LINES = DEFAULT_MAX_LINES;
+export const GREP_OUTPUT_DEFAULT_MAX_BYTES = Math.min(DEFAULT_MAX_BYTES, 50 * 1024);
+
+function resolveDimension(rawEnvValue: string | undefined, ceiling: number): number {
+	const parsed = parsePositiveBase10Int(rawEnvValue);
+	if (parsed === undefined) return ceiling;
+	return Math.min(parsed, ceiling);
+}
+
+/**
+ * Resolve the effective grep visible-output budget. Re-reads `process.env`
+ * on every call (no memoization) so tests and long-lived agent sessions can
+ * change the env vars dynamically.
+ *
+ * Invalid / zero / negative env values fall back to the current defaults.
+ * Above-default values clamp to the current defaults. Below-default values
+ * are used as-is.
+ */
+export function resolveGrepOutputBudget(): GrepOutputBudget {
+	return {
+		maxLines: resolveDimension(
+			process.env.PI_HASHLINE_GREP_MAX_LINES,
+			GREP_OUTPUT_DEFAULT_MAX_LINES,
+		),
+		maxBytes: resolveDimension(
+			process.env.PI_HASHLINE_GREP_MAX_BYTES,
+			GREP_OUTPUT_DEFAULT_MAX_BYTES,
+		),
+	};
+}

--- a/src/grep-output.ts
+++ b/src/grep-output.ts
@@ -1,10 +1,9 @@
 import type { PtcLine, PtcWarning } from "./ptc-value.js";
 import {
-  DEFAULT_MAX_BYTES,
-  DEFAULT_MAX_LINES,
   formatSize,
   truncateHead,
 } from "@mariozechner/pi-coding-agent";
+import { resolveGrepOutputBudget } from "./grep-budget.js";
 import {
   buildContextHygieneMetadata,
   buildFileResource,
@@ -152,9 +151,10 @@ export function buildGrepOutput(input: BuildGrepOutputInput): GrepOutputResult {
   if (!input.summary && input.scopeMode === "symbol" && (input.scopeWarnings?.length ?? 0) > 0) {
     text = `${input.scopeWarnings!.map((warning) => warning.message).join("\n\n")}\n\n${text}`;
   }
+  const budget = resolveGrepOutputBudget();
   const truncated = truncateHead(text, {
-    maxLines: DEFAULT_MAX_LINES,
-    maxBytes: Math.min(DEFAULT_MAX_BYTES, 50 * 1024),
+    maxLines: budget.maxLines,
+    maxBytes: budget.maxBytes,
   });
   if (truncated.truncated) {
     text = `${truncated.content}\n\n[Output truncated: showing ${truncated.outputLines} of ${truncated.totalLines} lines (${formatSize(truncated.outputBytes)} of ${formatSize(truncated.totalBytes)}). Refine pattern or increase limit.]`;

--- a/tests/grep-budget.test.ts
+++ b/tests/grep-budget.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "@mariozechner/pi-coding-agent";
+import { resolveGrepOutputBudget, parsePositiveBase10Int } from "../src/grep-budget.js";
+
+const LINES_DEFAULT = DEFAULT_MAX_LINES; // 2000
+const BYTES_DEFAULT = Math.min(DEFAULT_MAX_BYTES, 50 * 1024); // 51200
+
+describe("parsePositiveBase10Int", () => {
+	it("accepts plain positive base-10 integer strings", () => {
+		expect(parsePositiveBase10Int("1")).toBe(1);
+		expect(parsePositiveBase10Int("500")).toBe(500);
+		expect(parsePositiveBase10Int("32768")).toBe(32768);
+	});
+
+	it("trims surrounding whitespace before validating", () => {
+		expect(parsePositiveBase10Int(" 500 ")).toBe(500);
+		expect(parsePositiveBase10Int("\t42\n")).toBe(42);
+	});
+
+	it("rejects non-positive-base-10 inputs", () => {
+		const rejects: Array<string | undefined> = [
+			undefined,
+			"",
+			" ",
+			"0",
+			"-5",
+			"+5",
+			"abc",
+			"3.14",
+			"0x10",
+			"1e3",
+			"1,000",
+			"1_000",
+			"5 5",
+		];
+		for (const value of rejects) {
+			expect(parsePositiveBase10Int(value)).toBeUndefined();
+		}
+	});
+});
+
+describe("resolveGrepOutputBudget", () => {
+	const SAVED: { lines: string | undefined; bytes: string | undefined } = {
+		lines: process.env.PI_HASHLINE_GREP_MAX_LINES,
+		bytes: process.env.PI_HASHLINE_GREP_MAX_BYTES,
+	};
+
+	beforeEach(() => {
+		delete process.env.PI_HASHLINE_GREP_MAX_LINES;
+		delete process.env.PI_HASHLINE_GREP_MAX_BYTES;
+	});
+
+	afterEach(() => {
+		if (SAVED.lines === undefined) delete process.env.PI_HASHLINE_GREP_MAX_LINES;
+		else process.env.PI_HASHLINE_GREP_MAX_LINES = SAVED.lines;
+		if (SAVED.bytes === undefined) delete process.env.PI_HASHLINE_GREP_MAX_BYTES;
+		else process.env.PI_HASHLINE_GREP_MAX_BYTES = SAVED.bytes;
+	});
+
+	it("returns current defaults when both env vars are unset", () => {
+		expect(resolveGrepOutputBudget()).toEqual({
+			maxLines: LINES_DEFAULT,
+			maxBytes: BYTES_DEFAULT,
+		});
+	});
+
+	it("uses a valid below-default lines value as-is", () => {
+		process.env.PI_HASHLINE_GREP_MAX_LINES = "10";
+		expect(resolveGrepOutputBudget()).toEqual({
+			maxLines: 10,
+			maxBytes: BYTES_DEFAULT,
+		});
+	});
+
+	it("uses a valid below-default bytes value as-is", () => {
+		process.env.PI_HASHLINE_GREP_MAX_BYTES = "1024";
+		expect(resolveGrepOutputBudget()).toEqual({
+			maxLines: LINES_DEFAULT,
+			maxBytes: 1024,
+		});
+	});
+
+	it("clamps above-default lines values to the default", () => {
+		process.env.PI_HASHLINE_GREP_MAX_LINES = "99999";
+		expect(resolveGrepOutputBudget().maxLines).toBe(LINES_DEFAULT);
+	});
+
+	it("clamps above-default bytes values to the default", () => {
+		process.env.PI_HASHLINE_GREP_MAX_BYTES = "104857600"; // 100 MiB
+		expect(resolveGrepOutputBudget().maxBytes).toBe(BYTES_DEFAULT);
+	});
+
+	it.each(["abc", "-5", "0", "3.14", "", " ", "0x10", "1e3", "1,000", "+5"])(
+		"falls back to defaults for invalid value %j",
+		(raw) => {
+			process.env.PI_HASHLINE_GREP_MAX_LINES = raw;
+			process.env.PI_HASHLINE_GREP_MAX_BYTES = raw;
+			expect(resolveGrepOutputBudget()).toEqual({
+				maxLines: LINES_DEFAULT,
+				maxBytes: BYTES_DEFAULT,
+			});
+		},
+	);
+
+	it("treats the two env vars independently", () => {
+		process.env.PI_HASHLINE_GREP_MAX_LINES = "50";
+		expect(resolveGrepOutputBudget()).toEqual({
+			maxLines: 50,
+			maxBytes: BYTES_DEFAULT,
+		});
+	});
+
+	it("re-reads env on each call (no memoization)", () => {
+		expect(resolveGrepOutputBudget().maxLines).toBe(LINES_DEFAULT);
+		process.env.PI_HASHLINE_GREP_MAX_LINES = "7";
+		expect(resolveGrepOutputBudget().maxLines).toBe(7);
+		delete process.env.PI_HASHLINE_GREP_MAX_LINES;
+		expect(resolveGrepOutputBudget().maxLines).toBe(LINES_DEFAULT);
+	});
+
+	it("equals default when value equals default exactly", () => {
+		process.env.PI_HASHLINE_GREP_MAX_LINES = String(LINES_DEFAULT);
+		process.env.PI_HASHLINE_GREP_MAX_BYTES = String(BYTES_DEFAULT);
+		expect(resolveGrepOutputBudget()).toEqual({
+			maxLines: LINES_DEFAULT,
+			maxBytes: BYTES_DEFAULT,
+		});
+	});
+});

--- a/tests/grep-output-budget-env.test.ts
+++ b/tests/grep-output-budget-env.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerGrepTool } from "../src/grep.js";
+
+function getText(result: any): string {
+	return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+async function callGrep(params: {
+	pattern: string;
+	path: string;
+	literal?: boolean;
+	limit?: number;
+}) {
+	let capturedTool: any = null;
+	registerGrepTool({ registerTool(def: any) { capturedTool = def; } } as any);
+	if (!capturedTool) throw new Error("grep tool was not registered");
+	return capturedTool.execute(
+		"test-call",
+		params,
+		new AbortController().signal,
+		() => {},
+		{ cwd: process.cwd() },
+	);
+}
+
+function makeFixture(): string {
+	// 12 files, 10 matching lines each → 120 matches. Each line is ~80 bytes.
+	// Sized below default budgets (2000 lines / 50 KiB) so truncation can only
+	// fire via the env knob.
+	const dir = mkdtempSync(join(tmpdir(), "pi-grep-budget-env-"));
+	const line = "needle " + "x".repeat(60);
+	for (let i = 0; i < 12; i++) {
+		const filePath = join(dir, `file-${String(i + 1).padStart(2, "0")}.txt`);
+		writeFileSync(filePath, Array.from({ length: 10 }, () => line).join("\n"), "utf8");
+	}
+	return dir;
+}
+
+describe("grep output budget env vars", () => {
+	const SAVED: { lines: string | undefined; bytes: string | undefined } = {
+		lines: process.env.PI_HASHLINE_GREP_MAX_LINES,
+		bytes: process.env.PI_HASHLINE_GREP_MAX_BYTES,
+	};
+
+	beforeEach(() => {
+		delete process.env.PI_HASHLINE_GREP_MAX_LINES;
+		delete process.env.PI_HASHLINE_GREP_MAX_BYTES;
+	});
+
+	afterEach(() => {
+		if (SAVED.lines === undefined) delete process.env.PI_HASHLINE_GREP_MAX_LINES;
+		else process.env.PI_HASHLINE_GREP_MAX_LINES = SAVED.lines;
+		if (SAVED.bytes === undefined) delete process.env.PI_HASHLINE_GREP_MAX_BYTES;
+		else process.env.PI_HASHLINE_GREP_MAX_BYTES = SAVED.bytes;
+	});
+
+	it("does not truncate small fixture by default", async () => {
+		const dir = makeFixture();
+		const result = await callGrep({ pattern: "needle", path: dir, literal: true, limit: 200 });
+		const text = getText(result);
+		expect(text).not.toContain("[Output truncated:");
+	});
+
+	it("truncates earlier when PI_HASHLINE_GREP_MAX_LINES is small", async () => {
+		const dir = makeFixture();
+		process.env.PI_HASHLINE_GREP_MAX_LINES = "10";
+		const result = await callGrep({ pattern: "needle", path: dir, literal: true, limit: 200 });
+		const text = getText(result);
+		expect(text).toContain("[Output truncated:");
+		expect(text).toContain("Refine pattern or increase limit.]");
+	});
+
+	it("truncates earlier when PI_HASHLINE_GREP_MAX_BYTES is small", async () => {
+		const dir = makeFixture();
+		process.env.PI_HASHLINE_GREP_MAX_BYTES = "1024";
+		const result = await callGrep({ pattern: "needle", path: dir, literal: true, limit: 200 });
+		const text = getText(result);
+		expect(text).toContain("[Output truncated:");
+	});
+
+	it.each(["abc", "-5", "0", "3.14", "", "0x10", "1e3", "1,000", "+5"])(
+		"falls back to defaults for invalid value %j",
+		async (raw) => {
+			const dir = makeFixture();
+			process.env.PI_HASHLINE_GREP_MAX_LINES = raw;
+			process.env.PI_HASHLINE_GREP_MAX_BYTES = raw;
+			const result = await callGrep({ pattern: "needle", path: dir, literal: true, limit: 200 });
+			const text = getText(result);
+			expect(text).not.toContain("[Output truncated:");
+		},
+	);
+
+	it("clamps above-default lines/bytes to defaults (no expansion)", async () => {
+		const dir = makeFixture();
+		process.env.PI_HASHLINE_GREP_MAX_LINES = "99999";
+		process.env.PI_HASHLINE_GREP_MAX_BYTES = "104857600"; // 100 MiB
+		const result = await callGrep({ pattern: "needle", path: dir, literal: true, limit: 200 });
+		const text = getText(result);
+		// Same as "no env" baseline on this fixture: not truncated.
+		expect(text).not.toContain("[Output truncated:");
+	});
+
+	it("accepts whitespace-padded values", async () => {
+		const dir = makeFixture();
+		process.env.PI_HASHLINE_GREP_MAX_LINES = " 10 ";
+		const result = await callGrep({ pattern: "needle", path: dir, literal: true, limit: 200 });
+		const text = getText(result);
+		expect(text).toContain("[Output truncated:");
+	});
+
+	it("treats the two env vars independently when only lines is set", async () => {
+		const dir = makeFixture();
+		process.env.PI_HASHLINE_GREP_MAX_LINES = "10";
+		// bytes left unset
+		const result = await callGrep({ pattern: "needle", path: dir, literal: true, limit: 200 });
+		const text = getText(result);
+		expect(text).toContain("[Output truncated:");
+	});
+});


### PR DESCRIPTION
## Summary

Adds two opt-in environment variables that let users tighten the final visible
grep output budgets without changing default behavior:

- `PI_HASHLINE_GREP_MAX_LINES` — caps rendered line count
- `PI_HASHLINE_GREP_MAX_BYTES` — caps rendered byte count

Both vars can only **narrow** today's caps — they cannot expand them. Defaults
are byte-for-byte unchanged when both vars are unset.

## Behavior

- **Valid value**: positive base-10 integer string (after trim), e.g. \`\"500\"\`,
  \`\" 32768 \"\`. Strict regex \`/^[1-9][0-9]*$/\`.
- **Invalid / zero / negative** values silently fall back to current defaults.
- **Above-default** values clamp down via \`Math.min(parsed, defaultCeiling)\`.
- **Below-default** values are used as-is.
- Limits apply **only** to the final \`truncateHead\` call in \`buildGrepOutput\` —
  per-file match caps, scope handling, IR truncation, and per-line escaping
  are unchanged.
- The existing \`[Output truncated: showing X of Y lines (… of …). Refine
  pattern or increase limit.]\` notice format is reused exactly.

## Why

Source: GitHub issue #56 (M5 hashline + pi-ptc-next integration), part A.
Users want a way to tighten grep's final output budget for tighter context
hygiene in long agent sessions, without expanding context usage anywhere.

## Out of scope (deferred)

- Metadata signaling that an env override is active
  (\`details.budgetSource\`, \`ptcValue.budgetOverride\`, etc.)
- Configurable per-file match caps or the global match threshold
- Equivalent env knobs for \`read\`, \`ast_search\`, or \`bash\`
- Non-\`process.env\` configuration channels

## Files

- \`src/grep-budget.ts\` (new) — \`parsePositiveBase10Int\` strict parser,
  \`resolveGrepOutputBudget\` resolver with fallback + clamp.
- \`src/grep-output.ts\` — single 4-line edit in \`buildGrepOutput\`: replace
  hardcoded \`truncateHead\` budget with \`resolveGrepOutputBudget()\`.
- \`tests/grep-budget.test.ts\` (new, 21 tests) — unit coverage of parser
  and resolver with strict reject table and env-restoration discipline.
- \`tests/grep-output-budget-env.test.ts\` (new, 15 tests) — end-to-end
  tests through \`registerGrepTool\` with deterministic temp fixture sized
  below default ceilings.

## Verification

- \`npm test\` — **234 files, 1146/1146 tests passing**.
- \`npm run typecheck\` — clean.
- Existing \`tests/grep-output-budget.test.ts\` (default-behavior regression)
  still green.

## Risks

Minimal. Single 4-line change at one call site; default behavior preserved
when env vars are unset.