### PR TITLE
docs: refresh release documentation for 0.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ yarn-error.log*
 # pi agent local state
 .megapowers/
 .pi/
+runs/workguards/
 
 # Local workspace / planning docs
 .zellij*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.8.0] - 2026-04-28
+
+### Added
+- Opt-in `grep` final output budget controls via `PI_HASHLINE_GREP_MAX_LINES` and `PI_HASHLINE_GREP_MAX_BYTES`; values can only tighten existing defaults and invalid values fall back safely.
+- Phase 0 context-hygiene metadata for read, search, command-output, and mutation tool results, including an opt-in `context_hygiene_report` debug tool behind `PI_CONTEXT_HYGIENE_DEBUG=1`.
+- Stale-context contract foundations for mutated-file context tracking and downstream context replacement work.
+
+### Fixed
+- `edit`: restore the default shell rendering path.
+- `edit`: preserve blank lines in `replace_lines` wrapped-line restoration.
+- Structural map cache: validate content hashes on in-memory cache hits to avoid stale maps.
+
+### Docs
+- Refresh README configuration, context-hygiene, release, and documentation links for the current codebase.
+- Update exploratory functional testing notes for the current suite size and coverage areas.
+
 ## [0.7.0] - 2026-04-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This package consolidates those improvements into one extension instead of stack
 - Agent-optimized `ls` and `find` tools for file exploration
 - Optional `nu` tool for structured exploration with Nushell
 - Route-aware `bash` compression for tests, builds, Git, Docker, linters, package managers, and more
+- Context-hygiene metadata for read/search/command/mutation outputs, plus an opt-in debug report tool
 
 ## Quick Start
 
@@ -238,6 +239,8 @@ Use the bypass when the filtered output hides information you need.
 - supports literal or regex search
 - supports `summary: true` for per-file match counts
 - supports `scope: "symbol"` and `scopeContext` for symbol-local results
+- supports opt-in final visible output budgets with `PI_HASHLINE_GREP_MAX_LINES` and `PI_HASHLINE_GREP_MAX_BYTES`
+
 ### `ast_search`
 - wraps `ast-grep` for structure-aware code search
 - returns merged, anchored match blocks grouped by file
@@ -277,11 +280,14 @@ This package is configured with environment variables rather than a project-loca
 
 | Variable | Purpose | Default / behavior |
 |---|---|---|
+| `PI_HASHLINE_GREP_MAX_LINES` | Tighten `grep`'s final visible line budget | Positive base-10 integer; invalid/unset values use the built-in default; above-default values are clamped down |
+| `PI_HASHLINE_GREP_MAX_BYTES` | Tighten `grep`'s final visible byte budget | Positive base-10 integer; invalid/unset values use the built-in default; above-default values are clamped down |
 | `PI_HASHLINE_MAP_CACHE_DIR` | Override the persistent structural-map cache directory | Uses the provided path verbatim |
 | `XDG_CACHE_HOME` | Base directory for the persistent map cache when no explicit cache dir is set | Cache lives under `$XDG_CACHE_HOME/pi-hashline-readmap/maps` |
 | `PI_HASHLINE_NO_PERSIST_MAPS=1` | Disable the on-disk structural-map cache | Keeps caching in-memory only |
 | `PI_NUSHELL_CONFIG` | Override the Nushell config path used by `nu` | Otherwise prefers `~/.config/pi/nushell/config.nu`, then `--no-config-file` |
 | `PI_RTK_BYPASS=1` | Disable route-specific `bash` compression for one command invocation | ANSI is still stripped; anti-pattern hints still apply |
+| `PI_CONTEXT_HYGIENE_DEBUG=1` | Register the debug-only `context_hygiene_report` read-only tool | Disabled unless explicitly set to `1` |
 
 ## Structured output (`details.ptcValue`)
 
@@ -345,11 +351,17 @@ Policy summary:
 - `edit` is not safe-by-default and is mutating
 - `pi-prompt-assembler` may optionally consume this contract
 
+## Context hygiene metadata
+
+Tool results include additive `details.contextHygiene` metadata that classifies context as read, search, command output, or mutation context. This metadata is intended for downstream session/context-management integrations and does not change the visible tool output contract.
+
+When `PI_CONTEXT_HYGIENE_DEBUG=1` is set before starting pi, the extension also registers `context_hygiene_report`, a debug-only read-only tool that reports tracked context-hygiene resources, stale candidates, and retirement candidates without mutating tracker state.
+
 ## EventBus integration
 
 On load, the extension emits tool executor references for downstream consumers.
 
