### PR TITLE
Ship 137-m8-java-structural-navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "tree-sitter": "0.22.4",
         "tree-sitter-clojure": "github:ghoseb/tree-sitter-clojure#78928e6",
         "tree-sitter-cpp": "0.23.4",
+        "tree-sitter-java": "^0.23.5",
         "tree-sitter-rust": "0.23.3",
         "ts-morph": "^27.0.2",
         "xxhash-wasm": "^1.1.0"
@@ -4927,6 +4928,25 @@
         "node-addon-api": "^8.2.1",
         "node-gyp-build": "^4.8.2",
         "tree-sitter-c": "^0.23.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-java": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/tree-sitter-java/-/tree-sitter-java-0.23.5.tgz",
+      "integrity": "sha512-Yju7oQ0Xx7GcUT01mUglPP+bYfvqjNCGdxqigTnew9nLGoII42PNVP3bHrYeMxswiCRM0yubWmN5qk+zsg0zMA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
       },
       "peerDependencies": {
         "tree-sitter": "^0.21.1"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "tree-sitter": "0.22.4",
     "tree-sitter-clojure": "github:ghoseb/tree-sitter-clojure#78928e6",
     "tree-sitter-cpp": "0.23.4",
+    "tree-sitter-java": "^0.23.5",
     "tree-sitter-rust": "0.23.3",
     "ts-morph": "^27.0.2",
     "xxhash-wasm": "^1.1.0"

--- a/src/readmap/language-detect.ts
+++ b/src/readmap/language-detect.ts
@@ -26,6 +26,9 @@ const EXTENSION_MAP: Record<string, LanguageInfo> = {
   // Go
   ".go": { id: "go", name: "Go" },
 
+  // Java
+  ".java": { id: "java", name: "Java" },
+
   // Swift
   ".swift": { id: "swift", name: "Swift" },
 

--- a/src/readmap/mapper.ts
+++ b/src/readmap/mapper.ts
@@ -10,6 +10,7 @@ import { ctagsMapper, MAPPER_VERSION as CTAGS_VERSION } from "./mappers/ctags.js
 import { fallbackMapper, MAPPER_VERSION as FALLBACK_VERSION } from "./mappers/fallback.js";
 import { goMapper, MAPPER_VERSION as GO_VERSION } from "./mappers/go.js";
 import { jsonMapper, MAPPER_VERSION as JSON_VERSION } from "./mappers/json.js";
+import { javaMapper, MAPPER_VERSION as JAVA_VERSION } from "./mappers/java.js";
 import { jsonlMapper, MAPPER_VERSION as JSONL_VERSION } from "./mappers/jsonl.js";
 import { markdownMapper, MAPPER_VERSION as MARKDOWN_VERSION } from "./mappers/markdown.js";
 import { pythonMapper, MAPPER_VERSION as PYTHON_VERSION } from "./mappers/python.js";
@@ -50,6 +51,8 @@ const MAPPERS_V: Record<string, MapperEntry> = {
   rust: { fn: rustMapper, version: RUST_VERSION },
   cpp: { fn: cppMapper, version: CPP_VERSION },
   "c-header": { fn: cppMapper, version: CPP_VERSION }, // .h files
+  // Phase 8: Java tree-sitter mapper
+  java: { fn: javaMapper, version: JAVA_VERSION },
   // Phase 2: Regex/subprocess mappers
   sql: { fn: sqlMapper, version: SQL_VERSION },
   json: { fn: jsonMapper, version: JSON_VERSION },

--- a/src/readmap/mappers/java.ts
+++ b/src/readmap/mappers/java.ts
@@ -1,0 +1,225 @@
+import { readFile, stat } from "node:fs/promises";
+import { createRequire } from "node:module";
+
+import type { FileMap, FileSymbol } from "../types.js";
+import { DetailLevel, SymbolKind } from "../enums.js";
+
+export const MAPPER_VERSION = 1;
+
+type SyntaxNode = import("tree-sitter").SyntaxNode;
+
+const TYPE_KINDS: Record<string, SymbolKind> = {
+  class_declaration: SymbolKind.Class,
+  interface_declaration: SymbolKind.Interface,
+  enum_declaration: SymbolKind.Enum,
+  record_declaration: SymbolKind.Class,
+  annotation_type_declaration: SymbolKind.Interface,
+  module_declaration: SymbolKind.Module,
+};
+
+const SKIP_TYPES = new Set([
+  "package_declaration",
+  "import_declaration",
+  "modifiers",
+  "annotation",
+  "marker_annotation",
+  "local_variable_declaration",
+]);
+
+
+const MEMBER_METHOD_TYPES = new Set([
+  "method_declaration",
+  "constructor_declaration",
+  "compact_constructor_declaration",
+]);
+
+let parser: import("tree-sitter") | null = null;
+let parserInitialized = false;
+
+function ensureWritableTypeProperty(parserCtor: unknown): void {
+  const syntaxNode = (parserCtor as { SyntaxNode?: { prototype?: object } }).SyntaxNode;
+  const proto = syntaxNode?.prototype;
+  if (!proto) return;
+  const desc = Object.getOwnPropertyDescriptor(proto, "type");
+  if (!desc || desc.set) return;
+  Object.defineProperty(proto, "type", { ...desc, set: () => {} });
+}
+
+function getParser(): import("tree-sitter") | null {
+  if (parserInitialized) return parser;
+  parserInitialized = true;
+  if (typeof (globalThis as { Bun?: unknown }).Bun !== "undefined") return null;
+
+  try {
+    const require = createRequire(import.meta.url);
+    const ParserCtor = require("tree-sitter") as typeof import("tree-sitter");
+    const JavaModule = require("tree-sitter-java") as import("tree-sitter").Language | { default: import("tree-sitter").Language };
+    const Java = "default" in JavaModule ? JavaModule.default : JavaModule;
+    ensureWritableTypeProperty(ParserCtor);
+    parser = new ParserCtor();
+    parser.setLanguage(Java);
+    return parser;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replaceAll(/\s+/g, " ").trim();
+}
+
+function getNodeText(node: SyntaxNode, source: string): string {
+  return source.slice(node.startIndex, node.endIndex);
+}
+
+function getLineRange(node: SyntaxNode): { startLine: number; endLine: number } {
+  return { startLine: node.startPosition.row + 1, endLine: node.endPosition.row + 1 };
+}
+
+function extractName(node: SyntaxNode, source: string): string | null {
+  const nameNode = node.childForFieldName("name");
+  return nameNode ? normalizeWhitespace(getNodeText(nameNode, source)) : null;
+}
+
+function formatSignature(node: SyntaxNode, source: string, options?: { stripLeadingAnnotations?: boolean }): string {
+  const body = node.childForFieldName("body");
+  const end = body ? body.startIndex : node.endIndex;
+  let signature = source.slice(node.startIndex, end).replace(/;\s*$/, "");
+  if (options?.stripLeadingAnnotations && node.type !== "annotation_type_declaration") {
+    signature = signature.replace(/^(?:\s*@[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\([^)]*\))?\s*)+/, "");
+  }
+  return normalizeWhitespace(signature);
+}
+
+function extractModifiers(node: SyntaxNode, source: string): string[] {
+  const modifiers = node.namedChildren.find((child) => child.type === "modifiers");
+  if (!modifiers) return [];
+  const text = getNodeText(modifiers, source);
+  return ["public", "protected", "private", "static", "final", "abstract", "native", "synchronized", "transient", "volatile", "strictfp", "default"]
+    .filter((modifier) => new RegExp(`\\b${modifier}\\b`).test(text));
+}
+
+function extractImports(root: SyntaxNode, source: string): string[] {
+  const imports: string[] = [];
+  const visit = (node: SyntaxNode): void => {
+    if (node.type === "package_declaration" || node.type === "import_declaration") {
+      imports.push(normalizeWhitespace(getNodeText(node, source)));
+      return;
+    }
+    for (const child of node.namedChildren) visit(child);
+  };
+  visit(root);
+  return imports;
+}
+
+function buildSymbol(
+  node: SyntaxNode,
+  source: string,
+  name: string,
+  kind: SymbolKind,
+  options?: { stripLeadingAnnotations?: boolean; modifiers?: string[] },
+): FileSymbol {
+  const modifiers = options?.modifiers ?? extractModifiers(node, source);
+  const symbol: FileSymbol = {
+    name,
+    kind,
+    ...getLineRange(node),
+    signature: formatSignature(node, source, options),
+    isExported: modifiers.includes("public"),
+  };
+  if (modifiers.length > 0) {
+    symbol.modifiers = modifiers;
+  }
+  return symbol;
+}
+
+function variableDeclarators(node: SyntaxNode): SyntaxNode[] {
+  return node.namedChildren.filter((child) => child.type === "variable_declarator");
+}
+
+function handleVariableDeclaration(node: SyntaxNode, source: string, parent: FileSymbol | undefined, rootSymbols: FileSymbol[]): void {
+  const modifiers = extractModifiers(node, source);
+  const kind = node.type === "constant_declaration" || (modifiers.includes("static") && modifiers.includes("final"))
+    ? SymbolKind.Constant
+    : SymbolKind.Property;
+
+  for (const declarator of variableDeclarators(node)) {
+    const name = extractName(declarator, source);
+    if (!name) continue;
+    const symbol = buildSymbol(declarator, source, name, kind, { modifiers });
+    (parent ? (parent.children ??= []) : rootSymbols).push(symbol);
+  }
+}
+
+function extractSymbols(root: SyntaxNode, source: string): FileSymbol[] {
+  const rootSymbols: FileSymbol[] = [];
+
+  const visit = (node: SyntaxNode, parent?: FileSymbol): void => {
+    const typeKind = TYPE_KINDS[node.type];
+    if (typeKind) {
+      const name = extractName(node, source);
+      if (!name) return;
+      const symbol = buildSymbol(node, source, name, typeKind, { stripLeadingAnnotations: Boolean(parent) });
+      (parent ? (parent.children ??= []) : rootSymbols).push(symbol);
+      const body = node.childForFieldName("body");
+      for (const child of body?.namedChildren ?? []) visit(child, symbol);
+      return;
+    }
+
+    if (MEMBER_METHOD_TYPES.has(node.type)) {
+      const name = extractName(node, source);
+      if (!name) return;
+      (parent ? (parent.children ??= []) : rootSymbols).push(buildSymbol(node, source, name, SymbolKind.Method));
+      return;
+    }
+
+    if (node.type === "static_initializer") {
+      (parent ? (parent.children ??= []) : rootSymbols).push(buildSymbol(node, source, "<clinit>", SymbolKind.Method));
+      return;
+    }
+
+
+    if (node.type === "field_declaration" || node.type === "constant_declaration") {
+      handleVariableDeclaration(node, source, parent, rootSymbols);
+      return;
+    }
+
+    if (node.type === "enum_constant") {
+      const name = extractName(node, source);
+      if (name) (parent ? (parent.children ??= []) : rootSymbols).push(buildSymbol(node, source, name, SymbolKind.Constant));
+      return;
+    }
+
+    if (SKIP_TYPES.has(node.type)) return;
+    for (const child of node.namedChildren) visit(child, parent);
+  };
+
+  visit(root);
+  return rootSymbols;
+}
+
+export async function javaMapper(filePath: string, signal?: AbortSignal): Promise<FileMap | null> {
+  try {
+    const p = getParser();
+    if (!p) return null;
+    const stats = await stat(filePath);
+    const content = await readFile(filePath, "utf8");
+    if (signal?.aborted) return null;
+    const tree = p.parse(content);
+    const symbols = extractSymbols(tree.rootNode, content);
+    if (symbols.length === 0) return null;
+    return {
+      path: filePath,
+      totalLines: content.split("\n").length,
+      totalBytes: stats.size,
+      language: "Java",
+      symbols,
+      imports: extractImports(tree.rootNode, content),
+      detailLevel: DetailLevel.Full,
+    };
+  } catch (error) {
+    if (signal?.aborted) return null;
+    console.error(`Java mapper failed: ${error}`);
+    return null;
+  }
+}

--- a/src/readmap/symbol-lookup.ts
+++ b/src/readmap/symbol-lookup.ts
@@ -78,6 +78,16 @@ function resolveDotPath(symbols: FileSymbol[], parts: string[]): SymbolCandidate
   return candidates;
 }
 
+const JAVA_TOP_LEVEL_TYPE_KINDS = new Set(["class", "interface", "enum", "module"]);
+
+function preferJavaTopLevelType(map: FileMap, candidates: SymbolCandidate[]): SymbolCandidate | undefined {
+  if (map.language !== "Java") return undefined;
+  const topLevelTypes = candidates.filter(
+    (candidate) => !candidate.parentName && JAVA_TOP_LEVEL_TYPE_KINDS.has(candidate.symbol.kind),
+  );
+  return topLevelTypes.length === 1 ? topLevelTypes[0] : undefined;
+}
+
 export function findSymbol(map: FileMap, query: string): SymbolLookupResult {
   const q = query.trim();
   if (!q) return { type: "not-found" };
@@ -98,7 +108,11 @@ export function findSymbol(map: FileMap, query: string): SymbolLookupResult {
 
   const exact = allSymbols.filter((c) => c.symbol.name === q);
   if (exact.length === 1) return { type: "found", symbol: toMatch(exact[0].symbol, exact[0].parentName) };
-  if (exact.length > 1) return { type: "ambiguous", candidates: toMatches(exact.slice(0, 5)) };
+  if (exact.length > 1) {
+    const preferred = preferJavaTopLevelType(map, exact);
+    if (preferred) return { type: "found", symbol: toMatch(preferred.symbol, preferred.parentName) };
+    return { type: "ambiguous", candidates: toMatches(exact.slice(0, 5)) };
+  }
 
   if (q.includes(".")) {
     const parts = q.split(".").map((p) => p.trim());

--- a/tests/fixtures/KafkaConsumerConfiguration.java
+++ b/tests/fixtures/KafkaConsumerConfiguration.java
@@ -1,0 +1,21 @@
+package com.example.kafka;
+
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+
+public class KafkaConsumerConfiguration {
+  private final String bootstrapServers;
+
+  public KafkaConsumerConfiguration(String bootstrapServers) {
+    this.bootstrapServers = bootstrapServers;
+  }
+
+  @Bean
+  public Map<String, Object> consumerFactory() {
+    return Map.of("bootstrap.servers", bootstrapServers, "helper", helperName());
+  }
+
+  private String helperName() {
+    return "consumer";
+  }
+}

--- a/tests/fixtures/module-info.java
+++ b/tests/fixtures/module-info.java
@@ -1,0 +1,4 @@
+module com.example.navigation {
+  requires java.logging;
+  exports com.example.navigation.api;
+}

--- a/tests/java-language-detect.test.ts
+++ b/tests/java-language-detect.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { detectLanguage, getSupportedExtensions, isSupported } from "../src/readmap/language-detect.js";
+
+describe("Java language detection", () => {
+  it("detects .java files as Java", () => {
+    expect(detectLanguage("Example.java")).toEqual({ id: "java", name: "Java" });
+    expect(detectLanguage("src/main/java/com/example/App.JAVA")).toEqual({ id: "java", name: "Java" });
+    expect(isSupported("module-info.java")).toBe(true);
+    expect(getSupportedExtensions()).toContain(".java");
+  });
+});

--- a/tests/java-mapper-basic.test.ts
+++ b/tests/java-mapper-basic.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { javaMapper, MAPPER_VERSION } from "../src/readmap/mappers/java.js";
+import { SymbolKind } from "../src/readmap/enums.js";
+
+const dirs: string[] = [];
+
+async function writeJava(name: string, source: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pi-java-basic-"));
+  dirs.push(dir);
+  const file = join(dir, name);
+  await writeFile(file, source, "utf8");
+  return file;
+}
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("javaMapper basic tree-sitter extraction", () => {
+  it("exports version 1 and maps a class with package/imports", async () => {
+    const file = await writeJava("Example.java", [
+      "package com.example.demo;",
+      "",
+      "import java.util.List;",
+      "import static java.util.Collections.emptyList;",
+      "",
+      "public class Example {",
+      "}",
+      "",
+    ].join("\n"));
+
+    const map = await javaMapper(file);
+
+    expect(MAPPER_VERSION).toBe(1);
+    expect(map).not.toBeNull();
+    expect(map!.language).toBe("Java");
+    expect(map!.imports).toEqual([
+      "package com.example.demo;",
+      "import java.util.List;",
+      "import static java.util.Collections.emptyList;",
+    ]);
+    expect(map!.symbols).toEqual([
+      expect.objectContaining({
+        name: "Example",
+        kind: SymbolKind.Class,
+        startLine: 6,
+        endLine: 7,
+        signature: "public class Example",
+        modifiers: ["public"],
+        isExported: true,
+      }),
+    ]);
+  });
+});

--- a/tests/java-mapper-declarators.test.ts
+++ b/tests/java-mapper-declarators.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { javaMapper } from "../src/readmap/mappers/java.js";
+import { SymbolKind } from "../src/readmap/enums.js";
+
+const dirs: string[] = [];
+
+async function writeJava(source: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pi-java-declarators-"));
+  dirs.push(dir);
+  const file = join(dir, "Declarators.java");
+  await writeFile(file, source, "utf8");
+  return file;
+}
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function child(parent: any, name: string) {
+  return parent.children?.find((symbol: any) => symbol.name === name);
+}
+
+describe("javaMapper fields, constants, and enum constants", () => {
+  it("maps multi-declarator fields, constants, and enum constants as separate symbols", async () => {
+    const file = await writeJava([
+      "public class Declarators {",
+      "  private int x, y, z;",
+      "  public static final String A = \"a\", B = \"b\";",
+      "}",
+      "interface Constants { String IA = \"ia\", IB = \"ib\"; }",
+      "enum Color { RED, GREEN; }",
+      "",
+    ].join("\n"));
+
+    const map = await javaMapper(file);
+    expect(map).not.toBeNull();
+
+    const declarators = map!.symbols.find((symbol) => symbol.name === "Declarators")!;
+    expect(child(declarators, "x")).toEqual(expect.objectContaining({ kind: SymbolKind.Property, startLine: 2, endLine: 2 }));
+    expect(child(declarators, "y")).toEqual(expect.objectContaining({ kind: SymbolKind.Property, startLine: 2, endLine: 2 }));
+    expect(child(declarators, "z")).toEqual(expect.objectContaining({ kind: SymbolKind.Property, startLine: 2, endLine: 2 }));
+    expect(child(declarators, "A")).toEqual(expect.objectContaining({ kind: SymbolKind.Constant, startLine: 3, endLine: 3 }));
+    expect(child(declarators, "B")).toEqual(expect.objectContaining({ kind: SymbolKind.Constant, startLine: 3, endLine: 3 }));
+    expect(child(declarators, "x")).toEqual(expect.objectContaining({ modifiers: ["private"], isExported: false }));
+    expect(child(declarators, "A")).toEqual(expect.objectContaining({ modifiers: ["public", "static", "final"], isExported: true }));
+
+    const constants = map!.symbols.find((symbol) => symbol.name === "Constants")!;
+    expect(child(constants, "IA")).toEqual(expect.objectContaining({ kind: SymbolKind.Constant, startLine: 5, endLine: 5 }));
+    expect(child(constants, "IB")).toEqual(expect.objectContaining({ kind: SymbolKind.Constant, startLine: 5, endLine: 5 }));
+
+    const color = map!.symbols.find((symbol) => symbol.name === "Color")!;
+    expect(child(color, "RED")).toEqual(expect.objectContaining({ kind: SymbolKind.Constant, startLine: 6, endLine: 6 }));
+    expect(child(color, "GREEN")).toEqual(expect.objectContaining({ kind: SymbolKind.Constant, startLine: 6, endLine: 6 }));
+  });
+});

--- a/tests/java-mapper-members.test.ts
+++ b/tests/java-mapper-members.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { javaMapper } from "../src/readmap/mappers/java.js";
+import { SymbolKind } from "../src/readmap/enums.js";
+
+const dirs: string[] = [];
+
+async function writeJava(source: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pi-java-members-"));
+  dirs.push(dir);
+  const file = join(dir, "Members.java");
+  await writeFile(file, source, "utf8");
+  return file;
+}
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function child(parent: any, name: string) {
+  return parent.children?.find((symbol: any) => symbol.name === name);
+}
+
+describe("javaMapper member methods and initializers", () => {
+  it("maps constructors, methods, compact constructors, and static initializers", async () => {
+    const file = await writeJava([
+      "public class Members {",
+      "  static { System.setProperty(\"ready\", \"true\"); }",
+      "  public Members() {}",
+      "  @Override",
+      "  public String toString() { int localValue = 1; return String.valueOf(localValue); }",
+      "}",
+      "record MemberRecord(int id) { MemberRecord { if (id < 0) throw new IllegalArgumentException(); } }",
+      "",
+    ].join("\n"));
+
+    const map = await javaMapper(file);
+    expect(map).not.toBeNull();
+
+    const members = map!.symbols.find((symbol) => symbol.name === "Members")!;
+    expect(child(members, "<clinit>")).toEqual(expect.objectContaining({ kind: SymbolKind.Method, startLine: 2, endLine: 2 }));
+    expect(child(members, "Members")).toEqual(expect.objectContaining({ kind: SymbolKind.Method, startLine: 3, endLine: 3 }));
+    expect(child(members, "toString")).toEqual(expect.objectContaining({
+      kind: SymbolKind.Method,
+      startLine: 4,
+      endLine: 5,
+      signature: expect.stringContaining("public String toString()"),
+    }));
+
+    const record = map!.symbols.find((symbol) => symbol.name === "MemberRecord")!;
+    expect(child(record, "MemberRecord")).toEqual(expect.objectContaining({ kind: SymbolKind.Method, startLine: 7, endLine: 7 }));
+
+    const serialized = JSON.stringify(map!.symbols);
+    expect(serialized).not.toContain("localValue");
+  });
+});

--- a/tests/java-mapper-nested-and-excluded.test.ts
+++ b/tests/java-mapper-nested-and-excluded.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { javaMapper } from "../src/readmap/mappers/java.js";
+import { SymbolKind } from "../src/readmap/enums.js";
+
+const dirs: string[] = [];
+
+async function writeJava(source: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pi-java-nested-"));
+  dirs.push(dir);
+  const file = join(dir, "Nested.java");
+  await writeFile(file, source, "utf8");
+  return file;
+}
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function child(parent: any, name: string) {
+  return parent.children?.find((symbol: any) => symbol.name === name);
+}
+
+describe("javaMapper nested declarations and excluded nodes", () => {
+  it("maps nested Java types as children and excludes annotations, local variables, and modifiers", async () => {
+    const file = await writeJava([
+      "public class Outer {",
+      "  @Deprecated",
+      "  class InnerClass {}",
+      "  interface InnerInterface {}",
+      "  enum InnerEnum { ONE, TWO }",
+      "  record InnerRecord(int id) {}",
+      "  @interface InnerAnnotation {}",
+      "  public String method() { int localValue = 1; return String.valueOf(localValue); }",
+      "}",
+      "",
+    ].join("\n"));
+
+    const map = await javaMapper(file);
+    expect(map).not.toBeNull();
+
+    const outer = map!.symbols[0];
+    expect(child(outer, "InnerClass")).toEqual(expect.objectContaining({ kind: SymbolKind.Class, startLine: 2, endLine: 3 }));
+    expect(child(outer, "InnerInterface")).toEqual(expect.objectContaining({ kind: SymbolKind.Interface }));
+    expect(child(outer, "InnerEnum")).toEqual(expect.objectContaining({ kind: SymbolKind.Enum }));
+    expect(child(child(outer, "InnerEnum"), "ONE")).toEqual(expect.objectContaining({ kind: SymbolKind.Constant }));
+    expect(child(child(outer, "InnerEnum"), "TWO")).toEqual(expect.objectContaining({ kind: SymbolKind.Constant }));
+    expect(child(outer, "InnerRecord")).toEqual(expect.objectContaining({ kind: SymbolKind.Class }));
+    expect(child(outer, "InnerAnnotation")).toEqual(expect.objectContaining({ kind: SymbolKind.Interface }));
+
+    const names = JSON.stringify(map!.symbols.map((symbol) => [symbol.name, ...(symbol.children ?? []).map((child: any) => child.name)]));
+    expect(names).not.toContain("Deprecated");
+    expect(names).not.toContain("localValue");
+    expect(names).not.toContain("modifiers");
+  });
+});

--- a/tests/java-mapper-top-level-types.test.ts
+++ b/tests/java-mapper-top-level-types.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { javaMapper } from "../src/readmap/mappers/java.js";
+import { SymbolKind } from "../src/readmap/enums.js";
+
+const dirs: string[] = [];
+
+async function writeJava(source: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pi-java-types-"));
+  dirs.push(dir);
+  const file = join(dir, "Declarations.java");
+  await writeFile(file, source, "utf8");
+  return file;
+}
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("javaMapper top-level type declarations", () => {
+  it("maps Java top-level class, interface, enum, record, and annotation declarations", async () => {
+    const file = await writeJava([
+      "package com.example.nav;",
+      "",
+      "@Deprecated",
+      "public class Declarations {",
+      "}",
+      "interface TopInterface {}",
+      "enum TopEnum { RED }",
+      "record TopRecord(String name) {}",
+      "@interface TopAnnotation { String value(); }",
+      "",
+    ].join("\n"));
+
+    const map = await javaMapper(file);
+
+    expect(map).not.toBeNull();
+    expect(map!.symbols.map((symbol) => `${symbol.name}:${symbol.kind}`)).toEqual([
+      `Declarations:${SymbolKind.Class}`,
+      `TopInterface:${SymbolKind.Interface}`,
+      `TopEnum:${SymbolKind.Enum}`,
+      `TopRecord:${SymbolKind.Class}`,
+      `TopAnnotation:${SymbolKind.Interface}`,
+    ]);
+    expect(map!.symbols[0]).toEqual(expect.objectContaining({
+      name: "Declarations",
+      kind: SymbolKind.Class,
+      startLine: 3,
+      endLine: 5,
+      signature: "@Deprecated public class Declarations",
+      modifiers: ["public"],
+      isExported: true,
+    }));
+  });
+});

--- a/tests/java-module-info.test.ts
+++ b/tests/java-module-info.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { javaMapper } from "../src/readmap/mappers/java.js";
+import { SymbolKind } from "../src/readmap/enums.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixture = resolve(__dirname, "fixtures/module-info.java");
+
+describe("Java module-info mapping", () => {
+  it("maps module_declaration as SymbolKind.Module", async () => {
+    const direct = await javaMapper(fixture);
+
+    expect(direct).not.toBeNull();
+    expect(direct!.language).toBe("Java");
+    expect(direct!.symbols).toEqual([
+      expect.objectContaining({
+        name: "com.example.navigation",
+        kind: SymbolKind.Module,
+        startLine: 1,
+        endLine: 4,
+        signature: "module com.example.navigation",
+      }),
+    ]);
+  });
+});

--- a/tests/java-readmap-registration.test.ts
+++ b/tests/java-readmap-registration.test.ts
@@ -1,0 +1,89 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { basename, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { clearMapCache } from "../src/map-cache.js";
+import { registerGrepTool } from "../src/grep.js";
+import { ensureHashInit } from "../src/hashline.js";
+import { registerReadTool } from "../src/read.js";
+import { generateMap, generateMapWithIdentity } from "../src/readmap/mapper.js";
+import { SymbolKind } from "../src/readmap/enums.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixture = resolve(__dirname, "fixtures/KafkaConsumerConfiguration.java");
+
+async function readTool(params: { path: string; symbol?: string; map?: boolean; bundle?: "local" }) {
+  let capturedTool: any = null;
+  registerReadTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+async function grepTool(params: { pattern: string; path: string; literal?: boolean; scope?: "symbol" }) {
+  let capturedTool: any = null;
+  registerGrepTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function text(result: any): string {
+  return result.content?.find((entry: any) => entry.type === "text")?.text ?? "";
+}
+
+describe("Java readmap registration and workflow integration", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  beforeEach(() => {
+    clearMapCache();
+  });
+
+  it("uses the registered Java mapper for generated maps", async () => {
+    const identity = await generateMapWithIdentity(fixture);
+    expect(identity.mapperName).toBe("java");
+    expect(identity.mapperVersion).toBeGreaterThanOrEqual(1);
+
+    const map = await generateMap(fixture);
+    expect(map?.language).toBe("Java");
+    expect(map?.imports).toEqual([
+      "package com.example.kafka;",
+      "import java.util.Map;",
+      "import org.springframework.context.annotation.Bean;",
+    ]);
+    expect(map?.symbols[0]).toEqual(expect.objectContaining({
+      name: "KafkaConsumerConfiguration",
+      kind: SymbolKind.Class,
+      startLine: 6,
+      endLine: 21,
+    }));
+  });
+
+  it("uses registered Java maps for read map rendering and symbol reads", async () => {
+    const mapRead = await readTool({ path: fixture, map: true });
+    expect(text(mapRead)).toContain("File Map: KafkaConsumerConfiguration.java");
+    expect(text(mapRead)).toContain("Java");
+    expect(text(mapRead)).toContain("KafkaConsumerConfiguration");
+
+    const classRead = await readTool({ path: fixture, symbol: "KafkaConsumerConfiguration" });
+    expect(text(classRead)).toMatch(/^\[Symbol: KafkaConsumerConfiguration \(class\), lines 6-21 of 2\d\]/);
+    expect(text(classRead)).toContain("public class KafkaConsumerConfiguration");
+
+    const methodRead = await readTool({ path: fixture, symbol: "KafkaConsumerConfiguration.consumerFactory" });
+    expect(text(methodRead)).toMatch(/^\[Symbol: consumerFactory \(method\) in KafkaConsumerConfiguration, lines 13-16 of 2\d\]/);
+    expect(text(methodRead)).toContain("return Map.of");
+  });
+
+  it("uses registered Java maps for local bundles and symbol-scoped grep", async () => {
+    const bundleRead = await readTool({ path: fixture, symbol: "KafkaConsumerConfiguration.consumerFactory", bundle: "local" });
+    expect(text(bundleRead)).toContain("## Requested symbol");
+    expect(text(bundleRead)).toContain("## Local support");
+    expect(text(bundleRead)).toContain("private String helperName()");
+
+    const grep = await grepTool({ pattern: "bootstrap.servers", path: fixture, literal: true, scope: "symbol" });
+    expect(text(grep)).toContain(`--- ${basename(fixture)} :: method consumerFactory in KafkaConsumerConfiguration (13-16, 1 matches) ---`);
+    const consumerScope = grep.details?.ptcValue.scopes.groups.find(
+      (group: any) => group.symbol.name === "consumerFactory",
+    );
+    expect(consumerScope?.symbol).toEqual(
+      expect.objectContaining({ name: "consumerFactory", kind: "method", startLine: 13, endLine: 16 }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds first-class Java structural navigation to `pi-hashline-readmap` using `tree-sitter-java`.

This PR makes `.java` files participate in the existing readmap pipeline for:

- structural maps via `read({ path, map: true })`
- symbol-addressable reads, including `ClassName.memberName` dot notation
- local bundles for Java symbols
- symbol-scoped `grep`
- `module-info.java` module declarations

## What Changed

- Added `.java` language detection as `{ id: "java", name: "Java" }`.
- Added `tree-sitter-java@0.23.5` as a dependency.
- Added `src/readmap/mappers/java.ts` with `MAPPER_VERSION = 1`.
- Registered the Java mapper in the mapper registry so `generateMapWithIdentity()` reports mapper identity `java`.
- Added Java symbol extraction for:
  - classes, interfaces, enums, records, annotations, and modules
  - methods, constructors, compact constructors, and static initializers (`<clinit>`)
  - fields/constants, including multi-declarator declarations
  - enum constants, including multiple constants on one line
- Added a Java-only exact-name lookup preference so `read({ symbol: "ClassName" })` resolves the top-level class instead of becoming ambiguous with its constructor.

## Test Coverage

New Java-focused tests cover:

- language detection
- basic package/import extraction
- top-level declarations
- member declarations and static initializers
- fields/constants/enum constants
- nested types and excluded nodes
- `module-info.java`
- mapper registration plus read/local-bundle/symbol-scoped-grep integration

## Verification

- `npm test` — 244 files / 1167 tests passed
- `npm run typecheck` — passed
- `npx vitest run tests/java-*.test.ts --reporter verbose` — 8 files / 10 tests passed

## Notes

- Non-Java mapper behavior is unchanged; existing full test suite remains green.
- No public TypeScript signatures changed.

Resolves #137
