### PR TITLE
Ship 139-m9-bash-post-rtk-recoverable-context-gua

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ import { registerLsTool } from "./src/ls.js";
 import { registerFindTool } from "./src/find.js";
 import { filterBashOutput } from "./src/rtk/bash-filter.js";
 import { selectBashOriginalOutput } from "./src/rtk/bash-original-output.js";
+import { applyBashContextGuard, resolveBashContextGuardConfig } from "./src/rtk/bash-context-guard.js";
 import { stripAnsi } from "./src/rtk/ansi.js";
 import { applyContextHygieneStaleContext } from "./src/context-application.js";
 import {
@@ -216,9 +217,11 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
 
     const existingDetails =
       event.details && typeof event.details === "object" ? (event.details as Record<string, unknown>) : {};
+    const bashContextGuardConfig = resolveBashContextGuardConfig();
     const originalSelection = selectBashOriginalOutput({
       visibleText: originalText,
       fullOutputPath: existingDetails.fullOutputPath,
+      enabled: bashContextGuardConfig.enabled,
     });
 
     const command =
@@ -238,13 +241,20 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
     };
     if (!BASH_FILTER_ENABLED) {
       const stripped = stripAnsi(originalText);
-      const text = applyWarning(stripped);
-      if (text === originalText) return undefined;
+      const finalText = applyWarning(stripped);
+      const guarded = applyBashContextGuard({
+        text: finalText,
+        command,
+        originalMetadata: originalSelection.metadata,
+        config: bashContextGuardConfig,
+      });
+      if (guarded.text === originalText && !originalSelection.metadata) return undefined;
       return {
-        content: [{ type: "text" as const, text }, ...nonTextContent],
+        content: [{ type: "text" as const, text: guarded.text }, ...nonTextContent],
         details: {
           ...existingDetails,
           contextHygiene,
+          bashContextGuard: guarded.metadata,
           ...(originalSelection.metadata ? { bashOriginalOutput: originalSelection.metadata } : {}),
         },
       };
@@ -255,12 +265,20 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
     }
     const notice = buildRtkNotice(info, command, output === "");
     const body = notice ? `${notice}\n${output}` : output;
+    const finalText = applyWarning(body);
+    const guarded = applyBashContextGuard({
+      text: finalText,
+      command,
+      originalMetadata: originalSelection.metadata,
+      config: bashContextGuardConfig,
+    });
     return {
-      content: [{ type: "text" as const, text: applyWarning(body) }, ...nonTextContent],
+      content: [{ type: "text" as const, text: guarded.text }, ...nonTextContent],
       details: {
         ...existingDetails,
         compressionInfo: info,
         contextHygiene,
+        bashContextGuard: guarded.metadata,
         ...(originalSelection.metadata ? { bashOriginalOutput: originalSelection.metadata } : {}),
       },
     };

