### PR TITLE
docs: simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,50 +7,19 @@
 
 Upgrade pi's local coding workflow with hash-anchored reads and edits, structural file maps, symbol-aware navigation, structural search, agent-friendly file exploration, and compressed `bash` output.
 
-`pi-hashline-readmap` is a drop-in pi extension. It replaces the stock `read`, `edit`, `grep`, `ls`, and `find` tools, provides an enhanced `ast_search` tool, registers `write`, adds an optional `nu` tool for structured exploration via Nushell, and post-processes `bash` output so more context budget goes to signal instead of noise.
+`pi-hashline-readmap` is a drop-in [pi](https://github.com/mariozechner/pi-coding-agent) extension. It replaces the stock `read`, `edit`, `grep`, `ls`, and `find` tools, provides an enhanced `ast_search` tool, registers `write`, adds an optional `nu` tool for structured exploration via Nushell, and post-processes `bash` output so more context budget goes to signal instead of noise.
 
-## Why this exists
+It also reduces extension conflict risk by replacing several overlapping tool packages with one coordinated implementation.
 
-If you use pi for real code changes, the stock local-tool workflow has a few recurring failure modes:
+## Why use it?
 
-- search and read output is easy for a model to paraphrase incorrectly
-- follow-up edits can drift to the wrong line when the file changes
-- large files cost too many tokens to navigate
-- search results often need an extra read before they are useful
-- noisy test, build, Git, Docker, and package-manager output burns context
-- multiple extensions trying to own `read`, `grep`, or `edit` can create conflict
-
-This package consolidates those improvements into one extension instead of stacking overlapping packages.
-
-## Key features
-
-- Hash-anchored `read`, `grep`, and `ast_search` output plus hashlined `write` results for immediate follow-up edits
-- Hash-verified `edit` operations (`set_line`, `replace_lines`, `insert_after`, `replace`)
-- Structural maps and direct symbol reads for large or complex files
-- Symbol-scoped grep and local same-file support bundles for symbol reads
-- Agent-optimized `ls` and `find` tools for file exploration
-- Optional `nu` tool for structured exploration with Nushell
-- Route-aware `bash` compression for tests, builds, Git, Docker, linters, package managers, and more
-- Context-hygiene metadata for read/search/command/mutation outputs, plus an opt-in debug report tool
-
-## Quick Start
-
-### Install from npm
-
-```bash
-pi install npm:pi-hashline-readmap
-```
-
-Start a new pi session after installation. The extension registers its tools automatically for new sessions.
-
-### Install from a local clone
-
-```bash
-git clone https://github.com/coctostan/pi-hashline-readmap.git
-cd pi-hashline-readmap
-npm install
-pi install .
-```
+- Keep edits tied to stable `LINE:HASH` anchors instead of fragile line numbers.
+- Navigate large files with structural maps and direct symbol reads.
+- Turn search results into edit anchors without an extra read step.
+- Search code structurally with `ast_search` when text search is too brittle.
+- Explore files with agent-oriented `ls`, `find`, and optional `nu` tools.
+- Compress noisy test, build, Git, Docker, linter, package-manager, HTTP, transfer, and generic command output.
+- Use one extension instead of stacking overlapping `read`, `grep`, `edit`, and Bash-output packages.
 
 ## Installation
 
@@ -59,25 +28,19 @@ pi install .
 - [pi](https://github.com/mariozechner/pi-coding-agent) with extension support
 - Node.js **>= 20** for local development in this repository
 
-### Install methods
-
-#### 1. npm package
+### From npm
 
 ```bash
 pi install npm:pi-hashline-readmap
 ```
 
-Use this if you want the published package.
-
-#### 2. Git install
+### From GitHub
 
 ```bash
 pi install git:github.com/coctostan/pi-hashline-readmap
 ```
 
-Use this if you want to install directly from the repository.
-
-#### 3. Local workspace install
+### From a local checkout
 
 ```bash
 git clone https://github.com/coctostan/pi-hashline-readmap.git
@@ -86,38 +49,30 @@ npm install
 pi install .
 ```
 
-Use this when developing locally or testing unreleased changes.
+Start a new pi session after installation. Running sessions do not hot-reload extension code or tool registrations.
 
 ### Optional local tools
 
-These tools are not required for the package to load, but they unlock more capability or better output quality:
+These tools are not required for the extension to load, but they unlock more capability or better output quality:
 
 ```bash
-brew install nushell           # required for nu tool
+brew install nushell           # required for the nu tool
 brew install ast-grep          # required for ast_search
 brew install fd                # optional, speeds up find
 brew install difftastic        # optional, improves semantic edit summaries
 brew install shellcheck yq scc # optional, improves some bash-output compression paths
 ```
 
-## Usage
+## 30-second example
 
-After installation, open a new pi session. The extension wires in upgraded local tools automatically.
+The core workflow is: read a file, copy a `LINE:HASH` anchor, and edit against that verified anchor.
 
-### Read with stable `LINE:HASH` anchors
 ```text
 read({ path: "tests/fixtures/small.ts" })
-```
 
-Example output from this repository:
-
-```text
+# Example output:
 45:4bf|export function createDemoDirectory(): UserDirectory {
 ```
-
-The hash portion is currently a 3-character lowercase hex digest of the normalized line content.
-
-### Edit using the anchor you just read
 
 ```text
 edit({
@@ -133,162 +88,96 @@ edit({
 })
 ```
 
+Before writing, `edit` verifies that anchor against the current file contents. If the file changed, it reports a mismatch instead of silently editing the wrong line.
+
+## Common workflows
+
+### Safely edit a line
+
+Use `read` first, then pass the copied anchor to `edit`.
+
+```text
+read({ path: "src/example.ts" })
+edit({
+  path: "src/example.ts",
+  edits: [
+    { set_line: { anchor: "12:abc", new_text: "const enabled = true;" } }
+  ]
+})
+```
+
+`read`, `grep`, `ast_search`, and `write` all return hashlined output that can feed follow-up edits.
+
 ### Create a new file with `write`
 
 ```text
 write({ path: "src/new-module.ts", content: "export const demo = 1;\n" })
 ```
 
-`write` returns hashlined output you can feed straight into a follow-up `edit` call.
+`write` creates parent directories automatically and returns hashlined output for immediate refinement.
 
-### Read a symbol directly
+### Navigate a large file
 
 ```text
+read({ path: "src/hashline.ts", map: true })
 read({ path: "tests/fixtures/small.ts", symbol: "createDemoDirectory" })
 read({ path: "tests/fixtures/small.ts", symbol: "UserDirectory.addUser" })
 ```
 
-### Read a large file with a structural map
+Structural maps are appended automatically when large reads are truncated. The readmap supports 18 mapped language/file kinds, including TypeScript, JavaScript, Python, Rust, Go, Java, Swift, Shell, C/C++, Clojure, SQL, JSON/JSONL, Markdown, YAML, TOML, and CSV/TSV. Direct symbol reads can target functions, classes, methods, interfaces, type aliases, constants, and enums when the file type is supported.
 
-```text
-read({ path: "src/hashline.ts", map: true })
-```
-
-Use this when you need the shape of a file before choosing a symbol or line range.
-
-### Read a symbol with local same-file support
+### Read a symbol with local support
 
 ```text
 read({ path: "tests/fixtures/small.ts", symbol: "createDemoDirectory", bundle: "local" })
 ```
 
-### Search and edit directly with grep
+Use `bundle: "local"` when you want the requested symbol plus direct same-file local support.
+
+### Search and patch
 
 ```text
 grep({ pattern: "createDemoDirectory", path: "tests/fixtures", literal: true })
-```
-
-### Search within enclosing symbols
-
-```text
 grep({ pattern: "createDemoDirectory", path: "tests/fixtures", literal: true, scope: "symbol" })
 grep({ pattern: "createDemoDirectory", path: "tests/fixtures", literal: true, scope: "symbol", scopeContext: 3 })
 ```
-Use `scopeContext: 0` for only the matching lines inside the resolved symbol block.
 
-### Structural code search with `ast_search`
+`grep` returns anchored matches, supports literal and regex search, can summarize matches with `summary: true`, and can scope output to enclosing symbols. Use `scopeContext: 0` for only matching lines inside the resolved symbol block.
+
+### Search code structurally
 
 ```text
 ast_search({ pattern: "console.log($$$ARGS)", lang: "typescript", path: "src" })
 ```
 
-`ast_search` requires `ast-grep` installed locally.
+`ast_search` wraps local `ast-grep`, returns merged anchored match blocks grouped by file, and is best for syntax-shaped queries rather than raw text matching.
 
-### Explore files with `ls` and `find`
+### Explore files
 
 ```text
 ls({ path: "src" })
 find({ pattern: "*.ts", path: "src", maxDepth: 2 })
-```
-
-### Use Nushell for structured exploration
-
-```text
 nu({ command: "open package.json | get scripts" })
 ```
 
-When [Nushell](https://www.nushell.sh/) is installed, the extension registers `nu` for structured exploration and data inspection.
+`ls` shows one directory with directories first and dotfiles included. `find` performs recursive discovery, respects `.gitignore`, includes hidden files, and supports depth, regex, sort, mtime, and size filters. `nu` registers only when Nushell is installed and is useful for structured JSON, CSV, TOML, YAML, and filesystem inspection.
 
-### Bypass `bash` compression when you need raw output
+### Handle noisy command output
+
+The extension post-processes `bash` results to reduce noise while preserving useful output. Route-specific compression covers test runners, builds, compilers, Git, linters, Docker, package managers, HTTP clients, transfer tools, file-listing output, and oversized generic output.
+
+Use `PI_RTK_BYPASS=1` when route-specific compression hides something you need:
 
 ```bash
 PI_RTK_BYPASS=1 npm test
 PI_RTK_BYPASS=1 git log --stat
 ```
 
-Use the bypass when the filtered output hides information you need.
-
-### Bash context guard and recoverability
-
-Bash output is processed in layers:
-
-1. The extension first selects the best original/pre-RTK output source. When Pi provides a valid temporary `fullOutputPath`, that file is used for RTK compression. Otherwise the visible Bash text is used.
-2. Route-specific RTK compression may reduce noisy command output unless `PI_RTK_BYPASS=1` is set for that command invocation.
-3. The Bash context guard runs after RTK. When the final post-RTK text is still too large, the guard writes the full post-RTK output to a temporary file and replaces visible output with a recoverable head/tail preview.
-
-The guard is default-on. The shipped default-on policy supersedes the earlier opt-in proposal from the M9 design discussion. Set `PI_HASHLINE_BASH_CONTEXT_GUARD=0` to disable both the Bash context guard and the original-output restoration layer.
-
-`PI_RTK_BYPASS=1` only bypasses route-specific RTK compression. It does not disable the Bash context guard; large raw output can still be guarded unless `PI_HASHLINE_BASH_CONTEXT_GUARD=0` is also set.
-
-## Tool reference
-
-### `read`
-- returns `LINE:HASH|content` output
-- anchor examples currently look like `45:4bf|...` (3-character lowercase hex hashes)
-- supports targeted reads via `offset` and `limit`
-- appends a structural map automatically when a file is truncated
-- supports `map: true` for an explicit structural map
-- supports direct symbol lookup via `symbol`
-- supports `bundle: "local"` for same-file local support around a symbol read
-- supports structural maps across **18 mapped language/file kinds**
-- uses in-memory caching plus optional persistent caching across sessions for structural maps
-
-### `edit`
-- consumes anchors from `read`, `grep`, and `ast_search`
-- supports `set_line`, `replace_lines`, `insert_after`, and `replace`
-- verifies anchors before writing
-- reports mismatch diagnostics when the file changed since the read
-- adds semantic edit classification in structured output
-### `write`
-
-- creates parent directories automatically
-- returns hashlined output suitable for immediate follow-up `edit` calls
-- supports `map: true` to append a structural map to the visible output
-- warns and skips hashline generation for binary-looking content
-
-### `grep`
-- returns anchored matches ready for direct use with `edit`
-- supports literal or regex search
-- supports `summary: true` for per-file match counts
-- supports `scope: "symbol"` and `scopeContext` for symbol-local results
-- supports opt-in final visible output budgets with `PI_HASHLINE_GREP_MAX_LINES` and `PI_HASHLINE_GREP_MAX_BYTES`
-
-### `ast_search`
-- wraps `ast-grep` for structure-aware code search
-- returns merged, anchored match blocks grouped by file
-- is best for syntax-shaped queries rather than raw text matching
-- returns install guidance when the local `sg` binary is missing
-
-### `ls` and `find`
-- `ls` shows a single directory, dirs first, with dotfiles included
-- `find` performs recursive discovery, respects `.gitignore`, includes hidden files, and supports depth, regex, sort, mtime, and size filters
-
-### `nu`
-
-- registers only when Nushell is installed
-- useful for structured inspection of JSON, CSV, TOML, YAML, filesystem state, and other machine-readable data
-- supports pi-specific config lookup via `PI_NUSHELL_CONFIG`
-- points agents at optional plugins such as `gstat`, `query`, `formats`, `semver`, and `file`
-
-### `bash` output compression
-
-The extension post-processes `bash` tool results to reduce noise while preserving the useful parts. Specialized compressors currently cover:
-
-- test runners
-- build tools
-- compiler and bundler noise
-- Git output
-- linter output
-- Docker output
-- package manager output
-- HTTP client output
-- transfer tools
-- file-listing output
-- oversized generic output via smart truncation
+`PI_RTK_BYPASS=1` does not disable the Bash context guard; very large raw output can still be replaced with a recoverable preview unless `PI_HASHLINE_BASH_CONTEXT_GUARD=0` is also set. See [docs/bash-output.md](docs/bash-output.md) for the full layered behavior and recovery details.
 
 ## Configuration
 
-This package is configured with environment variables rather than a project-local config file.
+Most users do not need configuration. Use environment variables when you want to tighten visible grep output budgets, change where structural map caches are stored, disable persistent map caching, tune Bash output recovery, or enable context-hygiene debugging.
 
 | Variable | Purpose | Default / behavior |
 |---|---|---|
@@ -298,7 +187,7 @@ This package is configured with environment variables rather than a project-loca
 | `XDG_CACHE_HOME` | Base directory for the persistent map cache when no explicit cache dir is set | Cache lives under `$XDG_CACHE_HOME/pi-hashline-readmap/maps` |
 | `PI_HASHLINE_NO_PERSIST_MAPS=1` | Disable the on-disk structural-map cache | Keeps caching in-memory only |
 | `PI_NUSHELL_CONFIG` | Override the Nushell config path used by `nu` | Otherwise prefers `~/.config/pi/nushell/config.nu`, then `--no-config-file` |
-| `PI_RTK_BYPASS=1` | Disable route-specific `bash` compression for one command invocation | ANSI is still stripped; anti-pattern hints still apply |
+| `PI_RTK_BYPASS=1` | Disable route-specific `bash` compression for one command invocation | ANSI is still stripped; anti-pattern hints still apply; the Bash context guard can still trim oversized output |
 | `PI_HASHLINE_BASH_CONTEXT_GUARD=0` | Disable the Bash context guard and original-output restoration layer | Any value other than exact `0` leaves the default-on guard enabled |
 | `PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES` | Tighten the post-RTK Bash guard line budget | Positive base-10 integer; invalid/unset values use `2000`; above-default values are clamped down |
 | `PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES` | Tighten the post-RTK Bash guard byte budget | Positive base-10 integer interpreted as raw bytes; invalid/unset values use `51200`; above-default values are clamped down |
@@ -306,120 +195,23 @@ This package is configured with environment variables rather than a project-loca
 | `PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES` | Tighten the guarded preview tail size | Positive base-10 integer; invalid/unset values use `120`; above-default values are clamped down |
 | `PI_CONTEXT_HYGIENE_DEBUG=1` | Register the debug-only `context_hygiene_report` read-only tool | Disabled unless explicitly set to `1` |
 
-## Structured output (`details.ptcValue`)
+## Advanced documentation
 
-All tools provide machine-facing structured data alongside human-facing text output.
-
-### `read`
-
-Includes path, selected range, warnings, truncation info, symbol metadata, map status, and per-line anchors.
-
-### `grep`
-
-Includes total matches, per-record anchors, and additive symbol-scope metadata when `scope: "symbol"` is used.
-
-### `ast_search`
-
-Includes grouped match ranges and anchored lines.
-
-### `edit`
-
-Includes summary, diff, changed lines, warnings, no-op metadata, and semantic edit classification.
-
-### `ptcValue.error`
-
-When a tool fails, its result includes a structured `error` envelope inside `ptcValue` so downstream consumers can dispatch programmatically without parsing free text.
-
-```ts
-interface PtcError {
-  code: string;       // stable, kebab-case, drawn from src/ptc-error-codes.ts
-  message: string;    // matches (or is a clean superset of) content[0].text
-  hint?: string;      // concrete next-step recovery suggestion, when one exists
-  details?: unknown;  // tool-specific structured data
-}
-```
-
-```ts
-{
-  isError: true,
-  content: [{ type: "text", text: ... }],
-  details: {
-    ptcValue: {
-      tool: "<toolName>",
-      ok: false,
-      path?: string,
-      error: PtcError,
-    },
-  },
-}
-```
+- [docs/bash-output.md](https://github.com/coctostan/pi-hashline-readmap/blob/main/docs/bash-output.md) — Bash compression, original-output restoration, context-guard trimming, and bypass behavior.
+- [docs/structured-output.md](https://github.com/coctostan/pi-hashline-readmap/blob/main/docs/structured-output.md) — `details.ptcValue`, structured error envelopes, and the exported PTC policy contract.
+- [docs/context-hygiene.md](https://github.com/coctostan/pi-hashline-readmap/blob/main/docs/context-hygiene.md) — context-hygiene metadata, stale-context placeholders, and the debug report tool.
+- [docs/integrations.md](https://github.com/coctostan/pi-hashline-readmap/blob/main/docs/integrations.md) — EventBus/global executor exposure for downstream integrations.
+- [exploratory functional testing](https://github.com/coctostan/pi-hashline-readmap/blob/main/docs/exploratory-functional-testing.md) — exploratory testing notes.
+- [prompts/](prompts/) — tool prompt and schema documentation.
+- [CHANGELOG.md](CHANGELOG.md) — release history.
 
 ### PTC tool policy contract
 
-The package exports a machine-readable tool policy contract. The primary export is `HASHLINE_TOOL_PTC_POLICY`, and the package also exports `getHashlineToolPtcPolicy()`.
-
-```ts
-import { HASHLINE_TOOL_PTC_POLICY } from "pi-hashline-readmap";
-```
-
-Policy summary:
-- `read`, `grep`, `ls`, and `find` are safe-by-default and read-only
-- `ast_search` and `nu` are opt-in and read-only
-- `edit` is not safe-by-default and is mutating
-- `pi-prompt-assembler` may optionally consume this contract
-
-## Context hygiene metadata and stale context
-
-Tool results include additive `details.contextHygiene` metadata that classifies context as read, search, command output, or mutation context. This metadata is intended for downstream session/context-management integrations and does not change the visible current-turn tool output contract.
-
-When an `edit` or `write` mutates a file, older provider-context copies of `read`, `grep`, and `ast_search` results that touched the same `file:<path>` are marked stale before the next model call. Stale context is not deleted for token savings and is not treated as retired context; it is deterministic warning context that says the previous result is no longer trustworthy because file content changed after it was produced.
-
-What becomes stale:
-
-- earlier `read` results for the same mutated file
-- earlier `grep` results that touched the same mutated file
-- earlier `ast_search` results that touched the same mutated file
-- multi-file search artifacts when any touched file is later mutated; the stale record names the mutated `file:<path>` key that caused the stale status
-
-What does not become stale in Phase 1:
-
-- the latest `edit` or `write` mutation result
-- fresh `read`, `grep`, or `ast_search` results recorded after the mutation
-- results for unrelated files
-- Bash output such as old `git status`, `git diff`, or test logs
-- pressure-based retirement candidates
-
-To recover stale detail, re-run the original tool indicated by the placeholder: `read` for stale file reads, `grep` for stale text search results, or `ast_search` for stale structural search results. The current stale placeholders are deterministic:
-
-```text
-[Stale read context: file content changed after this result. Re-run read to refresh.]
-[Stale grep context: matched file content changed after this result. Re-run grep to refresh.]
-[Stale ast_search context: matched file content changed after this result. Re-run ast_search to refresh.]
-```
-
-When `PI_CONTEXT_HYGIENE_DEBUG=1` is set before starting pi, the extension also registers `context_hygiene_report`, a debug-only read-only tool that reports tracked context-hygiene resources, stale candidates, and retirement candidates without mutating tracker state.
+The package exports `HASHLINE_TOOL_PTC_POLICY` and `getHashlineToolPtcPolicy()` for integrations. In that contract, `read`, `grep`, `ls`, and `find` are safe-by-default and read-only; `ast_search` and `nu` are opt-in and read-only; `edit` is not safe-by-default and is mutating. `pi-prompt-assembler` may optionally consume this contract when deciding which helpers to expose.
 
 ## EventBus integration
 
-On load, the extension emits tool executor references for downstream consumers.
-
-The emitted/stashed executor surface always includes `read`, `edit`, `grep`, `ast_search`, `write`, `ls`, and `find`, plus `nu` when Nushell is available at runtime and `context_hygiene_report` when `PI_CONTEXT_HYGIENE_DEBUG=1`.
-
-```ts
-pi.events.emit("hashline:tool-executors", {
-  read,
-  edit,
-  grep,
-  ast_search,
-  write,
-  ls,
-  find,
-  ...(nu ? { nu } : {}),
-  ...(contextHygieneDebugTool ? { context_hygiene_report: contextHygieneDebugTool } : {}),
-});
-```
-
-The same executors are also exposed at `globalThis.__hashlineToolExecutors`.
+On extension load, the executor map is emitted with `pi.events.emit("hashline:tool-executors", toolExecutors)` and also assigned to `globalThis.__hashlineToolExecutors`. The core executor surface includes `read`, `edit`, `grep`, `ast_search`, `write`, `ls`, and `find`, plus `nu` when Nushell is available at runtime.
 
 ## Project Structure
 
@@ -438,19 +230,19 @@ src/
   rtk/                    # bash output compression pipeline
 prompts/                  # tool prompt/schema docs
 tests/                    # Vitest suite
-docs/                     # project notes and testing docs
+docs/                     # project notes and reference docs
 scripts/                  # helper scripts used by readmap internals
 ```
 
 ## Development
 
-### Install dependencies
+Install dependencies:
 
 ```bash
 npm install
 ```
 
-### Validate the workspace
+Validate the workspace:
 
 ```bash
 npm test
@@ -463,19 +255,11 @@ Release candidates should also pass an npm package dry run:
 npm pack --dry-run
 ```
 
-Before publishing or opening a PR, run the workspace checks above from a clean checkout and add any focused tests needed for the specific files or tools you changed.
-
-### Local development notes
+Before publishing or opening a PR, run the workspace checks above from a clean checkout.
 
 This repository is intended to be used as a pi extension workspace. New agent sessions pick up local extension edits from the checkout, but running sessions do not hot-reload the module graph. Restart the agent session after changing extension code.
 
 For project-specific development workflow details, see [AGENTS.md](https://github.com/coctostan/pi-hashline-readmap/blob/main/AGENTS.md).
-
-## Documentation
-
-- [CHANGELOG.md](CHANGELOG.md)
-- [docs/exploratory-functional-testing.md](https://github.com/coctostan/pi-hashline-readmap/blob/main/docs/exploratory-functional-testing.md)
-- [prompts/](prompts/)
 
 ## Contributing
 

--- a/docs/bash-output.md
+++ b/docs/bash-output.md
@@ -1,0 +1,95 @@
+# Bash output compression and recovery
+
+`pi-hashline-readmap` post-processes `bash` tool results after the command runs. The goal is to keep useful signal in the conversation while still preserving ways to inspect larger output when needed.
+
+## Processing layers
+
+Bash output moves through two layers:
+
+1. **RTK route compression** — command-aware reducers for common noisy tools.
+2. **Bash context guard** — a default-on safety layer that prevents very large post-RTK output from flooding the context.
+
+`PI_RTK_BYPASS=1` affects only the first layer. The Bash context guard can still replace oversized output with a preview unless it is disabled separately.
+
+## RTK route compression
+
+The extension routes common command output through specialized compressors, including:
+
+- test runners
+- build and compiler output
+- Git output
+- linters
+- Docker output
+- package-manager output
+- HTTP clients
+- file-transfer tools
+- file-listing output
+- generic oversized output
+
+When compression is effective, the visible result may include an RTK notice with the original and compressed sizes and a command showing how to bypass compression.
+
+## Bypass route compression
+
+Prefix a command with `PI_RTK_BYPASS=1` to skip route-specific compression for that invocation:
+
+```bash
+PI_RTK_BYPASS=1 npm test
+PI_RTK_BYPASS=1 git log --stat
+```
+
+Bypass behavior:
+
+- route-specific compression is skipped
+- ANSI is still stripped
+- Bash anti-pattern hints can still be shown
+- the Bash context guard still applies to oversized output
+
+To bypass both RTK compression and guard trimming, combine both variables:
+
+```bash
+PI_HASHLINE_BASH_CONTEXT_GUARD=0 PI_RTK_BYPASS=1 npm test
+```
+
+Use that only when you really want full raw output in the conversation.
+
+## Bash context guard
+
+The Bash context guard is default-on. It checks post-RTK output after compression or bypass handling.
+
+Default limits:
+
+| Limit | Default |
+|---|---:|
+| Maximum visible post-RTK lines | `2000` |
+| Maximum visible post-RTK bytes | `51200` |
+| Preview head lines | `80` |
+| Preview tail lines | `120` |
+
+When output exceeds the line or byte budget, the guard writes the full post-RTK output to a temp file and replaces the visible result with a recoverable preview. The preview includes:
+
+- `Full post-RTK output: <path>`
+- `Original/pre-RTK output: <path>` when an original snapshot is available
+- original and post-RTK line/byte counts
+- active limits
+- a compact command label
+- preserved RTK, hint, full-output, and repeated-call notices
+- head and tail snippets
+
+The guard uses raw byte counts. Environment values must be positive base-10 integers. Invalid values fall back to defaults, and values above the built-in defaults are clamped down to those defaults.
+
+## Environment variables
+
+| Variable | Behavior |
+|---|---|
+| `PI_RTK_BYPASS=1` | Disable route-specific compression for one command invocation. Does not disable guard trimming. |
+| `PI_HASHLINE_BASH_CONTEXT_GUARD=0` | Disable the Bash context guard. Any value other than exact `0` leaves it enabled. |
+| `PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES` | Tighten the maximum post-RTK line count. Default/ceiling: `2000`. |
+| `PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES` | Tighten the maximum post-RTK byte count. Default/ceiling: `51200`. |
+| `PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES` | Tighten preview head lines. Default/ceiling: `80`. |
+| `PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES` | Tighten preview tail lines. Default/ceiling: `120`. |
+
+## Recovering full output
+
+If the visible Bash result contains a full-output path, inspect that file in the same session or copy it elsewhere before cleaning temp files. The guard stores full post-RTK output with mode `0600` in the system temp directory.
+
+If an original/pre-RTK output snapshot path is present, use that path when you need the command output before RTK compression.

--- a/docs/context-hygiene.md
+++ b/docs/context-hygiene.md
@@ -1,0 +1,90 @@
+# Context hygiene metadata
+
+`pi-hashline-readmap` adds context-hygiene metadata to tool results so the extension can reason about stale read/search/command context without parsing rendered text.
+
+The feature is additive. It does not change normal tool output unless a later mutation or command rerun makes older context stale or retired.
+
+## Metadata shape
+
+Context-hygiene metadata uses schema version `1` and classifies tool results as one of:
+
+- `read-context`
+- `search-context`
+- `command-output`
+- `mutation`
+
+Tracked resource kinds are:
+
+- `file`
+- `symbol`
+- `command`
+
+Read-like outputs can also carry a rehydrate descriptor that tells the agent how to refresh the result, such as rerunning `read`, `grep`, or `ast_search` with the original focused input.
+
+## What gets tracked
+
+| Tool family | Typical classification | Resource examples |
+|---|---|---|
+| `read` | `read-context` | file path, selected symbol, bundled local support symbols |
+| `grep` | `search-context` | matched files and search inputs |
+| `ast_search` | `search-context` | matched files and structural search inputs |
+| `bash` | `command-output` | command string and command kind, such as test, build, typecheck, lint, VCS, install, or other |
+| `edit` / `write` | `mutation` | changed file path |
+
+The tracker keeps a bounded in-memory event history. The current default maximum is `1000` events.
+
+## Stale context replacement
+
+The extension listens to pi context events and replaces some old tool-result messages when they are known to be stale. This prevents agents from accidentally relying on obsolete file contents or command output.
+
+Maskable stale tools are:
+
+- `read`
+- `grep`
+- `ast_search`
+- `bash`
+
+Rendered placeholders include:
+
+```text
+[Stale read context: file content changed after this result. Re-run read to refresh.]
+[Stale grep context: matched file content changed after this result. Re-run grep to refresh.]
+[Stale ast_search context: matched file content changed after this result. Re-run ast_search to refresh.]
+[Stale bash context: mutation-after-read. Re-run the Bash command to refresh. Command: npm test]
+```
+
+When a later successful Bash command supersedes an older Bash result, the older result can be retired with a placeholder such as:
+
+```text
+[Retired bash context: same-command-success-rerun. Superseded by a later successful Bash command. Command: npm test]
+```
+
+## Reasons
+
+Stale invalidation reasons currently include:
+
+- `mutation-after-read`
+- `bash-repo-state-after-mutation`
+- `bash-verification-success-rerun`
+
+Retirement reasons currently include:
+
+- `command-rerun`
+- `same-command-success-rerun`
+
+## Debug report tool
+
+Set this environment variable before starting pi to register the debug-only report tool:
+
+```bash
+PI_CONTEXT_HYGIENE_DEBUG=1
+```
+
+When enabled, the extension registers `context_hygiene_report`, a read-only debug tool that exposes the current context-hygiene tracker state. Leave it disabled for normal use.
+
+## Integration guidance
+
+- Treat `details.contextHygiene` as metadata for state tracking, not as display text.
+- Use rehydrate descriptors when refreshing stale file/search context.
+- Do not assume stale placeholders contain enough information to reconstruct the original result.
+- Restart the pi session if you change extension code; the in-memory tracker is reset when the extension is loaded.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,53 @@
+# Integration surfaces
+
+`pi-hashline-readmap` exposes its registered tool executors for downstream pi integrations that want to call the same enhanced tools programmatically.
+
+## EventBus executor announcement
+
+When the extension loads, it emits the tool executor map on pi's EventBus:
+
+```ts
+pi.events.emit("hashline:tool-executors", toolExecutors);
+```
+
+Consumers can listen for the `hashline:tool-executors` event to discover the active executor map.
+
+## Global executor map
+
+The extension also assigns the executor map to `globalThis`:
+
+```ts
+(globalThis as any).__hashlineToolExecutors = toolExecutors;
+```
+
+This is intended for local integration with pi tooling that cannot subscribe to the EventBus directly.
+
+## Available executors
+
+The map includes these keys when the corresponding tool is registered:
+
+| Key | Notes |
+|---|---|
+| `read` | Enhanced hashlined read tool. |
+| `edit` | Hash-anchored mutating edit tool. |
+| `grep` | Hashlined text search. |
+| `ast_search` | Structural search wrapper; usefulness depends on local `ast-grep` availability. |
+| `write` | File creation/full-write tool with hashlined output. |
+| `ls` | Single-directory listing. |
+| `find` | Recursive file discovery. |
+| `nu` | Present only when the optional Nushell integration registers successfully. |
+| `context_hygiene_report` | Present only when `PI_CONTEXT_HYGIENE_DEBUG=1`. |
+
+## Recommended consumer behavior
+
+- Prefer the exported PTC policy in [structured-output.md](structured-output.md) when deciding which tools are safe to expose by default.
+- Treat `edit` and `write` as mutating operations even if an executor is present.
+- Use `details.ptcValue` for structured results instead of parsing rendered output when possible.
+- Be prepared for optional executors such as `nu` and `context_hygiene_report` to be absent.
+- Do not rely on hot reload. Restart the pi session after changing this extension's source.
+
+## Related docs
+
+- [structured-output.md](structured-output.md) for `details.ptcValue` and PTC policy.
+- [context-hygiene.md](context-hygiene.md) for stale-context metadata attached to tool results.
+- [bash-output.md](bash-output.md) for Bash result post-processing and recovery behavior.

--- a/docs/readme-simplification-analysis.md
+++ b/docs/readme-simplification-analysis.md
@@ -1,0 +1,207 @@
+# README Simplification Analysis
+
+## Summary
+
+The current `README.md` is accurate and comprehensive, but it is harder to understand than it needs to be because it mixes beginner, power-user, and integrator documentation in one linear flow.
+
+A README should act as the front door to the project. For this package, that means a new reader should quickly understand:
+
+1. what `pi-hashline-readmap` does,
+2. why it is useful,
+3. how to install it,
+4. how to use the core anchored-read/edit workflow,
+5. where to go for advanced configuration and integration details.
+
+The existing README answers all of these, but some answers are buried under advanced reference material.
+
+## Main issue
+
+The README currently serves three audiences at once:
+
+1. **New users** — want to know what this is, whether they need it, how to install it, and how to try it.
+2. **Power users** — want configuration, Bash guard behavior, optional tools, and workflow details.
+3. **Integrators / developers** — want `details.ptcValue`, EventBus integration, context hygiene metadata, and tool policy contracts.
+
+All three audiences are valid, but they should not all be forced through the same long document path.
+
+## Recommended restructure
+
+A clearer top-level README shape would be:
+
+```md
+# pi-hashline-readmap
+
+One paragraph: what it does and why it matters.
+
+## Why use it?
+
+Short practical bullets.
+
+## Install
+
+npm / git / local workspace.
+
+## 30-second example
+
+read → edit using a `LINE:HASH` anchor.
+
+## Common workflows
+
+- Safe anchored edits
+- Large-file navigation
+- Search-to-edit
+- Bash output compression and recovery
+- Optional Nushell exploration
+
+## Configuration
+
+Short intro plus the env-var table.
+
+## Advanced integrations
+
+Short links to structured output, PTC policy, context hygiene, and EventBus docs.
+
+## Development
+
+Tests, typecheck, project structure, contributing.
+```
+
+## Specific recommendations
+
+### 1. Condense Quick Start and Installation
+
+The README currently has both:
+
+- `## Quick Start`
+- `## Installation`
+
+They repeat the same install commands. These could be merged into one clearer install section:
+
+```md
+## Install
+
+### From npm
+pi install npm:pi-hashline-readmap
+
+### From GitHub
+pi install git:github.com/coctostan/pi-hashline-readmap
+
+### From a local checkout
+...
+```
+
+This reduces repeated cognitive load near the top of the file.
+
+### 2. Add a “30-second example” near the top
+
+The core value is anchored tool output that can be safely reused. Show that immediately:
+
+```md
+## 30-second example
+
+read({ path: "src/example.ts" })
+# 12:abc|const oldName = 1;
+
+edit({
+  path: "src/example.ts",
+  edits: [
+    { set_line: { anchor: "12:abc", new_text: "const newName = 1;" } }
+  ]
+})
+```
+
+This communicates the product better than a long feature list.
+
+### 3. Rename “Usage” to “Common workflows”
+
+The current `Usage` section is a list of tool examples. It would be easier to scan if grouped by job-to-be-done:
+
+- **Safely edit a line** — `read` → `edit`
+- **Navigate a large file** — `read({ map: true })`, `read({ symbol })`
+- **Search and patch** — `grep` → `edit`
+- **Search code structurally** — `ast_search`
+- **Explore files** — `ls`, `find`, `nu`
+- **Handle noisy command output** — Bash compression and guard recovery
+
+This makes the README more user-centered.
+
+### 4. Move advanced integration details to separate docs
+
+The following sections are useful but advanced:
+
+- `Structured output (details.ptcValue)`
+- `Context hygiene metadata and stale context`
+- `EventBus integration`
+
+They should likely move to dedicated docs, for example:
+
+- `docs/structured-output.md`
+- `docs/context-hygiene.md`
+- `docs/integrations.md`
+
+The README can keep a short `Advanced integrations` section with links and one-sentence summaries.
+
+### 5. Make configuration more task-oriented
+
+Before the env-var table, add a short guide:
+
+```md
+Most users do not need configuration.
+
+Use configuration when you want to:
+
+- tighten visible grep output budgets,
+- change where structural map caches are stored,
+- disable persistent map caching,
+- tighten or disable the Bash context guard,
+- enable context-hygiene debugging.
+```
+
+Then keep the table. This helps readers understand why the knobs exist before parsing the details.
+
+### 6. Keep Bash guard docs, but shorten the first-read path
+
+The Bash context guard documentation is important, especially because `PI_RTK_BYPASS=1` does not disable the guard. Keep that behavior in README, but place detailed recoverability semantics under configuration or a linked Bash docs page.
+
+Suggested split:
+
+- README: short explanation and env-var table.
+- `docs/bash-output.md`: full layered behavior, recovery paths, guard metadata, and examples.
+
+## What should stay in README
+
+The README should keep:
+
+- the project purpose,
+- install commands,
+- the core anchored edit example,
+- the most common tool workflows,
+- configuration summary,
+- development commands,
+- links to advanced docs.
+
+## What can move out
+
+The README can move or shorten:
+
+- full `ptcValue` interface details,
+- full context hygiene semantics,
+- full EventBus executor surface,
+- detailed policy contract explanation.
+
+Those are reference materials, not first-read materials.
+
+## Proposed follow-up issue
+
+Create a documentation issue with this scope:
+
+> Reorganize `README.md` around install, 30-second example, common workflows, and configuration. Move advanced integration/reference content into focused docs under `docs/`, keeping README links to each advanced topic.
+
+Acceptance criteria:
+
+1. README has a concise install path and no duplicate Quick Start / Installation commands.
+2. README includes a short read/edit anchor example near the top.
+3. Tool examples are grouped by common workflows rather than raw tool order.
+4. Advanced `ptcValue`, context hygiene, and EventBus details are moved to docs or substantially shortened with links.
+5. Configuration remains complete, including Bash guard variables and `PI_RTK_BYPASS=1` interaction.
+6. README remains accurate against `package.json`, source behavior, and current tests.

--- a/docs/structured-output.md
+++ b/docs/structured-output.md
@@ -1,0 +1,89 @@
+# Structured output and PTC policy
+
+`pi-hashline-readmap` keeps user-facing output readable, but tool results also carry structured metadata for integrations that should not parse display text.
+
+## `details.ptcValue`
+
+Tool implementations attach a `details.ptcValue` object where the host supports tool result details. The value is additive: rendered text remains the compatibility surface, while `ptcValue` gives downstream code typed access to paths, ranges, anchors, warnings, summaries, and errors.
+
+Common structured pieces include:
+
+| Shape | Used for |
+|---|---|
+| `PtcLine` | Hashlined source lines: `line`, `hash`, `anchor`, `raw`, and display-escaped text. |
+| `PtcWarning` | Non-fatal warnings with a stable `code`, message, and optional symbol metadata. |
+| `PtcError` | Structured errors with `code`, `message`, optional `hint`, and optional details. |
+| `PtcRange` | Start/end line ranges, optionally including total file lines. |
+| `PtcFileGroup` | File-grouped ranges and lines for search-style results. |
+| `PtcEditResult` | Edit status, summary, diff text, first changed line, warnings, no-op edits, and optional semantic summary. |
+
+The exact `ptcValue.tool` value identifies the producer, such as `read`, `grep`, `ast_search`, `edit`, `write`, `ls`, `find`, or `nu`.
+
+## Anchors in structured output
+
+For anchored line output, prefer `ptcValue.lines[*].anchor` instead of reparsing rendered `LINE:HASH|content` text. The rendered text is for agents and humans; `ptcValue` is for programmatic consumers.
+
+Example line shape:
+
+```json
+{
+  "line": 45,
+  "hash": "4bf",
+  "anchor": "45:4bf",
+  "raw": "export function createDemoDirectory(): UserDirectory {",
+  "display": "export function createDemoDirectory(): UserDirectory {"
+}
+```
+
+## Error envelopes
+
+Tools use structured error envelopes when a failure should be machine-readable. Consumers should key off stable error `code` values where available and treat display text as explanatory context.
+
+`PtcError` shape:
+
+```ts
+interface PtcError {
+  code: string;
+  message: string;
+  hint?: string;
+  details?: unknown;
+}
+```
+
+## Exported PTC policy
+
+The extension exports a static PTC policy for downstream integrations:
+
+```ts
+import {
+  HASHLINE_TOOL_PTC_POLICY,
+  getHashlineToolPtcPolicy,
+} from "pi-hashline-readmap";
+```
+
+Policy entries describe:
+
+- tool name
+- helper name
+- whether the tool overrides a built-in pi tool
+- mutability (`read-only` or `mutating`)
+- default exposure (`safe-by-default`, `opt-in`, or `not-safe-by-default`)
+
+Current policy summary:
+
+| Tool | Helper | Overrides built-in | Mutability | Default exposure |
+|---|---|---:|---|---|
+| `read` | `read` | Yes | `read-only` | `safe-by-default` |
+| `grep` | `grep` | Yes | `read-only` | `safe-by-default` |
+| `ast_search` | `ast_search` | No | `read-only` | `opt-in` |
+| `edit` | `edit` | Yes | `mutating` | `not-safe-by-default` |
+| `ls` | `ls` | Yes | `read-only` | `safe-by-default` |
+| `find` | `find` | Yes | `read-only` | `safe-by-default` |
+| `nu` | `nu` | No | `read-only` | `opt-in` |
+
+## Compatibility notes
+
+- Treat `ptcValue` as additive metadata, not a replacement for rendered text.
+- Use stable fields such as `tool`, `path`, `lines`, `anchor`, `warnings`, and `error.code` when available.
+- Avoid parsing rendered text when the same data exists in `ptcValue`.
+- Mutating consumers should honor the exported policy: `edit` is not safe-by-default, while `read`, `grep`, `ls`, and `find` are read-only.


### PR DESCRIPTION
## Summary

- Restructure README around install, a 30-second anchored read/edit example, common workflows, configuration, and development guidance
- Move detailed reference material into focused docs for Bash output handling, structured output/PTC policy, context hygiene, and integration surfaces
- Preserve documented contracts for Bash guard behavior, `PI_RTK_BYPASS=1`, PTC policy exposure, EventBus executors, and supported mapped file kinds

## Verification

- `npm test`
- `npm run typecheck`

## Notes

This is documentation-only. The README remains accurate against package metadata, current environment variables, and existing README coverage tests while shortening the first-read path for new users.