### PR TITLE
Harden Bash guard recoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.8.2] - 2026-04-30
+
+### Fixed
+- Harden Bash recoverability by validating Pi full-output paths before reading them and by preserving original/pre-RTK snapshots when the Bash context guard trims without a valid Pi original path.
+- Preserve recoverability metadata when trim-time original snapshot writing fails.
+
+### Docs
+- Document the Bash context guard variables, default-on policy, `PI_HASHLINE_BASH_CONTEXT_GUARD=0`, raw-byte/positive-integer parsing, clamp/fallback semantics, and `PI_RTK_BYPASS=1` interaction.
+- Record the release instruction to bump the package number whenever the Bash guard contract docs/release notes are updated.
+
 ## [0.8.0] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -208,6 +208,18 @@ PI_RTK_BYPASS=1 git log --stat
 
 Use the bypass when the filtered output hides information you need.
 
+### Bash context guard and recoverability
+
+Bash output is processed in layers:
+
+1. The extension first selects the best original/pre-RTK output source. When Pi provides a valid temporary `fullOutputPath`, that file is used for RTK compression. Otherwise the visible Bash text is used.
+2. Route-specific RTK compression may reduce noisy command output unless `PI_RTK_BYPASS=1` is set for that command invocation.
+3. The Bash context guard runs after RTK. When the final post-RTK text is still too large, the guard writes the full post-RTK output to a temporary file and replaces visible output with a recoverable head/tail preview.
+
+The guard is default-on. The shipped default-on policy supersedes the earlier opt-in proposal from the M9 design discussion. Set `PI_HASHLINE_BASH_CONTEXT_GUARD=0` to disable both the Bash context guard and the original-output restoration layer.
+
+`PI_RTK_BYPASS=1` only bypasses route-specific RTK compression. It does not disable the Bash context guard; large raw output can still be guarded unless `PI_HASHLINE_BASH_CONTEXT_GUARD=0` is also set.
+
 ## Tool reference
 
 ### `read`
@@ -287,6 +299,11 @@ This package is configured with environment variables rather than a project-loca
 | `PI_HASHLINE_NO_PERSIST_MAPS=1` | Disable the on-disk structural-map cache | Keeps caching in-memory only |
 | `PI_NUSHELL_CONFIG` | Override the Nushell config path used by `nu` | Otherwise prefers `~/.config/pi/nushell/config.nu`, then `--no-config-file` |
 | `PI_RTK_BYPASS=1` | Disable route-specific `bash` compression for one command invocation | ANSI is still stripped; anti-pattern hints still apply |
+| `PI_HASHLINE_BASH_CONTEXT_GUARD=0` | Disable the Bash context guard and original-output restoration layer | Any value other than exact `0` leaves the default-on guard enabled |
+| `PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES` | Tighten the post-RTK Bash guard line budget | Positive base-10 integer; invalid/unset values use `2000`; above-default values are clamped down |
+| `PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES` | Tighten the post-RTK Bash guard byte budget | Positive base-10 integer interpreted as raw bytes; invalid/unset values use `51200`; above-default values are clamped down |
+| `PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES` | Tighten the guarded preview head size | Positive base-10 integer; invalid/unset values use `80`; above-default values are clamped down |
+| `PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES` | Tighten the guarded preview tail size | Positive base-10 integer; invalid/unset values use `120`; above-default values are clamped down |
 | `PI_CONTEXT_HYGIENE_DEBUG=1` | Register the debug-only `context_hygiene_report` read-only tool | Disabled unless explicitly set to `1` |
 
 ## Structured output (`details.ptcValue`)

--- a/docs/exploratory-functional-testing.md
+++ b/docs/exploratory-functional-testing.md
@@ -94,6 +94,12 @@ Expected behavior:
 - includes targeted compression for tests, build tools, git, linters, docker, package managers, HTTP clients, transfer tools, and file-listing commands
 - strips ANSI noise
 - leaves truly useful output intact enough that the command result remains actionable