--- a/src/rtk/bash-context-guard.ts
+++ b/src/rtk/bash-context-guard.ts
@@ -1,0 +1,253 @@
+import { randomUUID } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parsePositiveBase10Int } from "../grep-budget.js";
+import type { BashOriginalOutputMetadata } from "./bash-original-output.js";
+
+export const BASH_CONTEXT_GUARD_DEFAULT_MAX_LINES = 2000;
+export const BASH_CONTEXT_GUARD_DEFAULT_MAX_BYTES = 50 * 1024;
+export const BASH_CONTEXT_GUARD_DEFAULT_HEAD_LINES = 80;
+export const BASH_CONTEXT_GUARD_DEFAULT_TAIL_LINES = 120;
+
+const BASH_CONTEXT_GUARD_PREVIEW_LINE_MAX_BYTES = 1024;
+
+export interface BashContextGuardConfig {
+  enabled: boolean;
+  maxLines: number;
+  maxBytes: number;
+  headLines: number;
+  tailLines: number;
+}
+
+export interface BashContextGuardMetadata {
+  enabled: boolean;
+  trimmed: boolean;
+  trimWanted: boolean;
+  postRtkLineCount: number;
+  postRtkByteCount: number;
+  maxLines: number;
+  maxBytes: number;
+  headLines: number;
+  tailLines: number;
+  postRtkOutputPath?: string;
+  postRtkWriteError?: string;
+  preservedNoticeCount?: number;
+}
+
+export interface BashContextGuardFs {
+  writeFile(path: string, content: string, options: { mode: number; flag: string }): void;
+  randomId(): string;
+  tempDir(): string;
+}
+
+export interface ApplyBashContextGuardOptions {
+  text: string;
+  command?: string;
+  originalMetadata?: BashOriginalOutputMetadata;
+  config?: BashContextGuardConfig;
+  fs?: Partial<BashContextGuardFs>;
+}
+
+export interface BashContextGuardResult {
+  text: string;
+  metadata: BashContextGuardMetadata;
+}
+
+type Env = Record<string, string | undefined>;
+
+function defaultFs(): BashContextGuardFs {
+  return {
+    writeFile: (path, content, options) => writeFileSync(path, content, options),
+    randomId: () => randomUUID(),
+    tempDir: () => tmpdir(),
+  };
+}
+
+function mergeFs(overrides: Partial<BashContextGuardFs> | undefined): BashContextGuardFs {
+  return { ...defaultFs(), ...(overrides ?? {}) };
+}
+
+function resolveDimension(rawEnvValue: string | undefined, ceiling: number): number {
+  const parsed = parsePositiveBase10Int(rawEnvValue);
+  if (parsed === undefined) return ceiling;
+  return Math.min(parsed, ceiling);
+}
+
+function lineCount(text: string): number {
+  return text === "" ? 0 : text.split("\n").length;
+}
+
+function byteCount(text: string): number {
+  return Buffer.byteLength(text, "utf8");
+}
+
+
+function truncateUtf8(text: string, maxBytes: number): { text: string; byteCount: number } {
+  let bytes = 0;
+  let result = "";
+
+  for (const char of text) {
+    const charBytes = byteCount(char);
+    if (bytes + charBytes > maxBytes) break;
+    result += char;
+    bytes += charBytes;
+  }
+
+  return { text: result, byteCount: bytes };
+}
+
+function formatPreviewLine(line: string): string {
+  const totalBytes = byteCount(line);
+  if (totalBytes <= BASH_CONTEXT_GUARD_PREVIEW_LINE_MAX_BYTES) return line;
+
+  const truncated = truncateUtf8(line, BASH_CONTEXT_GUARD_PREVIEW_LINE_MAX_BYTES);
+  return `${truncated.text}\n[truncated preview line: ${totalBytes} bytes total, showing ${truncated.byteCount} bytes]`;
+}
+
+function writePostRtkOutput(fs: BashContextGuardFs, text: string): string {
+  const path = join(fs.tempDir(), `hashline-bash-post-rtk-${fs.randomId()}.txt`);
+  fs.writeFile(path, text, { mode: 0o600, flag: "wx" });
+  return path;
+}
+
+function compactCommand(command: string | undefined): string | undefined {
+  const compact = command?.replace(/\s+/g, " ").trim();
+  if (!compact) return undefined;
+  return compact.length > 120 ? `${compact.slice(0, 117)}...` : compact;
+}
+
+function isRawCommandWrapper(line: string): boolean {
+  return /^Ran\b/.test(line.trim());
+}
+
+function isProtectedNotice(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    trimmed.startsWith("[RTK:") ||
+    trimmed.startsWith("[Hint:") ||
+    trimmed.includes("PI_RTK_BYPASS=1") ||
+    trimmed.includes("Full output:") ||
+    /^Full output:\s*\S+/.test(trimmed) ||
+    /^Command exited with code \d+/.test(trimmed) ||
+    trimmed.startsWith("[Bash context guard:") ||
+    trimmed.startsWith("Full post-RTK output:") ||
+    trimmed.startsWith("⚠ REPEATED-CALL WARNING:") ||
+    trimmed.startsWith("⚠ ALTERNATING-CALL WARNING:")
+  );
+}
+
+function splitPreviewLines(text: string): { bodyLines: string[]; preservedNotices: string[] } {
+  const bodyLines: string[] = [];
+  const preservedNotices: string[] = [];
+  const seenNotices = new Set<string>();
+
+  for (const line of text.split("\n")) {
+    if (isRawCommandWrapper(line)) continue;
+    if (isProtectedNotice(line)) {
+      if (!seenNotices.has(line)) {
+        seenNotices.add(line);
+        preservedNotices.push(line);
+      }
+      continue;
+    }
+    bodyLines.push(line);
+  }
+
+  return { bodyLines, preservedNotices };
+}
+
+function renderPreview(options: {
+  text: string;
+  outputPath: string;
+  command?: string;
+  originalMetadata?: BashOriginalOutputMetadata;
+  metadata: BashContextGuardMetadata;
+  preservedNotices: string[];
+}): string {
+  const { bodyLines, preservedNotices } = { ...splitPreviewLines(options.text), preservedNotices: options.preservedNotices };
+  const headEnd = Math.min(options.metadata.headLines, bodyLines.length);
+  const tailStart = options.metadata.tailLines === 0 ? bodyLines.length : Math.max(headEnd, bodyLines.length - options.metadata.tailLines);
+  const head = bodyLines.slice(0, headEnd).map(formatPreviewLine);
+  const tail = bodyLines.slice(tailStart).map(formatPreviewLine);
+  const omitted = bodyLines.slice(headEnd, tailStart);
+  const omittedText = omitted.join("\n");
+  const command = compactCommand(options.command);
+  const rendered: string[] = [
+    "[Bash context guard: preview]",
+    `Full post-RTK output: ${options.outputPath}`,
+  ];
+
+  if (options.originalMetadata?.originalPath) rendered.push(`Original/pre-RTK output: ${options.originalMetadata.originalPath}`);
+  if (options.originalMetadata) {
+    rendered.push(`Original/pre-RTK: ${options.originalMetadata.originalLineCount} lines, ${options.originalMetadata.originalByteCount} bytes`);
+  }
+  rendered.push(`Post-RTK: ${options.metadata.postRtkLineCount} lines, ${options.metadata.postRtkByteCount} bytes`);
+  rendered.push(`Limits: ${options.metadata.maxLines} lines, ${options.metadata.maxBytes} bytes`);
+  if (command) rendered.push(`Command: ${command}`);
+  if (preservedNotices.length > 0) rendered.push("", "Preserved notices:", ...preservedNotices);
+  rendered.push("", "Head:", ...head);
+  if (omitted.length > 0) rendered.push(`... omitted ${omitted.length} lines / ${byteCount(omittedText)} bytes ...`);
+  rendered.push("Tail:", ...tail, "[End Bash context guard preview]");
+  return rendered.join("\n");
+}
+
+export function resolveBashContextGuardConfig(env: Env = process.env): BashContextGuardConfig {
+  return {
+    enabled: env.PI_HASHLINE_BASH_CONTEXT_GUARD !== "0",
+    maxLines: resolveDimension(env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES, BASH_CONTEXT_GUARD_DEFAULT_MAX_LINES),
+    maxBytes: resolveDimension(env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES, BASH_CONTEXT_GUARD_DEFAULT_MAX_BYTES),
+    headLines: resolveDimension(env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES, BASH_CONTEXT_GUARD_DEFAULT_HEAD_LINES),
+    tailLines: resolveDimension(env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES, BASH_CONTEXT_GUARD_DEFAULT_TAIL_LINES),
+  };
+}
+
+export function applyBashContextGuard(options: ApplyBashContextGuardOptions): BashContextGuardResult {
+  const config = options.config ?? resolveBashContextGuardConfig();
+  const postRtkLineCount = lineCount(options.text);
+  const postRtkByteCount = byteCount(options.text);
+  const trimWanted = config.enabled && options.text !== "" && (postRtkLineCount > config.maxLines || postRtkByteCount > config.maxBytes);
+  const preservedNotices = trimWanted ? splitPreviewLines(options.text).preservedNotices : [];
+  const baseMetadata: BashContextGuardMetadata = {
+    enabled: config.enabled,
+    trimmed: false,
+    trimWanted,
+    postRtkLineCount,
+    postRtkByteCount,
+    maxLines: config.maxLines,
+    maxBytes: config.maxBytes,
+    headLines: config.headLines,
+    tailLines: config.tailLines,
+    preservedNoticeCount: preservedNotices.length,
+  };
+
+  if (!trimWanted) return { text: options.text, metadata: baseMetadata };
+
+  try {
+    const outputPath = writePostRtkOutput(mergeFs(options.fs), options.text);
+    const metadata: BashContextGuardMetadata = {
+      ...baseMetadata,
+      trimmed: true,
+      postRtkOutputPath: outputPath,
+    };
+    return {
+      text: renderPreview({
+        text: options.text,
+        outputPath,
+        command: options.command,
+        originalMetadata: options.originalMetadata,
+        metadata,
+        preservedNotices,
+      }),
+      metadata,
+    };
+  } catch (error) {
+    return {
+      text: options.text,
+      metadata: {
+        ...baseMetadata,
+        postRtkWriteError: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+}

--- a/tests/bash-context-guard-apply.test.ts
+++ b/tests/bash-context-guard-apply.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { applyBashContextGuard } from "../src/rtk/bash-context-guard.js";
+
+describe("applyBashContextGuard", () => {
+  it("leaves within-limit post-RTK text byte-for-byte unchanged while attaching metadata", () => {
+    const text = "alpha\nbeta";
+
+    const result = applyBashContextGuard({
+      text,
+      config: { enabled: true, maxLines: 5, maxBytes: 1024, headLines: 2, tailLines: 2 },
+    });
+
+    expect(result.text).toBe(text);
+    expect(result.metadata).toEqual({
+      enabled: true,
+      trimmed: false,
+      trimWanted: false,
+      postRtkLineCount: 2,
+      postRtkByteCount: Buffer.byteLength(text, "utf8"),
+      maxLines: 5,
+      maxBytes: 1024,
+      headLines: 2,
+      tailLines: 2,
+      preservedNoticeCount: 0,
+    });
+  });
+
+  it("returns disabled metadata without trimming when the guard is disabled", () => {
+    const text = "alpha\nbeta\ngamma";
+
+    const result = applyBashContextGuard({
+      text,
+      config: { enabled: false, maxLines: 1, maxBytes: 1, headLines: 1, tailLines: 1 },
+    });
+
+    expect(result.text).toBe(text);
+    expect(result.metadata).toMatchObject({
+      enabled: false,
+      trimmed: false,
+      trimWanted: false,
+      postRtkLineCount: 3,
+      postRtkByteCount: Buffer.byteLength(text, "utf8"),
+      maxLines: 1,
+      maxBytes: 1,
+      headLines: 1,
+      tailLines: 1,
+    });
+  });
+});

--- a/tests/bash-context-guard-config.test.ts
+++ b/tests/bash-context-guard-config.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  BASH_CONTEXT_GUARD_DEFAULT_HEAD_LINES,
+  BASH_CONTEXT_GUARD_DEFAULT_MAX_BYTES,
+  BASH_CONTEXT_GUARD_DEFAULT_MAX_LINES,
+  BASH_CONTEXT_GUARD_DEFAULT_TAIL_LINES,
+  resolveBashContextGuardConfig,
+} from "../src/rtk/bash-context-guard.js";
+
+describe("resolveBashContextGuardConfig", () => {
+  const saved = {
+    enabled: process.env.PI_HASHLINE_BASH_CONTEXT_GUARD,
+    maxLines: process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES,
+    maxBytes: process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES,
+    headLines: process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES,
+    tailLines: process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES,
+  };
+
+  beforeEach(() => {
+    delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD;
+    delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES;
+    delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES;
+    delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES;
+    delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES;
+  });
+
+  afterEach(() => {
+    if (saved.enabled === undefined) delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD;
+    else process.env.PI_HASHLINE_BASH_CONTEXT_GUARD = saved.enabled;
+    if (saved.maxLines === undefined) delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES;
+    else process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES = saved.maxLines;
+    if (saved.maxBytes === undefined) delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES;
+    else process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES = saved.maxBytes;
+    if (saved.headLines === undefined) delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES;
+    else process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES = saved.headLines;
+    if (saved.tailLines === undefined) delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES;
+    else process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES = saved.tailLines;
+  });
+
+  it("uses conservative defaults when env vars are unset", () => {
+    expect(resolveBashContextGuardConfig()).toEqual({
+      enabled: true,
+      maxLines: 2000,
+      maxBytes: 51200,
+      headLines: 80,
+      tailLines: 120,
+    });
+    expect(BASH_CONTEXT_GUARD_DEFAULT_MAX_LINES).toBe(2000);
+    expect(BASH_CONTEXT_GUARD_DEFAULT_MAX_BYTES).toBe(51200);
+    expect(BASH_CONTEXT_GUARD_DEFAULT_HEAD_LINES).toBe(80);
+    expect(BASH_CONTEXT_GUARD_DEFAULT_TAIL_LINES).toBe(120);
+  });
+
+  it("uses valid below-default positive base-10 env values", () => {
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES = "25";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES = "1024";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES = "3";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES = "7";
+
+    expect(resolveBashContextGuardConfig()).toEqual({
+      enabled: true,
+      maxLines: 25,
+      maxBytes: 1024,
+      headLines: 3,
+      tailLines: 7,
+    });
+  });
+
+  it("trims surrounding whitespace before parsing env values", () => {
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES = " 25 ";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES = "\t1024\n";
+
+    expect(resolveBashContextGuardConfig().maxLines).toBe(25);
+    expect(resolveBashContextGuardConfig().maxBytes).toBe(1024);
+  });
+
+  it("falls back to defaults for invalid env values", () => {
+    for (const raw of ["abc", "", " ", "0", "-1", "+1", "3.14", "0x10", "1e3", "1,000", "1_000"]) {
+      process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES = raw;
+      process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES = raw;
+      process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES = raw;
+      process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES = raw;
+
+      expect(resolveBashContextGuardConfig()).toEqual({
+        enabled: true,
+        maxLines: 2000,
+        maxBytes: 51200,
+        headLines: 80,
+        tailLines: 120,
+      });
+    }
+  });
+
+  it("clamps above-default env values to defaults", () => {
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES = "99999";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES = "104857600";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES = "999";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES = "999";
+
+    expect(resolveBashContextGuardConfig()).toEqual({
+      enabled: true,
+      maxLines: 2000,
+      maxBytes: 51200,
+      headLines: 80,
+      tailLines: 120,
+    });
+  });
+
+  it("disables the guard only when PI_HASHLINE_BASH_CONTEXT_GUARD is exactly 0", () => {
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD = "0";
+    expect(resolveBashContextGuardConfig().enabled).toBe(false);
+
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD = "false";
+    expect(resolveBashContextGuardConfig().enabled).toBe(true);
+  });
+
+  it("re-reads env on every call", () => {
+    expect(resolveBashContextGuardConfig().maxLines).toBe(2000);
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES = "9";
+    expect(resolveBashContextGuardConfig().maxLines).toBe(9);
+    delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES;
+    expect(resolveBashContextGuardConfig().maxLines).toBe(2000);
+  });
+});

--- a/tests/bash-context-guard-integration.test.ts
+++ b/tests/bash-context-guard-integration.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as gitModule from "../src/rtk/git.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+async function loadHandlers(tag: string) {
+  const modUrl = pathToFileURL(resolve(root, "index.ts")).href + `?bash-context-guard=${tag}-${Date.now()}`;
+  const handlers: Record<string, Function> = {};
+  const mockPi = {
+    registerTool() {},
+    on(event: string, handler: Function) { handlers[event] = handler; },
+    events: { emit() {}, on() {} },
+  };
+  const mod = await import(modUrl);
+  mod.default(mockPi as any);
+  return handlers;
+}
+
+describe("bash context guard integration", () => {
+  const saved = {
+    enabled: process.env.PI_HASHLINE_BASH_CONTEXT_GUARD,
+    maxLines: process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES,
+    maxBytes: process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES,
+    headLines: process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES,
+    tailLines: process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES,
+  };
+
+  beforeEach(() => {
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES = "3";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES = "4096";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES = "1";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES = "1";
+    delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (saved.enabled === undefined) delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD;
+    else process.env.PI_HASHLINE_BASH_CONTEXT_GUARD = saved.enabled;
+    if (saved.maxLines === undefined) delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES;
+    else process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES = saved.maxLines;
+    if (saved.maxBytes === undefined) delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES;
+    else process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES = saved.maxBytes;
+    if (saved.headLines === undefined) delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES;
+    else process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES = saved.headLines;
+    if (saved.tailLines === undefined) delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES;
+    else process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES = saved.tailLines;
+  });
+
+  it("does not guard non-bash tool results", async () => {
+    const handlers = await loadHandlers("non-bash");
+
+    const result = await handlers.tool_result({
+      type: "tool_result",
+      toolName: "read",
+      toolCallId: "read-guard-skip",
+      input: { path: "src/example.ts" },
+      content: [{ type: "text", text: "plain read result" }],
+      isError: false,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("guards after RTK notices and doom-loop warnings are assembled while preserving non-text content", async () => {
+    vi.spyOn(gitModule, "compactGitOutput").mockReturnValue(["post-1", "post-2", "post-3", "post-4"].join("\n"));
+    const handlers = await loadHandlers("after-rtk-doom");
+    const nonText = { type: "image", data: "opaque" };
+    const input = { command: "git diff" };
+
+    handlers.tool_call({ toolName: "bash", toolCallId: "loop-1", input });
+    handlers.tool_call({ toolName: "bash", toolCallId: "loop-2", input });
+    handlers.tool_call({ toolName: "bash", toolCallId: "bash-guard-after-rtk", input });
+
+    const result = await handlers.tool_result({
+      type: "tool_result",
+      toolName: "bash",
+      toolCallId: "bash-guard-after-rtk",
+      input,
+      content: [{ type: "text", text: "raw git diff\n" + "x".repeat(3000) }, nonText],
+      details: { existing: "kept" },
+      isError: false,
+    });
+
+    expect(result.content[0].text).toContain("[Bash context guard: preview]");
+    expect(result.content[0].text).toContain("Preserved notices:");
+    expect(result.content[0].text).toContain("[RTK: compressed git output");
+    expect(result.content[0].text).toContain("⚠ REPEATED-CALL WARNING: This is the 3rd identical tool call.");
+    expect(result.content[0].text).toContain("post-4");
+    expect(result.content[0].text).not.toContain("raw git diff");
+    expect(result.content.slice(1)).toEqual([nonText]);
+    expect(result.details.existing).toBe("kept");
+    expect(result.details.compressionInfo.technique).toBe("git");
+    expect(result.details.bashContextGuard).toMatchObject({
+      enabled: true,
+      trimmed: true,
+      trimWanted: true,
+      maxLines: 3,
+      headLines: 1,
+      tailLines: 1,
+    });
+    expect(result.details.bashContextGuard.postRtkLineCount).toBeGreaterThan(4);
+    expect(result.details.bashOriginalOutput).toMatchObject({ source: "pi-visible" });
+  });
+
+  it("still guards PI_RTK_BYPASS output", async () => {
+    const handlers = await loadHandlers("rtk-bypass");
+
+    const result = await handlers.tool_result({
+      type: "tool_result",
+      toolName: "bash",
+      toolCallId: "bash-guard-bypass",
+      input: { command: "PI_RTK_BYPASS=1 echo hello" },
+      content: [{ type: "text", text: ["a", "b", "c", "d"].join("\n") }],
+      isError: false,
+    });
+
+    expect(result.details.compressionInfo).toMatchObject({ technique: "none", bypassedBy: "env-var" });
+    expect(result.details.bashContextGuard).toMatchObject({ enabled: true, trimmed: true, trimWanted: true });
+    expect(result.content[0].text).toContain("[Bash context guard: preview]");
+  });
+
+  it("feature flag disables original restoration and final guard trimming while preserving RTK", async () => {
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD = "0";
+    const dir = mkdtempSync(join(tmpdir(), "hashline-guard-disabled-"));
+    const fullPath = join(dir, "full.txt");
+    writeFileSync(fullPath, "FULL\nFULL\nFULL\nFULL\n", "utf8");
+    let seenByRtk = "";
+    vi.spyOn(gitModule, "compactGitOutput").mockImplementation((output) => {
+      seenByRtk = output;
+      return output.includes("FULL") ? "compressed full" : "compressed visible";
+    });
+
+    try {
+      const handlers = await loadHandlers("disabled");
+      const result = await handlers.tool_result({
+        type: "tool_result",
+        toolName: "bash",
+        toolCallId: "bash-guard-disabled",
+        input: { command: "git diff" },
+        content: [{ type: "text", text: `VISIBLE\n[Showing lines 1-1 of 4. Full output: ${fullPath}]` }],
+        details: { fullOutputPath: fullPath },
+        isError: false,
+      });
+
+      expect(seenByRtk).toContain("VISIBLE");
+      expect(seenByRtk).not.toContain("FULL\nFULL");
+      expect(result.content[0].text).toBe("compressed visible");
+      expect(result.details.compressionInfo.technique).toBe("git");
+      expect(result.details.bashOriginalOutput).toBeUndefined();
+      expect(result.details.bashContextGuard).toMatchObject({ enabled: false, trimmed: false, trimWanted: false });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/bash-context-guard-notices.test.ts
+++ b/tests/bash-context-guard-notices.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { applyBashContextGuard } from "../src/rtk/bash-context-guard.js";
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe("guarded Bash preview protected notices", () => {
+  it("deduplicates protected notices, removes wrapper lines, and truncates the command in the header", () => {
+    const rtkNotice = "[RTK: compressed git output 100.0 KB → 1.0 KB (99% saved). Use `PI_RTK_BYPASS=1 git diff` to see full output.]";
+    const exitNotice = "Command exited with code 1";
+    const text = [
+      rtkNotice,
+      "Ran bash command: git diff --stat",
+      "body-1",
+      exitNotice,
+      "body-2",
+      rtkNotice,
+      "body-3",
+      exitNotice,
+      "body-4",
+    ].join("\n");
+    const longCommand = `node ${"x".repeat(200)}`;
+    const expectedCommand = longCommand.slice(0, 117) + "...";
+
+    const result = applyBashContextGuard({
+      text,
+      command: longCommand,
+      config: { enabled: true, maxLines: 4, maxBytes: 4096, headLines: 1, tailLines: 1 },
+      fs: {
+        randomId: () => "notice-id",
+        tempDir: () => "/tmp",
+        writeFile() {},
+      },
+    });
+
+    expect(result.text).toContain("Preserved notices:");
+    expect(occurrences(result.text, rtkNotice)).toBe(1);
+    expect(occurrences(result.text, exitNotice)).toBe(1);
+    expect(result.text).not.toContain("Ran bash command");
+    expect(result.text).toContain(`Command: ${expectedCommand}`);
+    expect(result.text).toContain("Head:\nbody-1");
+    expect(result.text).toContain("Tail:\nbody-4");
+    expect(result.metadata.preservedNoticeCount).toBe(2);
+  });
+
+  it("protects pi full-output notices and stable doom-loop warning lines", () => {
+    const fullOutputNotice = "[Showing lines 1-2 of 10. Full output: /tmp/full-output.txt]";
+    const doomLoopNotice = "⚠ REPEATED-CALL WARNING: This is the 3rd identical tool call.";
+    const text = [fullOutputNotice, "body-1", doomLoopNotice, "body-2", "body-3"].join("\n");
+
+    const result = applyBashContextGuard({
+      text,
+      config: { enabled: true, maxLines: 3, maxBytes: 4096, headLines: 1, tailLines: 1 },
+      fs: {
+        randomId: () => "doom-id",
+        tempDir: () => "/tmp",
+        writeFile() {},
+      },
+    });
+
+    expect(result.text).toContain("Preserved notices:");
+    expect(result.text).toContain(fullOutputNotice);
+    expect(result.text).toContain(doomLoopNotice);
+    expect(result.metadata.preservedNoticeCount).toBe(2);
+  });
+});

--- a/tests/bash-context-guard-trim.test.ts
+++ b/tests/bash-context-guard-trim.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { applyBashContextGuard } from "../src/rtk/bash-context-guard.js";
+
+describe("applyBashContextGuard trimming", () => {
+  it("writes full post-RTK text before replacing line-over-limit output with a recoverable preview", () => {
+    const text = ["line-1", "line-2", "line-3", "line-4", "line-5", "line-6"].join("\n");
+    const writes: Array<{ path: string; content: string; options: { mode: number; flag: string } }> = [];
+
+    const result = applyBashContextGuard({
+      text,
+      command: "npm test -- --runInBand",
+      originalMetadata: {
+        enabled: true,
+        source: "pi-full-output-path",
+        restoredContentForRtk: true,
+        originalPath: "/tmp/original-output.txt",
+        snapshotNeeded: false,
+        snapshotWritten: false,
+        originalLineCount: 10,
+        originalByteCount: 300,
+        visibleLineCount: 2,
+        visibleByteCount: 40,
+      },
+      config: { enabled: true, maxLines: 5, maxBytes: 1024, headLines: 2, tailLines: 2 },
+      fs: {
+        randomId: () => "fixed-id",
+        tempDir: () => "/tmp",
+        writeFile(path, content, options) {
+          writes.push({ path, content, options });
+        },
+      },
+    });
+
+    expect(writes).toEqual([
+      {
+        path: "/tmp/hashline-bash-post-rtk-fixed-id.txt",
+        content: text,
+        options: { mode: 0o600, flag: "wx" },
+      },
+    ]);
+    expect(result.text).not.toBe(text);
+    expect(result.text).toContain("[Bash context guard: preview]");
+    expect(result.text).toContain("Full post-RTK output: /tmp/hashline-bash-post-rtk-fixed-id.txt");
+    expect(result.text).toContain("Original/pre-RTK output: /tmp/original-output.txt");
+    expect(result.text).toContain("Original/pre-RTK: 10 lines, 300 bytes");
+    expect(result.text).toContain(`Post-RTK: 6 lines, ${Buffer.byteLength(text, "utf8")} bytes`);
+    expect(result.text).toContain("Limits: 5 lines, 1024 bytes");
+    expect(result.text).toContain("Command: npm test -- --runInBand");
+    expect(result.text).toContain("Head:");
+    expect(result.text).toContain("line-1\nline-2");
+    expect(result.text).toContain("... omitted 2 lines");
+    expect(result.text).toContain("Tail:");
+    expect(result.text).toContain("line-5\nline-6");
+    expect(result.text).not.toContain("use tool");
+    expect(result.metadata).toMatchObject({
+      enabled: true,
+      trimmed: true,
+      trimWanted: true,
+      postRtkLineCount: 6,
+      postRtkByteCount: Buffer.byteLength(text, "utf8"),
+      maxLines: 5,
+      maxBytes: 1024,
+      headLines: 2,
+      tailLines: 2,
+      postRtkOutputPath: "/tmp/hashline-bash-post-rtk-fixed-id.txt",
+      preservedNoticeCount: 0,
+    });
+  });
+
+  it("leaves byte-over-limit output unchanged when writing the recoverable file fails", () => {
+    const text = "0123456789";
+
+    const result = applyBashContextGuard({
+      text,
+      config: { enabled: true, maxLines: 20, maxBytes: 5, headLines: 1, tailLines: 1 },
+      fs: {
+        randomId: () => "fixed-id",
+        tempDir: () => "/tmp",
+        writeFile() {
+          throw new Error("disk full");
+        },
+      },
+    });
+
+    expect(result.text).toBe(text);
+    expect(result.metadata).toMatchObject({
+      enabled: true,
+      trimmed: false,
+      trimWanted: true,
+      postRtkLineCount: 1,
+      postRtkByteCount: 10,
+      maxLines: 20,
+      maxBytes: 5,
+      headLines: 1,
+      tailLines: 1,
+      postRtkWriteError: "disk full",
+    });
+    expect(result.metadata.postRtkOutputPath).toBeUndefined();
+  });
+
+
+  it("keeps byte-over-limit single-line previews concise after writing the recoverable file", () => {
+    const text = "x".repeat(10_000);
+    const writes: Array<{ path: string; content: string; options: { mode: number; flag: string } }> = [];
+
+    const result = applyBashContextGuard({
+      text,
+      config: { enabled: true, maxLines: 20, maxBytes: 5, headLines: 1, tailLines: 1 },
+      fs: {
+        randomId: () => "long-line-id",
+        tempDir: () => "/tmp",
+        writeFile(path, content, options) {
+          writes.push({ path, content, options });
+        },
+      },
+    });
+
+    expect(writes).toEqual([
+      {
+        path: "/tmp/hashline-bash-post-rtk-long-line-id.txt",
+        content: text,
+        options: { mode: 0o600, flag: "wx" },
+      },
+    ]);
+    expect(result.text).toContain("[Bash context guard: preview]");
+    expect(result.text).toContain("[truncated preview line: 10000 bytes total");
+    expect(result.text).not.toContain(text);
+    expect(Buffer.byteLength(result.text, "utf8")).toBeLessThan(2_500);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Bash-only post-RTK context guard that prevents oversized Bash tool results from flooding provider context while keeping the complete final output recoverable.

When a Bash result exceeds configured line or byte limits, the guard now writes the full post-RTK text to a restrictive temp file before replacing visible output with a concise preview. The preview includes recovery paths, counts, configured limits, preserved stable notices, and bounded head/tail snippets. Guard metadata is attached separately as `details.bashContextGuard` so callers can distinguish disabled, untrimmed, trimmed, and write-failed states.

## What changed

- Added `src/rtk/bash-context-guard.ts` with:
  - env parsing for `PI_HASHLINE_BASH_CONTEXT_GUARD_*` limits
  - recoverable post-RTK temp-file writes using `0o600` + `wx`
  - guarded preview rendering with preserved notice extraction
  - UTF-8 byte/line metadata and write-failure fallback metadata
  - byte-safe truncation for oversized single preview lines
- Wired Bash `tool_result` handling in `index.ts` so the guard runs after RTK filtering and final notice/warning assembly.
- Kept #138 original-output metadata separate as `details.bashOriginalOutput` and added guard metadata as `details.bashContextGuard`.
- Added focused unit and integration tests covering config, metadata states, recoverable writes, protected notices, RTK bypass, disabled guard behavior, and extension-level Bash handling.

## Verification

- `npm test -- tests/bash-context-guard-trim.test.ts`
  - 1 file passed, 3 tests passed
- `npm test && npm run typecheck`
  - 251 files passed
  - 1198 tests passed
  - typecheck passed

## Notes

- `PI_RTK_BYPASS=1` still only bypasses RTK compression; final Bash output remains guarded.
- `PI_HASHLINE_BASH_CONTEXT_GUARD=0` disables original restoration/snapshotting and final guard trimming while preserving existing RTK behavior.
