### PR TITLE
Apply stale context masking at the provider boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,9 +351,34 @@ Policy summary:
 - `edit` is not safe-by-default and is mutating
 - `pi-prompt-assembler` may optionally consume this contract
 
-## Context hygiene metadata
+## Context hygiene metadata and stale context
 
-Tool results include additive `details.contextHygiene` metadata that classifies context as read, search, command output, or mutation context. This metadata is intended for downstream session/context-management integrations and does not change the visible tool output contract.
+Tool results include additive `details.contextHygiene` metadata that classifies context as read, search, command output, or mutation context. This metadata is intended for downstream session/context-management integrations and does not change the visible current-turn tool output contract.
+
+When an `edit` or `write` mutates a file, older provider-context copies of `read`, `grep`, and `ast_search` results that touched the same `file:<path>` are marked stale before the next model call. Stale context is not deleted for token savings and is not treated as retired context; it is deterministic warning context that says the previous result is no longer trustworthy because file content changed after it was produced.
+
+What becomes stale:
+
+- earlier `read` results for the same mutated file
+- earlier `grep` results that touched the same mutated file
+- earlier `ast_search` results that touched the same mutated file
+- multi-file search artifacts when any touched file is later mutated; the stale record names the mutated `file:<path>` key that caused the stale status
+
+What does not become stale in Phase 1:
+
+- the latest `edit` or `write` mutation result
+- fresh `read`, `grep`, or `ast_search` results recorded after the mutation
+- results for unrelated files
+- Bash output such as old `git status`, `git diff`, or test logs
+- pressure-based retirement candidates
+
+To recover stale detail, re-run the original tool indicated by the placeholder: `read` for stale file reads, `grep` for stale text search results, or `ast_search` for stale structural search results. The current stale placeholders are deterministic:
+
+```text
+[Stale read context: file content changed after this result. Re-run read to refresh.]
+[Stale grep context: matched file content changed after this result. Re-run grep to refresh.]
+[Stale ast_search context: matched file content changed after this result. Re-run ast_search to refresh.]
+```
 
 When `PI_CONTEXT_HYGIENE_DEBUG=1` is set before starting pi, the extension also registers `context_hygiene_report`, a debug-only read-only tool that reports tracked context-hygiene resources, stale candidates, and retirement candidates without mutating tracker state.
 

--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ import { registerLsTool } from "./src/ls.js";
 import { registerFindTool } from "./src/find.js";
 import { filterBashOutput } from "./src/rtk/bash-filter.js";
 import { stripAnsi } from "./src/rtk/ansi.js";
+import { applyContextHygieneStaleContext } from "./src/context-application.js";
 import {
   buildCommandResource,
   buildContextHygieneMetadata,
@@ -157,6 +158,16 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
       (event.input ?? {}) as Record<string, unknown>,
     );
     return undefined;