+- validates Pi-provided Bash `fullOutputPath` values before reading them and only restores from valid temporary full-output files
+- writes recoverable full post-RTK output when the Bash context guard trims final output
+- writes an original/pre-RTK snapshot when the guard trims and Pi did not provide a valid original full-output path
+- exposes stricter-only guard controls through `PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES`, `PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES`, `PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES`, and `PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES`
+- disables the guard/original-restoration layer only when `PI_HASHLINE_BASH_CONTEXT_GUARD=0`
+- keeps `PI_RTK_BYPASS=1` scoped to RTK compression; bypassed raw output is still eligible for context-guard trimming
 
 Practical expectation:
 
@@ -119,7 +125,7 @@ The present test suite covers, at minimum:
 - `ast_search` formatting, schema handling, execution behavior, no-match behavior, and path handling
 - binary / control-character handling regressions
 - map cache behavior
-- RTK / bash filter routing and compressor-specific behavior
+- RTK / bash filter routing, Bash context guard recoverability, guard configuration, and compressor-specific behavior
 - public PTC policy/value contracts
 - context-hygiene metadata and debug-tool registration
 - configurable grep output budgets

--- a/index.ts
+++ b/index.ts
@@ -8,8 +8,8 @@ import { registerWriteTool } from "./src/write.js";
 import { registerLsTool } from "./src/ls.js";
 import { registerFindTool } from "./src/find.js";
 import { filterBashOutput } from "./src/rtk/bash-filter.js";
-import { selectBashOriginalOutput } from "./src/rtk/bash-original-output.js";
-import { applyBashContextGuard, resolveBashContextGuardConfig } from "./src/rtk/bash-context-guard.js";
+import { ensureBashOriginalOutputSnapshot, selectBashOriginalOutput } from "./src/rtk/bash-original-output.js";
+import { applyBashContextGuard, resolveBashContextGuardConfig, type BashContextGuardConfig } from "./src/rtk/bash-context-guard.js";
 import { stripAnsi } from "./src/rtk/ansi.js";
 import { applyContextHygieneStaleContext } from "./src/context-application.js";
 import { buildBashCommandState } from "./src/bash-command-state.js";
@@ -111,6 +111,10 @@ function buildRtkNotice(
   if (info.compressionRatio >= 0.5) return null;
   const pct = Math.round((1 - info.compressionRatio) * 100);
   return `[RTK: compressed ${info.technique} output ${formatBytes(info.originalBytes)} → ${formatBytes(info.outputBytes)} (${pct}% saved). Use \`PI_RTK_BYPASS=1 ${command}\` to see full output.]`;
+}
+
+function willBashContextGuardTrim(text: string, config: BashContextGuardConfig): boolean {
+  return config.enabled && text !== "" && (text.split("\n").length > config.maxLines || Buffer.byteLength(text, "utf8") > config.maxBytes);
 }
 
 export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
@@ -251,20 +255,28 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
     if (!BASH_FILTER_ENABLED) {
       const stripped = stripAnsi(originalText);
       const finalText = applyWarning(stripped);
+      const originalMetadataForGuard = willBashContextGuardTrim(finalText, bashContextGuardConfig)
+        ? ensureBashOriginalOutputSnapshot({
+            visibleText: originalText,
+            metadata: originalSelection.metadata,
+            enabled: bashContextGuardConfig.enabled,
+          })
+        : originalSelection.metadata;
       const guarded = applyBashContextGuard({
         text: finalText,
         command,
-        originalMetadata: originalSelection.metadata,
+        originalMetadata: originalMetadataForGuard,
         config: bashContextGuardConfig,
       });
-      if (guarded.text === originalText && !originalSelection.metadata) return undefined;
+      const bashOriginalOutput = guarded.metadata.trimmed ? originalMetadataForGuard : originalSelection.metadata;
+      if (guarded.text === originalText && !bashOriginalOutput) return undefined;
       return {
         content: [{ type: "text" as const, text: guarded.text }, ...nonTextContent],
         details: {
           ...existingDetails,
           contextHygiene,
           bashContextGuard: guarded.metadata,
-          ...(originalSelection.metadata ? { bashOriginalOutput: originalSelection.metadata } : {}),
+          ...(bashOriginalOutput ? { bashOriginalOutput } : {}),
         },
       };
     }
