### PR TITLE
fix: resolve tree-sitter-java peer override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {
@@ -61,6 +61,9 @@
   },
   "overrides": {
     "tree-sitter-cpp": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-java": {
       "tree-sitter": "0.22.4"
     }
   }


### PR DESCRIPTION
## Summary
- bump package version to 0.8.1 for republish
- add a tree-sitter-java override so npm resolves it with tree-sitter@0.22.4
- refresh package-lock root version metadata

## Reported issue
- https://github.com/coctostan/pi-hashline-readmap/pull/66#issuecomment-4353802950

## Validation
- rm -rf node_modules && npm install --omit=dev
- npm install
- npm run typecheck
- npm test
- npm pack --dry-run

Fixes #141