-The emitted/stashed executor surface always includes `read`, `edit`, `grep`, `ast_search`, `write`, `ls`, and `find`, plus `nu` when Nushell is available at runtime.
+The emitted/stashed executor surface always includes `read`, `edit`, `grep`, `ast_search`, `write`, `ls`, and `find`, plus `nu` when Nushell is available at runtime and `context_hygiene_report` when `PI_CONTEXT_HYGIENE_DEBUG=1`.
 
 ```ts
 pi.events.emit("hashline:tool-executors", {
@@ -361,6 +373,7 @@ pi.events.emit("hashline:tool-executors", {
   ls,
   find,
   ...(nu ? { nu } : {}),
+  ...(contextHygieneDebugTool ? { context_hygiene_report: contextHygieneDebugTool } : {}),
 });
 ```
 
@@ -400,6 +413,12 @@ npm install
 ```bash
 npm test
 npm run typecheck
+```
+
+Release candidates should also pass an npm package dry run:
+
+```bash
+npm pack --dry-run
 ```
 
 Before publishing or opening a PR, run the workspace checks above from a clean checkout and add any focused tests needed for the specific files or tools you changed.

--- a/docs/exploratory-functional-testing.md
+++ b/docs/exploratory-functional-testing.md
@@ -2,7 +2,7 @@
 
 Current repo snapshot note for `pi-hashline-readmap`.
 
-- Date: 2026-03-24
+- Date: 2026-04-28
 - Repo: `pi-hashline-readmap`
 - Scope: current expected behavior of the package, based on the present codebase and passing automated suite
 
@@ -19,7 +19,7 @@ Observed result:
 
 - `npm run typecheck` — passes
 - `npm test` — passes
-- Vitest suite: **107 test files / 524 tests** passing
+- Vitest suite: **234 test files / 1146 tests** passing
 
 This document is not a bug diary. It is the current testing reference for what the package is expected to do.
 
@@ -66,6 +66,7 @@ Expected behavior:
 - supports `ignoreCase`, `context`, `limit`, and `summary`
 - supports `scope: "symbol"` to group results by enclosing mapped symbol when available
 - truncates large result sets with explicit indicators instead of failing silently
+- supports opt-in final visible output budgets through `PI_HASHLINE_GREP_MAX_LINES` and `PI_HASHLINE_GREP_MAX_BYTES`
 - handles problematic file content defensively enough to avoid misleading raw output where possible
 
 Practical expectation:
@@ -98,6 +99,14 @@ Practical expectation:
 
 - common local development commands should consume less context than raw terminal output
 
+### Context hygiene metadata
+
+Expected behavior:
+
+- read/search/command/mutation tool results expose additive `details.contextHygiene` metadata
+- `context_hygiene_report` registers only when `PI_CONTEXT_HYGIENE_DEBUG=1`
+- debug reports are read-only and do not mutate tracker state
+
 ## Areas covered by the current automated suite
 
 The present test suite covers, at minimum:
@@ -112,6 +121,8 @@ The present test suite covers, at minimum:
 - map cache behavior
 - RTK / bash filter routing and compressor-specific behavior
 - public PTC policy/value contracts
+- context-hygiene metadata and debug-tool registration
+- configurable grep output budgets
 - README / prompts / scripts file integrity checks
 
 ## Manual spot-check guidance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Prepares the repository for the `0.8.0` release with a documentation audit, package version bump, and release-readiness updates.

This PR also documents release work that **partially addresses #56**: the grep side of the requested context-budget feature is now covered via configurable final visible output budgets. The bash context-budget/guard portion of #56 remains open for follow-up work.

## What changed

- Bumps `pi-hashline-readmap` from `0.7.0` to `0.8.0` in `package.json` and `package-lock.json`.
- Refreshes `README.md` to document the current codebase, including:
  - configurable grep output budgets via `PI_HASHLINE_GREP_MAX_LINES` and `PI_HASHLINE_GREP_MAX_BYTES` — partially addresses #56
  - context-hygiene metadata and the opt-in `context_hygiene_report` debug tool
  - updated EventBus executor surface notes
  - release validation guidance with `npm pack --dry-run`
- Adds a `0.8.0` changelog entry covering the recent grep budget, context-hygiene, stale-context foundation, edit, and map-cache work.
- Updates exploratory functional testing notes with the current suite size and coverage expectations.
- Ignores Workguard snapshot output at `runs/workguards/`.

## Issue coverage

- Partially addresses #56 by documenting and releasing the grep output-budget controls.
- Does not close #56; the bash context-budget design and implementation remain outstanding.

## Validation

- `npm run typecheck` — passed
- `npm test` — passed (`234` files, `1146` tests)
- `npm pack --dry-run` — passed for `pi-hashline-readmap@0.8.0`