@@ -275,12 +287,20 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
     const notice = buildRtkNotice(info, command, output === "");
     const body = notice ? `${notice}\n${output}` : output;
     const finalText = applyWarning(body);
+    const originalMetadataForGuard = willBashContextGuardTrim(finalText, bashContextGuardConfig)
+      ? ensureBashOriginalOutputSnapshot({
+          visibleText: originalText,
+          metadata: originalSelection.metadata,
+          enabled: bashContextGuardConfig.enabled,
+        })
+      : originalSelection.metadata;
     const guarded = applyBashContextGuard({
       text: finalText,
       command,
-      originalMetadata: originalSelection.metadata,
+      originalMetadata: originalMetadataForGuard,
       config: bashContextGuardConfig,
     });
+    const bashOriginalOutput = guarded.metadata.trimmed ? originalMetadataForGuard : originalSelection.metadata;
     return {
       content: [{ type: "text" as const, text: guarded.text }, ...nonTextContent],
       details: {
@@ -288,7 +308,7 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
         compressionInfo: info,
         contextHygiene,
         bashContextGuard: guarded.metadata,
-        ...(originalSelection.metadata ? { bashOriginalOutput: originalSelection.metadata } : {}),
+        ...(bashOriginalOutput ? { bashOriginalOutput } : {}),
       },
     };
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {

--- a/src/rtk/bash-original-output.ts
+++ b/src/rtk/bash-original-output.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join, relative, sep } from "node:path";
 import { readFileSync, writeFileSync } from "node:fs";
 
 export type BashOriginalOutputSource = "pi-full-output-path" | "pi-visible-fallback" | "pi-visible";
@@ -72,6 +72,18 @@ export function extractVisibleFullOutputPath(visibleText: string): string | unde
   return match?.[1]?.trim() || undefined;
 }
 