+  });
+
+  pi.on("context", (event: any): any => {
+    if (!Array.isArray(event.messages)) return undefined;
+    const messages = applyContextHygieneStaleContext(
+      event.messages,
+      getContextHygieneTracker().generateReport(),
+    );
+    if (messages === event.messages) return undefined;
+    return { messages };
   });
 
   pi.on("tool_result", (event: any) => {

--- a/src/context-application.ts
+++ b/src/context-application.ts
@@ -1,0 +1,68 @@
+import {
+  renderStaleContextPlaceholder,
+  type ContextHygieneReport,
+  type ContextHygieneStaleRecord,
+} from "./context-hygiene.js";
+
+type ContextToolResultMessage = {
+  role?: unknown;
+  toolCallId?: unknown;
+  toolName?: unknown;
+  content?: unknown;
+  details?: unknown;
+  [key: string]: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object";
+}
+
+function isMaskableStaleTool(tool: string): boolean {
+  return tool === "read" || tool === "grep" || tool === "ast_search";
+}
+
+function staleRecordsByResultId(report: ContextHygieneReport): Map<string, ContextHygieneStaleRecord> {
+  const records = new Map<string, ContextHygieneStaleRecord>();
+  for (const candidate of report.staleCandidates) {
+    for (const record of candidate.staleResults) {
+      if (!record.originalResultId || !isMaskableStaleTool(record.originalTool)) continue;
+      const existing = records.get(record.originalResultId);
+      if (!existing || existing.invalidatingMutationEventId < record.invalidatingMutationEventId) {
+        records.set(record.originalResultId, record);
+      }
+    }
+  }
+  return records;
+}
+
+function maskToolResultMessage<T extends ContextToolResultMessage>(message: T, record: ContextHygieneStaleRecord): T {
+  const details = isRecord(message.details) ? message.details : {};
+  return {
+    ...message,
+    content: [{ type: "text" as const, text: renderStaleContextPlaceholder(record) }],
+    details: {
+      ...details,
+      contextHygieneStale: record,
+    },
+  };
+}
+
+export function applyContextHygieneStaleContext<T extends ContextToolResultMessage>(
+  messages: readonly T[],
+  report: ContextHygieneReport,
+): T[] {
+  const staleByResultId = staleRecordsByResultId(report);
+  if (staleByResultId.size === 0) return messages as T[];
+
+  let changed = false;
+  const nextMessages = messages.map((message) => {
+    if (message.role !== "toolResult" || typeof message.toolCallId !== "string") return message;
+    const record = staleByResultId.get(message.toolCallId);
+    if (!record) return message;
+    if (message.toolName !== record.originalTool) return message;
+    changed = true;
+    return maskToolResultMessage(message, record);
+  });
+
+  return changed ? nextMessages : (messages as T[]);
+}

--- a/tests/context-hygiene-context-application.test.ts
+++ b/tests/context-hygiene-context-application.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from "vitest";
+import { applyContextHygieneStaleContext } from "../src/context-application.js";
+import {
+  buildContextHygieneMetadata,
+  buildFileResource,
+  createContextHygieneTracker,
+} from "../src/context-hygiene.js";
+
+function toolResult(toolCallId: string, toolName: string, text: string, details: Record<string, unknown> = {}) {
+  return {
+    role: "toolResult" as const,
+    toolCallId,
+    toolName,
+    content: [{ type: "text" as const, text }],
+    details,
+    isError: false,
+    timestamp: 1,
+  };
+}
+
+describe("context hygiene context application", () => {
+  it("masks stale read provider context after same-file edit", () => {
+    const tracker = createContextHygieneTracker();
+    const file = buildFileResource("src/read.ts");
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "read", classification: "read-context", resources: [file] }),
+      { resultId: "read-before-edit" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "edit", classification: "mutation", resources: [file] }),
+      { resultId: "edit-file" },
+    );
+
+    const staleRead = toolResult("read-before-edit", "read", "old read output", { ptcValue: { tool: "read" } });
+    const liveEdit = toolResult("edit-file", "edit", "edit succeeded", { ptcValue: { tool: "edit" } });
+    const messages = [staleRead, liveEdit];
+
+    const applied = applyContextHygieneStaleContext(messages, tracker.generateReport());
+
+    expect(applied).not.toBe(messages);
+    expect(applied[0]).not.toBe(staleRead);
+    expect(applied[0].content).toEqual([
+      { type: "text", text: "[Stale read context: file content changed after this result. Re-run read to refresh.]" },
+    ]);
+    expect(applied[0].details).toMatchObject({
+      ptcValue: { tool: "read" },
+      contextHygieneStale: {
+        status: "stale",
+        originalTool: "read",
+        originalResultId: "read-before-edit",
+        invalidatingMutationResultId: "edit-file",
+        reason: "mutation-after-read",
+      },
+    });
+    expect(applied[1]).toBe(liveEdit);
+    expect(staleRead.content).toEqual([{ type: "text", text: "old read output" }]);
+  });
+
+  it("masks only pre-write read context and preserves a fresh read after the mutation", () => {
+    const tracker = createContextHygieneTracker();
+    const file = buildFileResource("src/write.ts");
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "read", classification: "read-context", resources: [file] }),
+      { resultId: "read-before-write" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "write", classification: "mutation", resources: [file] }),
+      { resultId: "write-file" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "read", classification: "read-context", resources: [file] }),
+      { resultId: "read-after-write" },
+    );
+
+    const staleBeforeWrite = toolResult("read-before-write", "read", "old write-target read");
+    const liveWrite = toolResult("write-file", "write", "write succeeded");
+    const freshRead = toolResult("read-after-write", "read", "fresh read output");
+
+    const applied = applyContextHygieneStaleContext(
+      [staleBeforeWrite, liveWrite, freshRead],
+      tracker.generateReport(),
+    );
+
+    expect(applied[0].content).toEqual([
+      { type: "text", text: "[Stale read context: file content changed after this result. Re-run read to refresh.]" },
+    ]);
+    expect(applied[1]).toBe(liveWrite);
+    expect(applied[2]).toBe(freshRead);
+  });
+
+  it("masks stale grep provider context after same-file edit", () => {
+    const tracker = createContextHygieneTracker();
+    const file = buildFileResource("src/grep.ts");
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "grep", classification: "search-context", resources: [file] }),
+      { resultId: "grep-before-edit" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "edit", classification: "mutation", resources: [file] }),
+      { resultId: "edit-grep-file" },
+    );
+
+    const staleGrep = toolResult("grep-before-edit", "grep", "old grep output");
+    const liveEdit = toolResult("edit-grep-file", "edit", "edit succeeded");
+    const applied = applyContextHygieneStaleContext([staleGrep, liveEdit], tracker.generateReport());
+
+    expect(applied[0].content).toEqual([
+      { type: "text", text: "[Stale grep context: matched file content changed after this result. Re-run grep to refresh.]" },
+    ]);
+    expect(applied[0].details).toMatchObject({
+      contextHygieneStale: {
+        status: "stale",
+        originalTool: "grep",
+        originalResultId: "grep-before-edit",
+        invalidatingMutationResultId: "edit-grep-file",
+        reason: "mutation-after-read",
+      },
+    });
+    expect(applied[1]).toBe(liveEdit);
+  });
+
+  it("masks stale grep provider context after same-file write", () => {
+    const tracker = createContextHygieneTracker();
+    const file = buildFileResource("src/grep-write.ts");
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "grep", classification: "search-context", resources: [file] }),
+      { resultId: "grep-before-write" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "write", classification: "mutation", resources: [file] }),
+      { resultId: "write-grep-file" },
+    );
+
+    const staleGrep = toolResult("grep-before-write", "grep", "old grep write output");
+    const liveWrite = toolResult("write-grep-file", "write", "write succeeded");
+    const applied = applyContextHygieneStaleContext([staleGrep, liveWrite], tracker.generateReport());
+
+    expect(applied[0].content).toEqual([
+      { type: "text", text: "[Stale grep context: matched file content changed after this result. Re-run grep to refresh.]" },
+    ]);
+    expect(applied[1]).toBe(liveWrite);
+  });
+
+  it("masks both prior grep and read context in a grep read edit workflow", () => {
+    const tracker = createContextHygieneTracker();
+    const file = buildFileResource("src/chain.ts");
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "grep", classification: "search-context", resources: [file] }),
+      { resultId: "grep-chain" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "read", classification: "read-context", resources: [file] }),
+      { resultId: "read-chain" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "edit", classification: "mutation", resources: [file] }),
+      { resultId: "edit-chain" },
+    );
+
+    const applied = applyContextHygieneStaleContext([
+      toolResult("grep-chain", "grep", "chain grep output"),
+      toolResult("read-chain", "read", "chain read output"),
+      toolResult("edit-chain", "edit", "chain edit output"),
+    ], tracker.generateReport());
+
+    expect(applied[0].content).toEqual([
+      { type: "text", text: "[Stale grep context: matched file content changed after this result. Re-run grep to refresh.]" },
+    ]);
+    expect(applied[1].content).toEqual([
+      { type: "text", text: "[Stale read context: file content changed after this result. Re-run read to refresh.]" },
+    ]);
+    expect(applied[2].content).toEqual([{ type: "text", text: "chain edit output" }]);
+  });
+
+  it("masks stale ast_search provider context after same-file edit", () => {
+    const tracker = createContextHygieneTracker();
+    const file = buildFileResource("src/sg.ts");
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "ast_search", classification: "search-context", resources: [file] }),
+      { resultId: "ast-before-edit" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "edit", classification: "mutation", resources: [file] }),
+      { resultId: "edit-ast-file" },
+    );
+
+    const staleAst = toolResult("ast-before-edit", "ast_search", "old ast_search output");
+    const liveEdit = toolResult("edit-ast-file", "edit", "edit succeeded");
+    const applied = applyContextHygieneStaleContext([staleAst, liveEdit], tracker.generateReport());
+
+    expect(applied[0].content).toEqual([
+      { type: "text", text: "[Stale ast_search context: matched file content changed after this result. Re-run ast_search to refresh.]" },
+    ]);
+    expect(applied[0].details).toMatchObject({
+      contextHygieneStale: {
+        status: "stale",
+        originalTool: "ast_search",
+        originalResultId: "ast-before-edit",
+        invalidatingMutationResultId: "edit-ast-file",
+        reason: "mutation-after-read",
+      },
+    });
+    expect(applied[1]).toBe(liveEdit);
+  });
+
+  it("masks stale ast_search provider context after same-file write", () => {
+    const tracker = createContextHygieneTracker();
+    const file = buildFileResource("src/sg-write.ts");
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "ast_search", classification: "search-context", resources: [file] }),
+      { resultId: "ast-before-write" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "write", classification: "mutation", resources: [file] }),
+      { resultId: "write-ast-file" },
+    );
+
+    const staleAst = toolResult("ast-before-write", "ast_search", "old ast_search write output");
+    const liveWrite = toolResult("write-ast-file", "write", "write succeeded");
+    const applied = applyContextHygieneStaleContext([staleAst, liveWrite], tracker.generateReport());
+
+    expect(applied[0].content).toEqual([
+      { type: "text", text: "[Stale ast_search context: matched file content changed after this result. Re-run ast_search to refresh.]" },
+    ]);
+    expect(applied[1]).toBe(liveWrite);
+  });
+
+  it("does not mask a non-matching bash tool result even if its id matches a stale read", () => {
+    const tracker = createContextHygieneTracker();
+    const file = buildFileResource("src/read.ts");
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "read", classification: "read-context", resources: [file] }),
+      { resultId: "read-before-edit" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "edit", classification: "mutation", resources: [file] }),
+      { resultId: "edit-file" },
+    );
+
+    const bashWithSameId = toolResult("read-before-edit", "bash", "bash output must stay live");
+    const bashMessages = [bashWithSameId];
+    const bashApplied = applyContextHygieneStaleContext(bashMessages, tracker.generateReport());
+
+    expect(bashApplied[0].content).toEqual([{ type: "text", text: "bash output must stay live" }]);
+    expect(bashApplied).toBe(bashMessages);
+    expect(bashApplied[0]).toBe(bashWithSameId);
+
+    const staleRead = toolResult("read-before-edit", "read", "old read output");
+    const staleApplied = applyContextHygieneStaleContext([staleRead], tracker.generateReport());
+    expect(staleApplied[0].content).toEqual([
+      { type: "text", text: "[Stale read context: file content changed after this result. Re-run read to refresh.]" },
+    ]);
+    expect(staleApplied[0].content[0].text.toLowerCase()).toContain("stale");
+    expect(staleApplied[0].content[0].text.toLowerCase()).not.toContain("retired");
+  });
+
+
+  it("leaves read grep and ast_search context unchanged before any same-file mutation", () => {
+    const tracker = createContextHygieneTracker();
+    const file = buildFileResource("src/no-mutation.ts");
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "read", classification: "read-context", resources: [file] }),
+      { resultId: "read-live" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "grep", classification: "search-context", resources: [file] }),
+      { resultId: "grep-live" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "ast_search", classification: "search-context", resources: [file] }),
+      { resultId: "ast-live" },
+    );
+
+    const messages = [
+      toolResult("read-live", "read", "live read output"),
+      toolResult("grep-live", "grep", "live grep output"),
+      toolResult("ast-live", "ast_search", "live ast output"),
+    ];
+
+    const applied = applyContextHygieneStaleContext(messages, tracker.generateReport());
+
+    expect(applied).toBe(messages);
+    expect(applied.map((message) => message.content[0].text)).toEqual([
+      "live read output",
+      "live grep output",
+      "live ast output",
+    ]);
+  });
+
+
+  it("does not mask prior tool results for unrelated files", () => {
+    const tracker = createContextHygieneTracker();
+    const mutatedFile = buildFileResource("src/read.ts");
+    const otherFile = buildFileResource("src/other.ts");
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "read", classification: "read-context", resources: [mutatedFile] }),
+      { resultId: "read-before-edit" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "read", classification: "read-context", resources: [otherFile] }),
+      { resultId: "read-other" },
+    );
+    tracker.record(
+      buildContextHygieneMetadata({ tool: "edit", classification: "mutation", resources: [mutatedFile] }),
+      { resultId: "edit-file" },
+    );
+
+    const unrelatedRead = toolResult("read-other", "read", "other read output");
+    const unrelatedMessages = [unrelatedRead];
+    const applied = applyContextHygieneStaleContext(unrelatedMessages, tracker.generateReport());
+
+    expect(applied).toBe(unrelatedMessages);
+    expect(applied[0]).toBe(unrelatedRead);
+    expect(applied[0].content).toEqual([{ type: "text", text: "other read output" }]);
+  });
+});

