### PR TITLE
Add mutated-file stale context invalidation

### DIFF
--- a/src/context-hygiene.ts
+++ b/src/context-hygiene.ts
@@ -109,6 +109,7 @@ export type ContextHygieneStaleInvalidationReason = "mutation-after-read";
 export interface ContextHygieneStaleRecord {
   status: "stale";
   originalTool: string;
+  originalClassification?: ContextHygieneClassification;
   originalEventId?: number;
   originalResultId?: string;
   staleResourceKeys: string[];
@@ -120,6 +121,7 @@ export interface ContextHygieneStaleRecord {
 
 export interface BuildStaleContextRecordInput {
   originalTool: string;
+  originalClassification?: ContextHygieneClassification;
   originalEventId?: number;
   originalResultId?: string;
   staleResourceKeys: readonly string[];
@@ -150,6 +152,7 @@ export function buildStaleContextRecord(input: BuildStaleContextRecordInput): Co
     invalidatingMutationEventId: input.invalidatingMutationEventId,
     reason: input.reason ?? "mutation-after-read",
   };
+  if (input.originalClassification) record.originalClassification = input.originalClassification;
   if (input.originalEventId !== undefined) record.originalEventId = input.originalEventId;
   if (input.originalResultId) record.originalResultId = input.originalResultId;
   if (input.invalidatingMutationResultId) record.invalidatingMutationResultId = input.invalidatingMutationResultId;
@@ -561,6 +564,7 @@ class DefaultContextHygieneTracker implements ContextHygieneTracker {
   generateReport(): ContextHygieneReport {
     const eventsByResource = new Map<string, ContextHygieneEvent[]>();
     const readEventsByResource = new Map<string, ContextHygieneEvent[]>();
+    const staleableEventsByResource = new Map<string, ContextHygieneEvent[]>();
     const commandEventsByResource = new Map<string, ContextHygieneEvent[]>();
     const mutationEventsByResource = new Map<string, ContextHygieneEvent[]>();
     const byClassification = createEmptyClassificationCounts();
@@ -569,13 +573,20 @@ class DefaultContextHygieneTracker implements ContextHygieneTracker {
     for (const event of this.events) {
       byClassification[event.classification] += 1;
       byTool[event.tool] = (byTool[event.tool] ?? 0) + 1;
+      for (const resource of event.resources) {
+        if (event.classification === "read-context" || event.classification === "search-context") {
+          const staleableBucket = staleableEventsByResource.get(resource.key) ?? [];
+          staleableBucket.push(event);
+          staleableEventsByResource.set(resource.key, staleableBucket);
+        }
+      }
 
       for (const resource of event.resources) {
         const bucket = eventsByResource.get(resource.key) ?? [];
         bucket.push(event);
         eventsByResource.set(resource.key, bucket);
 
-        if (event.classification === "read-context" || event.classification === "search-context") {
+        if (event.classification === "read-context") {
           const readBucket = readEventsByResource.get(resource.key) ?? [];
           readBucket.push(event);
           readEventsByResource.set(resource.key, readBucket);
@@ -610,27 +621,32 @@ class DefaultContextHygieneTracker implements ContextHygieneTracker {
     const retirementCandidates: ContextHygieneRetirementCandidateReportEntry[] = [];
 
     for (const resourceKey of sortResourceKeys(mutationEventsByResource.keys())) {
-      const reads = readEventsByResource.get(resourceKey) ?? [];
+      const staleableEvents = staleableEventsByResource.get(resourceKey) ?? [];
       const mutations = mutationEventsByResource.get(resourceKey) ?? [];
       for (const mutation of mutations) {
-        const priorReads = reads.filter((read) => read.id < mutation.id);
-        const priorReadIds = priorReads.map((read) => read.id);
-        if (priorReadIds.length === 0) continue;
-        mutationAfterRead.push({ resourceKey, readEventIds: priorReadIds, mutationEventId: mutation.id });
+        const priorReads = (readEventsByResource.get(resourceKey) ?? []).filter((read) => read.id < mutation.id);
+        if (priorReads.length > 0) {
+          mutationAfterRead.push({ resourceKey, readEventIds: priorReads.map((read) => read.id), mutationEventId: mutation.id });
+        }
+
+        const priorStaleableEvents = staleableEvents.filter((event) => event.id < mutation.id);
+        const priorStaleableEventIds = priorStaleableEvents.map((event) => event.id);
+        if (priorStaleableEventIds.length === 0) continue;
         staleCandidates.push({
           resourceKey,
-          staleEventIds: priorReadIds,
+          staleEventIds: priorStaleableEventIds,
           mutationEventId: mutation.id,
           reason: "mutation-after-read",
-          staleResults: priorReads.map((read) => buildStaleContextRecord({
-            originalTool: read.tool,
-            originalEventId: read.id,
-            originalResultId: read.resultId,
+          staleResults: priorStaleableEvents.map((event) => buildStaleContextRecord({
+            originalTool: event.tool,
+            originalClassification: event.classification,
+            originalEventId: event.id,
+            originalResultId: event.resultId,
             staleResourceKeys: [resourceKey],
             invalidatingMutationEventId: mutation.id,
             invalidatingMutationResultId: mutation.resultId,
             reason: "mutation-after-read",
-            rehydrate: read.rehydrate,
+            rehydrate: event.rehydrate,
           })),
         });
       }
@@ -639,12 +655,7 @@ class DefaultContextHygieneTracker implements ContextHygieneTracker {
     for (const resourceKey of sortResourceKeys(commandEventsByResource.keys())) {
       const commands = commandEventsByResource.get(resourceKey) ?? [];
       for (let index = 1; index < commands.length; index += 1) {
-        retirementCandidates.push({
-          resourceKey,
-          eventIds: commands.slice(0, index).map((event) => event.id),
-          supersededByEventId: commands[index].id,
-          reason: "command-rerun",
-        });
+        retirementCandidates.push({ resourceKey, eventIds: commands.slice(0, index).map((event) => event.id), supersededByEventId: commands[index].id, reason: "command-rerun" });
       }
     }
 

--- a/tests/context-hygiene-debug-tool.test.ts
+++ b/tests/context-hygiene-debug-tool.test.ts
@@ -125,6 +125,7 @@ describe("context_hygiene_report debug tool", () => {
         {
           status: "stale",
           originalTool: "read",
+          originalClassification: "read-context",
           originalEventId: readEvent.id,
           originalResultId: "debug-tool-read-task9",
           staleResourceKeys: [fileResource.key],

--- a/tests/context-hygiene-mutated-file-read-stale.test.ts
+++ b/tests/context-hygiene-mutated-file-read-stale.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildContextHygieneMetadata,
+  buildFileResource,
+  buildReadRehydrateDescriptor,
+  createContextHygieneTracker,
+  renderStaleContextPlaceholder,
+} from "../src/context-hygiene.js";
+
+describe("context hygiene mutated-file read invalidation", () => {
+  it("reports an older same-file read context stale after an edit mutation", () => {
+    const tracker = createContextHygieneTracker();
+    const fileResource = buildFileResource("src/read.ts");
+    const readRehydrate = buildReadRehydrateDescriptor({ path: "src/read.ts", symbol: "buildReadOutput" });
+
+    tracker.record(buildContextHygieneMetadata({ tool: "read", classification: "read-context", resources: [fileResource], rehydrate: readRehydrate }), { resultId: "read-before" });
+    tracker.record(buildContextHygieneMetadata({ tool: "edit", classification: "mutation", resources: [fileResource] }), { resultId: "edit-file" });
+
+    const report = tracker.generateReport();
+    expect(report.staleCandidates).toHaveLength(1);
+    expect(report.staleCandidates[0]).toMatchObject({ resourceKey: "file:src/read.ts", staleEventIds: [1], mutationEventId: 2, reason: "mutation-after-read" });
+    expect(report.staleCandidates[0].staleResults).toEqual([
+      {
+        status: "stale",
+        originalTool: "read",
+        originalClassification: "read-context",
+        originalEventId: 1,
+        originalResultId: "read-before",
+        staleResourceKeys: ["file:src/read.ts"],
+        invalidatingMutationEventId: 2,
+        invalidatingMutationResultId: "edit-file",
+        reason: "mutation-after-read",
+        rehydrate: readRehydrate,
+      },
+    ]);
+    expect(renderStaleContextPlaceholder(report.staleCandidates[0].staleResults[0])).toBe("[Stale read context: file content changed after this result. Re-run read to refresh.]");
+  });
+
+  it("reports an older same-file read context stale after a write mutation", () => {
+    const tracker = createContextHygieneTracker();
+    const fileResource = buildFileResource("src/write.ts");
+
+    tracker.record(buildContextHygieneMetadata({ tool: "read", classification: "read-context", resources: [fileResource] }), { resultId: "read-before-write" });
+    tracker.record(buildContextHygieneMetadata({ tool: "write", classification: "mutation", resources: [fileResource] }), { resultId: "write-file" });
+
+    const report = tracker.generateReport();
+    expect(report.staleCandidates).toHaveLength(1);
+    expect(report.staleCandidates[0]).toMatchObject({ resourceKey: "file:src/write.ts", staleEventIds: [1], mutationEventId: 2 });
+    expect(report.staleCandidates[0].staleResults[0]).toMatchObject({ originalTool: "read", originalClassification: "read-context", originalResultId: "read-before-write", invalidatingMutationResultId: "write-file" });
+  });
+
+  it("does not stale read contexts for unrelated files", () => {
+    const tracker = createContextHygieneTracker();
+    const fileResource = buildFileResource("src/read.ts");
+    const otherResource = buildFileResource("src/other.ts");
+
+    tracker.record(buildContextHygieneMetadata({ tool: "read", classification: "read-context", resources: [otherResource] }), { resultId: "read-other" });
+    tracker.record(buildContextHygieneMetadata({ tool: "edit", classification: "mutation", resources: [fileResource] }), { resultId: "edit-file" });
+
+    const staleResultIds = tracker.generateReport().staleCandidates.flatMap((candidate) => candidate.staleResults.map((record) => record.originalResultId));
+    expect(staleResultIds).not.toContain("read-other");
+    expect(tracker.generateReport().staleCandidates).toHaveLength(0);
+  });
+
+  it("does not stale reads recorded after an earlier same-file mutation", () => {
+    const tracker = createContextHygieneTracker();
+    const fileResource = buildFileResource("src/read.ts");
+
+    tracker.record(buildContextHygieneMetadata({ tool: "edit", classification: "mutation", resources: [fileResource] }), { resultId: "edit-before" });
+    tracker.record(buildContextHygieneMetadata({ tool: "read", classification: "read-context", resources: [fileResource] }), { resultId: "read-after" });
+
+    expect(tracker.generateReport().staleCandidates).toEqual([]);
+  });
+});

--- a/tests/context-hygiene-mutated-file-search-stale.test.ts
+++ b/tests/context-hygiene-mutated-file-search-stale.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAstSearchRehydrateDescriptor,
+  buildContextHygieneMetadata,
+  buildFileResource,
+  buildSymbolResource,
+  buildGrepRehydrateDescriptor,
+  createContextHygieneTracker,
+} from "../src/context-hygiene.js";
+
+describe("context hygiene mutated-file search invalidation", () => {
+  it("reports older same-file grep and ast_search contexts stale after an edit mutation", () => {
+    const tracker = createContextHygieneTracker();
+    const fileResource = buildFileResource("src/grep.ts");
+    const grepRehydrate = buildGrepRehydrateDescriptor({ pattern: "needle", path: "src" });
+    const astRehydrate = buildAstSearchRehydrateDescriptor({ pattern: "console.log($A)", lang: "typescript", path: "src" });
+
+    tracker.record(buildContextHygieneMetadata({ tool: "grep", classification: "search-context", resources: [fileResource], rehydrate: grepRehydrate }), { resultId: "grep-file" });
+    tracker.record(buildContextHygieneMetadata({ tool: "ast_search", classification: "search-context", resources: [fileResource], rehydrate: astRehydrate }), { resultId: "ast-file" });
+    tracker.record(buildContextHygieneMetadata({ tool: "edit", classification: "mutation", resources: [fileResource] }), { resultId: "edit-file" });
+
+    const report = tracker.generateReport();
+    expect(report.staleCandidates).toHaveLength(1);
+    expect(report.staleCandidates[0]).toMatchObject({ resourceKey: "file:src/grep.ts", staleEventIds: [1, 2], mutationEventId: 3, reason: "mutation-after-read" });
+    expect(report.mutationAfterRead).toEqual([]);
+    expect(report.staleCandidates[0].staleResults).toEqual([
+      { status: "stale", originalTool: "grep", originalClassification: "search-context", originalEventId: 1, originalResultId: "grep-file", staleResourceKeys: ["file:src/grep.ts"], invalidatingMutationEventId: 3, invalidatingMutationResultId: "edit-file", reason: "mutation-after-read", rehydrate: grepRehydrate },
+      { status: "stale", originalTool: "ast_search", originalClassification: "search-context", originalEventId: 2, originalResultId: "ast-file", staleResourceKeys: ["file:src/grep.ts"], invalidatingMutationEventId: 3, invalidatingMutationResultId: "edit-file", reason: "mutation-after-read", rehydrate: astRehydrate },
+    ]);
+  });
+
+  it("reports prior same-file grep and ast_search contexts stale after a write mutation", () => {
+    const tracker = createContextHygieneTracker();
+    const fileResource = buildFileResource("src/sg.ts");
+
+    tracker.record(buildContextHygieneMetadata({ tool: "grep", classification: "search-context", resources: [fileResource] }), { resultId: "grep-before-write" });
+    tracker.record(buildContextHygieneMetadata({ tool: "ast_search", classification: "search-context", resources: [fileResource] }), { resultId: "ast-before-write" });
+    tracker.record(buildContextHygieneMetadata({ tool: "write", classification: "mutation", resources: [fileResource] }), { resultId: "write-file" });
+
+    const report = tracker.generateReport();
+    expect(report.staleCandidates).toHaveLength(1);
+    expect(report.staleCandidates[0]).toMatchObject({ resourceKey: "file:src/sg.ts", staleEventIds: [1, 2], mutationEventId: 3 });
+    expect(report.staleCandidates[0].staleResults.map((record) => record.originalTool)).toEqual(["grep", "ast_search"]);
+  });
+
+  it("does not stale search contexts for unrelated files", () => {
+    const tracker = createContextHygieneTracker();
+    const fileResource = buildFileResource("src/grep.ts");
+    const otherResource = buildFileResource("src/other.ts");
+
+    tracker.record(buildContextHygieneMetadata({ tool: "grep", classification: "search-context", resources: [otherResource] }), { resultId: "grep-other" });
+    tracker.record(buildContextHygieneMetadata({ tool: "edit", classification: "mutation", resources: [fileResource] }), { resultId: "edit-file" });
+
+    expect(tracker.generateReport().staleCandidates).toEqual([]);
+  });
+
+  it("uses file resources for search invalidation even when symbol resources are present", () => {
+    const tracker = createContextHygieneTracker();
+    const fileResource = buildFileResource("src/grep.ts");
+    const symbolResource = buildSymbolResource("src/grep.ts", "runSearch", "function");
+
+    tracker.record(
+      buildContextHygieneMetadata({
+        tool: "ast_search",
+        classification: "search-context",
+        resources: [symbolResource, fileResource],
+      }),
+      { resultId: "ast-with-symbol" },
+    );
+    tracker.record(buildContextHygieneMetadata({ tool: "edit", classification: "mutation", resources: [fileResource] }), { resultId: "edit-file" });
+
+    const report = tracker.generateReport();
+    expect(report.staleCandidates).toHaveLength(1);
+    expect(report.staleCandidates[0].staleResults[0]).toMatchObject({ originalTool: "ast_search", originalClassification: "search-context", originalResultId: "ast-with-symbol", staleResourceKeys: ["file:src/grep.ts"] });
+  });
+
+  it("uses deterministic hybrid multi-file staling for search artifacts", () => {
+    const tracker = createContextHygieneTracker();
+    const fileResource = buildFileResource("src/grep.ts");
+    const otherResource = buildFileResource("src/other.ts");
+
+    tracker.record(buildContextHygieneMetadata({ tool: "grep", classification: "search-context", resources: [fileResource, otherResource] }), { resultId: "grep-multifile" });
+    tracker.record(buildContextHygieneMetadata({ tool: "edit", classification: "mutation", resources: [fileResource] }), { resultId: "edit-file" });
+
+    const report = tracker.generateReport();
+    expect(report.staleCandidates).toHaveLength(1);
+    expect(report.staleCandidates[0]).toMatchObject({ resourceKey: "file:src/grep.ts", staleEventIds: [1], mutationEventId: 2 });
+    expect(report.staleCandidates[0].staleResults[0].staleResourceKeys).toEqual(["file:src/grep.ts"]);
+    expect(report.staleCandidates[0].staleResults[0]).toMatchObject({
+      status: "stale",
+      originalTool: "grep",
+      originalClassification: "search-context",
+      originalEventId: 1,
+      originalResultId: "grep-multifile",
+      invalidatingMutationEventId: 2,
+      invalidatingMutationResultId: "edit-file",
+      reason: "mutation-after-read",
+    });
+  });
+});

--- a/tests/context-hygiene-stale-contract.test.ts
+++ b/tests/context-hygiene-stale-contract.test.ts
@@ -30,4 +30,28 @@ describe("context hygiene stale result contract", () => {
     expect((record as any).state).toBeUndefined();
     expect((record as any).retired).toBeUndefined();
   });
+
+  it("preserves the original context classification when provided", () => {
+    const record = buildStaleContextRecord({
+      originalTool: "grep",
+      originalClassification: "search-context",
+      originalEventId: 3,
+      originalResultId: "grep-result-1",
+      staleResourceKeys: ["file:src/grep.ts"],
+      invalidatingMutationEventId: 4,
+      invalidatingMutationResultId: "edit-result-1",
+    });
+
+    expect(record).toMatchObject({
+      status: "stale",
+      originalTool: "grep",
+      originalClassification: "search-context",
+      originalEventId: 3,
+      originalResultId: "grep-result-1",
+      staleResourceKeys: ["file:src/grep.ts"],
+      invalidatingMutationEventId: 4,
+      invalidatingMutationResultId: "edit-result-1",
+      reason: "mutation-after-read",
+    });
+  });
 });

--- a/tests/context-hygiene-tracker.test.ts
+++ b/tests/context-hygiene-tracker.test.ts
@@ -94,6 +94,7 @@ describe("context hygiene telemetry tracker", () => {
             {
               status: "stale",
               originalTool: "read",
+              originalClassification: "read-context",
               originalEventId: 1,
               originalResultId: "read-1",
               staleResourceKeys: ["file:src/read.ts"],
@@ -105,6 +106,7 @@ describe("context hygiene telemetry tracker", () => {
             {
               status: "stale",
               originalTool: "read",
+              originalClassification: "read-context",
               originalEventId: 2,
               originalResultId: "read-2",
               staleResourceKeys: ["file:src/read.ts"],


### PR DESCRIPTION
## Summary

Implements M7 Phase 1 Batch B: mutated-file semantic invalidation in the context-hygiene tracker/report layer.

This PR makes retained context artifacts report as stale when they touched a file that is later mutated by `edit` or `write`:

- older `read` results for the same `file:<path>` become stale
- older `grep` and `ast_search` results touching the same `file:<path>` become stale
- unrelated files stay current
- reads/searches recorded after a mutation are not invalidated by that earlier mutation
- multi-file search artifacts use deterministic hybrid staling: if any touched file mutates, the artifact is stale, while the stale record preserves the specific mutated file resource key that caused it

## Why

Old hashlined reads and search results can carry stale anchors, stale line numbers, and stale symbol context after a file changes. This batch exposes that risk through deterministic report data so later phases can safely integrate it into context replacement without changing live tool rendering yet.

## Implementation Notes

- Extends stale records with optional `originalClassification` so consumers can distinguish `read-context` from `search-context` stale records.
- Keeps context-hygiene metadata beside `ptcValue`; no existing `ptcValue` contracts are changed.
- Keeps existing live rendered output for `read`, `grep`, `ast_search`, `edit`, and `write` unchanged.
- Preserves legacy `mutationAfterRead` as read-only telemetry; search staleness is reported through `staleCandidates`.
- Preserves original event/result identity, invalidating mutation identity, stale resource keys, reason, and rehydrate metadata when available.

## Files Changed

- `src/context-hygiene.ts` — tracker/report stale candidate logic and stale record contract extension
- `tests/context-hygiene-mutated-file-read-stale.test.ts` — read → edit/write invalidation coverage
- `tests/context-hygiene-mutated-file-search-stale.test.ts` — grep/ast_search → edit/write invalidation, unrelated search, symbol metadata, and hybrid multi-file coverage
- `tests/context-hygiene-stale-contract.test.ts` — stale record classification contract coverage
- `tests/context-hygiene-tracker.test.ts` and `tests/context-hygiene-debug-tool.test.ts` — updated report expectations
- `.megapowers/docs/134-m7-phase-1-batch-b-mutated-file-invalida.md`, `.megapowers/CHANGELOG.md`, `.megapowers/plans/134-m7-phase-1-batch-b-mutated-file-invalida/*` — done-phase docs/review/learnings artifacts

## Verification

- `npm test` — 236 files passed, 1156 tests passed
- `npm run typecheck` — passed
- Focused regression coverage passed for:
  - same-file `read → edit`
  - same-file `read → write`
  - unrelated read resources
  - post-mutation read ordering
  - same-file `grep → edit`
  - same-file `ast_search → edit`
  - write-based search invalidation
  - unrelated search resources
  - symbol-resource metadata with file-key invalidation
  - deterministic hybrid multi-file search staling

## Scope / Non-goals

This PR intentionally does not implement live Pi conversation context replacement, live stale placeholder insertion, automatic stale anchor repair, pressure-based retirement, or bash invalidation. Those remain future M7 work.

Closes #128.
Closes #129.
Part of #132.