+function isPathInside(parent: string, candidate: string): boolean {
+  const relativePath = relative(parent, candidate);
+  return relativePath === "" || (relativePath !== ".." && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath));
+}
+
+function validateFullOutputPath(fs: BashOriginalOutputFs, value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  if (value.trim() !== value || value === "") return undefined;
+  if (!isAbsolute(value)) return undefined;
+  return isPathInside(fs.tempDir(), value) ? value : undefined;
+}
+
 function writeSnapshot(fs: BashOriginalOutputFs, visibleText: string): string {
   const path = join(fs.tempDir(), `hashline-bash-original-${fs.randomId()}.txt`);
   fs.writeFile(path, visibleText, { mode: 0o600, flag: "wx" });
@@ -85,8 +97,8 @@ export function selectBashOriginalOutput(options: SelectBashOriginalOutputOption
   const fs = mergeFs(options.fs);
   const visibleLineCount = lineCount(visibleText);
   const visibleByteCount = byteCount(visibleText);
-  const metadataPath = typeof options.fullOutputPath === "string" ? options.fullOutputPath : undefined;
-  const visibleNoticePath = extractVisibleFullOutputPath(visibleText);
+  const metadataPath = validateFullOutputPath(fs, options.fullOutputPath);
+  const visibleNoticePath = validateFullOutputPath(fs, extractVisibleFullOutputPath(visibleText));
   const fullOutputPath = metadataPath ?? visibleNoticePath;
 
   let fallbackSource: BashOriginalOutputSource = "pi-visible";
@@ -150,4 +162,57 @@ export function selectBashOriginalOutput(options: SelectBashOriginalOutputOption
   };
 
   return { inputForRtk: visibleText, metadata };
+}
+
+export interface EnsureBashOriginalOutputSnapshotOptions {
+  visibleText: string;
+  metadata?: BashOriginalOutputMetadata;
+  enabled?: boolean;
+  fs?: Partial<BashOriginalOutputFs>;
+}
+
+export function ensureBashOriginalOutputSnapshot(
+  options: EnsureBashOriginalOutputSnapshotOptions,
+): BashOriginalOutputMetadata | undefined {
+  const enabled = options.enabled !== false;
+  const visibleText = options.visibleText;
+  const existing = options.metadata;
+  if (!enabled || visibleText === "") return existing;
+  if (existing?.restoredContentForRtk || existing?.originalPath) return existing;
+
+  const visibleLineCount = existing?.visibleLineCount ?? lineCount(visibleText);
+  const visibleByteCount = existing?.visibleByteCount ?? byteCount(visibleText);
+  const originalLineCount = existing?.originalLineCount ?? visibleLineCount;
+  const originalByteCount = existing?.originalByteCount ?? visibleByteCount;
+  const base: BashOriginalOutputMetadata = {
+    enabled: true,
+    source: existing?.source ?? "pi-visible",
+    restoredContentForRtk: false,
+    snapshotNeeded: true,
+    snapshotWritten: false,
+    snapshotPath: undefined,
+    originalPath: undefined,
+    originalLineCount,
+    originalByteCount,
+    visibleLineCount,
+    visibleByteCount,
+    fullOutputReadError: existing?.fullOutputReadError,
+    snapshotWriteError: existing?.snapshotWriteError,
+  };
+
+  try {
+    const snapshotPath = writeSnapshot(mergeFs(options.fs), visibleText);
+    return {
+      ...base,
+      snapshotWritten: true,
+      snapshotPath,
+      originalPath: snapshotPath,
+      snapshotWriteError: existing?.snapshotWriteError,
+    };
+  } catch (error) {
+    return {
+      ...base,
+      snapshotWriteError: error instanceof Error ? error.message : String(error),
+    };
+  }
 }

--- a/tests/bash-context-guard-integration.test.ts
+++ b/tests/bash-context-guard-integration.test.ts
@@ -158,4 +158,30 @@ describe("bash context guard integration", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+
+  it("writes an original/pre-RTK snapshot when stricter guard env trims without a Pi full-output path", async () => {
+    vi.spyOn(gitModule, "compactGitOutput").mockReturnValue(["post-1", "post-2", "post-3", "post-4"].join("\n"));
+    const handlers = await loadHandlers("trim-snapshot");
+
+    const result = await handlers.tool_result({
+      type: "tool_result",
+      toolName: "bash",
+      toolCallId: "bash-guard-trim-snapshot",
+      input: { command: "git diff" },
+      content: [{ type: "text", text: "VISIBLE ORIGINAL" }],
+      isError: false,
+    });
+
+    expect(result.details.bashContextGuard).toMatchObject({ enabled: true, trimmed: true, trimWanted: true });
+    expect(result.details.bashOriginalOutput).toMatchObject({
+      source: "pi-visible",
+      restoredContentForRtk: false,
+      snapshotNeeded: true,
+      snapshotWritten: true,
+    });
+    expect(result.details.bashOriginalOutput.originalPath).toEqual(expect.any(String));
+    expect(result.details.bashOriginalOutput.snapshotPath).toEqual(expect.any(String));
+    expect(result.content[0].text).toContain("Original/pre-RTK output:");
+  });
 });