--- a/tests/context-hygiene-context-handler.test.ts
+++ b/tests/context-hygiene-context-handler.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from "vitest";
+import init from "../index.js";
+import { buildContextHygieneMetadata, buildFileResource } from "../src/context-hygiene.js";
+
+function createHarness() {
+  const handlers: Record<string, Function> = {};
+
+  init({
+    registerTool() {},
+    on(event: string, handler: Function) {
+      handlers[event] = handler;
+    },
+    events: { emit() {}, on() {} },
+  } as any);
+
+  return handlers;
+}
+
+function toolResult(toolCallId: string, toolName: string, text: string, details: Record<string, unknown> = {}) {
+  return {
+    role: "toolResult" as const,
+    toolCallId,
+    toolName,
+    content: [{ type: "text" as const, text }],
+    details,
+    isError: false,
+    timestamp: 1,
+  };
+}
+
+afterEach(() => {
+  delete (globalThis as any).__hashlineToolExecutors;
+});
+
+describe("context hygiene provider context handler", () => {
+  it("masks stale prior tool results in the provider-context copy without mutating source messages", async () => {
+    const handlers = createHarness();
+    expect(typeof handlers.context).toBe("function");
+
+    const file = buildFileResource("src/read.ts");
+    const readMetadata = buildContextHygieneMetadata({
+      tool: "read",
+      classification: "read-context",
+      resources: [file],
+    });
+    const editMetadata = buildContextHygieneMetadata({
+      tool: "edit",
+      classification: "mutation",
+      resources: [file],
+    });
+
+    await handlers.tool_result({
+      type: "tool_result" as const,
+      toolName: "read",
+      toolCallId: "read-before-edit",
+      input: { path: "src/read.ts" },
+      content: [{ type: "text" as const, text: "old read output" }],
+      isError: false,
+      details: { contextHygiene: readMetadata, ptcValue: { tool: "read" } },
+    }, {});
+    await handlers.tool_result({
+      type: "tool_result" as const,
+      toolName: "edit",
+      toolCallId: "edit-file",
+      input: { path: "src/read.ts" },
+      content: [{ type: "text" as const, text: "edit succeeded" }],
+      isError: false,
+      details: { contextHygiene: editMetadata, ptcValue: { tool: "edit" } },
+    }, {});
+
+    const readMessage = toolResult("read-before-edit", "read", "old read output", { ptcValue: { tool: "read" } });
+    const editMessage = toolResult("edit-file", "edit", "edit succeeded", { ptcValue: { tool: "edit" } });
+    const providerContextCopy = [readMessage, editMessage];
+
+    const result = handlers.context({ type: "context", messages: providerContextCopy }, {});
+
+    expect(result.messages[0].content).toEqual([
+      { type: "text", text: "[Stale read context: file content changed after this result. Re-run read to refresh.]" },
+    ]);
+    expect(result.messages[0].details).toMatchObject({
+      ptcValue: { tool: "read" },
+      contextHygieneStale: { status: "stale", originalTool: "read", originalResultId: "read-before-edit" },
+    });
+    expect(result.messages[1]).toBe(editMessage);
+    expect(providerContextCopy[0].content).toEqual([{ type: "text", text: "old read output" }]);
+  });
+});