--- a/tests/bash-original-output.test.ts
+++ b/tests/bash-original-output.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { selectBashOriginalOutput } from "../src/rtk/bash-original-output.js";
+import { ensureBashOriginalOutputSnapshot, selectBashOriginalOutput } from "../src/rtk/bash-original-output.js";
 
 describe("selectBashOriginalOutput", () => {
   it("uses visible text and records counts without snapshot for small output", () => {
@@ -263,5 +263,74 @@ describe("selectBashOriginalOutput", () => {
 
     expect(result).toEqual({ inputForRtk: "" });
     expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it("records original snapshot write failures when forced at trim time", () => {
+    const metadata = selectBashOriginalOutput({
+      visibleText: "small original",
+      snapshotMaxLines: 99,
+      snapshotMaxBytes: 999,
+      fs: {
+        readFile: vi.fn(),
+        writeFile: vi.fn(),
+        randomId: () => "pre-existing-id",
+        tempDir: () => "/tmp/hashline-test",
+      },
+    }).metadata;
+
+    const result = ensureBashOriginalOutputSnapshot({
+      visibleText: "small original",
+      metadata,
+      fs: {
+        readFile: vi.fn(),
+        writeFile: () => { throw new Error("disk full"); },
+        randomId: () => "forced-fail-id",
+        tempDir: () => "/tmp/hashline-test",
+      },
+    });
+
+    expect(result).toMatchObject({
+      source: "pi-visible",
+      restoredContentForRtk: false,
+      snapshotNeeded: true,
+      snapshotWritten: false,
+      snapshotPath: undefined,
+      originalPath: undefined,
+      originalLineCount: 1,
+      originalByteCount: 14,
+      visibleLineCount: 1,
+      visibleByteCount: 14,
+    });
+    expect(result?.snapshotWriteError).toContain("disk full");
+  });
+
+  it("does not read non-temp full-output paths before validation", () => {
+    const readFile = vi.fn(() => {
+      throw new Error("BUG: unsafe read attempted");
+    });
+    const writeFile = vi.fn();
+
+    const result = selectBashOriginalOutput({
+      visibleText: "visible fallback",
+      fullOutputPath: "/etc/passwd",
+      snapshotMaxLines: 99,
+      snapshotMaxBytes: 999,
+      fs: {
+        readFile,
+        writeFile,
+        randomId: () => "unsafe-path-id",
+        tempDir: () => "/tmp/hashline-test",
+      },
+    });
+
+    expect(readFile).not.toHaveBeenCalled();
+    expect(result.inputForRtk).toBe("visible fallback");
+    expect(result.metadata).toMatchObject({
+      source: "pi-visible",
+      restoredContentForRtk: false,
+      snapshotNeeded: false,
+      snapshotWritten: false,
+    });
+    expect(result.metadata?.fullOutputReadError).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Hardens Bash recoverability where Pi full-output restoration meets the post-RTK context guard.

Closes #142.

## What changed

- **Validates Bash full-output paths before reading** — `selectBashOriginalOutput` now only accepts absolute paths inside the temp directory from either `details.fullOutputPath` or visible `Full output:` notices. Invalid paths such as `/etc/passwd` fall back to visible text without attempting `readFile` or recording a misleading read failure.
- **Preserves original/pre-RTK output when the guard trims** — the Bash result path now predicts whether the context guard will trim final post-RTK output and calls `ensureBashOriginalOutputSnapshot` before rendering the preview when no valid original path already exists.
- **Keeps trim-time snapshot failures recoverable** — forced original snapshot write failures are captured as `snapshotWriteError` metadata instead of aborting the Bash result.
- **Documents the guard contract** — README and exploratory testing docs now cover default-on behavior, `PI_HASHLINE_BASH_CONTEXT_GUARD=0`, stricter-only guard env vars, raw-byte/positive-integer parsing, clamp/fallback semantics, and the fact that `PI_RTK_BYPASS=1` bypasses RTK compression only.
- **Bumps release metadata** — package version and changelog now reflect `0.8.2`.

## User-visible behavior

Bash output is now recoverable in both dimensions when the guard trims:

- `Full post-RTK output:` points at the guarded final text.
- `Original/pre-RTK output:` is included when Pi did not provide a valid original full-output path and the guard needed to trim.

`PI_HASHLINE_BASH_CONTEXT_GUARD=0` still disables both original restoration and final guard trimming. `PI_RTK_BYPASS=1` still only bypasses route-specific RTK compression; large raw output remains eligible for guard trimming.

## Validation

```text
npm test -- tests/bash-original-output.test.ts tests/bash-context-guard-integration.test.ts
# Test Files 2 passed (2); Tests 17 passed (17)

npm test -- tests/bash-context-guard-config.test.ts
# Test Files 1 passed (1); Tests 7 passed (7)

npm test
# Test Files 254 passed (254); Tests 1209 passed (1209)

npm run typecheck
# tsc --noEmit, no diagnostics
```

The original regressions were re-run and now pass:

- non-temp `/etc/passwd` full-output paths are not read;
- guard-trimmed Bash output now includes original/pre-RTK recovery metadata and preview text.