### PR DESCRIPTION
## Summary

Completes Phase 1 context-hygiene application at the Pi provider-context boundary.

When a file is changed by `edit` or `write`, prior provider-context copies of same-file `read`, `grep`, and `ast_search` results are now replaced with deterministic stale placeholders before the next model call. This keeps old file/search artifacts from appearing trustworthy after mutation without changing current-turn tool output or rewriting persisted session history.

## What changed

- Added `applyContextHygieneStaleContext(...)` to apply existing Batch B stale records to provider-context tool-result messages.
- Registered a `pi.on("context", ...)` handler in the extension entry point to mask stale provider-context copies only.
- Preserved existing `details.ptcValue` contracts by adding stale metadata beside them as `details.contextHygieneStale`.
- Bounded masking to matching `toolCallId` + tool name for `read`, `grep`, and `ast_search` only.
- Left live mutation results, fresh post-mutation reads/searches, unrelated-file results, and Bash output unmasked.
- Documented stale-vs-retired behavior, rehydration guidance, and Phase 1 deferrals in README/roadmap/milestone docs.

## Covered workflows

- `read → edit`
- `read → write → read` where only the pre-write read becomes stale
- `grep → edit`
- `grep → write`
- `grep → read → edit` where both prior search and read context become stale
- `ast_search → edit`
- `ast_search → write`
- pre-mutation reads/searches remain live
- unrelated files remain live
- Bash results are not invalidated by this PR

## Out of scope / deferred

- Bash state invalidation (`git status`, `git diff`, test logs, etc.)
- pressure-based retirement
- generic context compression
- automatic stale read/search rehydration
- persisted session rewriting

## Testing

- `npm test`
- `npm run typecheck`
- `npx vitest run tests/context-hygiene-context-application.test.ts tests/context-hygiene-context-handler.test.ts --reporter verbose`

## Notes

This uses the existing Batch B stale candidate/report model and deterministic stale placeholder helpers. The provider-context handler returns replacement messages only when stale context is actually masked.

Related source issues: #130, #131.
