### PR TITLE
Ship 145-bash-command-classifier-has-no-file-targ

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,10 +16,12 @@ import { buildBashCommandState } from "./src/bash-command-state.js";
 import {
   buildCommandResource,
   buildContextHygieneMetadata,
+  buildFileResource,
   getContextHygieneTracker,
   registerContextHygieneDebugTool,
   resetContextHygieneTracker,
   type ContextHygieneMetadata,
+  type ContextHygieneResource,
 } from "./src/context-hygiene.js";
 import {
   consumeDoomLoopWarning,
@@ -267,14 +269,19 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
     const commandState = command
       ? buildBashCommandState({
           command,
+          cwd: process.cwd(),
           isError: event.isError === true,
           text: originalSelection.inputForRtk || originalText,
         })
       : undefined;
+    const contextHygieneResources: ContextHygieneResource[] = command ? [buildCommandResource(command)] : [];
+    for (const fileTarget of commandState?.fileTargets ?? []) {
+      contextHygieneResources.push(buildFileResource(fileTarget));
+    }
     const contextHygiene = buildContextHygieneMetadata({
       tool: "bash",
-      classification: "command-output",
-      resources: command ? [buildCommandResource(command)] : [],
+      classification: commandState?.stateKind === "shell-file-mutation" ? "mutation" : "command-output",
+      resources: contextHygieneResources,
       commandState,
     });
     recordContextHygiene(contextHygiene, event.toolCallId);

--- a/src/bash-command-state.ts
+++ b/src/bash-command-state.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
   classifyCommandForContextHygiene,
   normalizeCommandForContextHygiene,
@@ -9,6 +10,7 @@ export type BashCommandStateKind =
   | "repo-diff"
   | "git-history"
   | "git-worktree-mutation"
+  | "shell-file-mutation"
   | "verification"
   | "routine"
   | "debug";
@@ -19,6 +21,7 @@ export interface BuildBashCommandStateInput {
   command: string;
   isError?: boolean;
   text?: string;
+  cwd?: string;
 }
 
 export interface BashCommandState {
@@ -31,16 +34,179 @@ export interface BashCommandState {
   semanticInvalidationSensitive: boolean;
   routineRetirementEligible: boolean;
   protectedFromRoutineRetirement: boolean;
+  fileTargets?: string[];
 }
 
 const GIT_WORKTREE_MUTATION_RE =
   /^git\s+(add|apply|am|checkout|clean|commit|merge|mv|pull|rebase|reset|restore|rm|stash|switch)\b/;
 
+const REDIRECTION_RE = /(?:^|[\s;|&])(?:\d?>>?|&>|>>|>)\s*(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))/g;
+const TEE_RE = /(?:^|[|;&]\s*)tee((?:\s+(?:"[^"]+"|'[^']+'|[^\s;&|]+))*)/g;
+
 function containsDiagnostics(text: string): boolean {
   return /\b(error TS\d+|TypeError:|ReferenceError:|SyntaxError:|AssertionError:|\bat\s+\S+\s+\([^)]*:\d+:\d+\)|FAIL\b)/.test(text);
 }
 
-function classifyStateKind(normalizedCommand: string, commandKind: ContextHygieneCommandKind): BashCommandStateKind {
+function isSafeLiteralShellTarget(target: string): boolean {
+  if (/[$`*?{}()[\]]/.test(target)) return false;
+  if (target.includes("~")) return false;
+  if (target.startsWith("-")) return false;
+  return true;
+}
+function normalizeShellTarget(rawTarget: string, cwd: string): string | undefined {
+  const trimmed = rawTarget.trim();
+  if (!trimmed || trimmed === "/dev/null" || /^&\d+$/.test(trimmed)) return undefined;
+  if (!isSafeLiteralShellTarget(trimmed)) return undefined;
+  return path.resolve(cwd, trimmed);
+}
+
+function pushUniqueTarget(targets: string[], target: string | undefined): void {
+  if (!target || targets.includes(target)) return;
+  targets.push(target);
+}
+
+function splitShellWords(input: string): string[] {
+  const words: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  for (const char of input.trim()) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current.length > 0) {
+        words.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (current.length > 0) words.push(current);
+  return words;
+}
+
+function extractTeeTargets(command: string, cwd: string, targets: string[]): void {
+  for (const match of command.matchAll(TEE_RE)) {
+    const words = splitShellWords(match[1] ?? "");
+    for (const word of words) {
+      if (word === "-a" || word.startsWith("--")) continue;
+      pushUniqueTarget(targets, normalizeShellTarget(word, cwd));
+    }
+  }
+}
+
+function extractSedInPlaceTargets(command: string, cwd: string, targets: string[]): void {
+  const words = splitShellWords(command);
+  if (words[0] !== "sed") return;
+
+  const inPlaceIndex = words.findIndex((word) => word === "-i" || word.startsWith("-i"));
+  if (inPlaceIndex < 0) return;
+
+  let index = inPlaceIndex + 1;
+  if (words[inPlaceIndex] === "-i" && words[index] === "") index += 1;
+
+  while (index < words.length && words[index].startsWith("-") && words[index] !== "-") {
+    index += 1;
+  }
+
+  if (index < words.length) index += 1;
+
+  for (; index < words.length; index += 1) {
+    const word = words[index];
+    if (!word || word.startsWith("-")) continue;
+    pushUniqueTarget(targets, normalizeShellTarget(word, cwd));
+  }
+}
+
+function nonOptionOperands(words: readonly string[]): string[] {
+  const operands: string[] = [];
+  for (const word of words) {
+    if (!word || word === "--") continue;
+    if (word.startsWith("-")) continue;
+    operands.push(word);
+  }
+  return operands;
+}
+
+function extractPathCommandTargets(command: string, cwd: string, targets: string[]): void {
+  const words = splitShellWords(command);
+  const commandName = words[0];
+  if (!commandName) return;
+
+  if (commandName === "mv") {
+    const operands = nonOptionOperands(words.slice(1));
+    if (operands.length === 2) {
+      pushUniqueTarget(targets, normalizeShellTarget(operands[0], cwd));
+      pushUniqueTarget(targets, normalizeShellTarget(operands[1], cwd));
+    }
+  }
+
+
+  if (commandName === "cp") {
+    const operands = nonOptionOperands(words.slice(1));
+    if (operands.length === 2) {
+      pushUniqueTarget(targets, normalizeShellTarget(operands[1], cwd));
+    }
+  }
+
+
+  if (commandName === "rm") {
+    for (const operand of nonOptionOperands(words.slice(1))) {
+      pushUniqueTarget(targets, normalizeShellTarget(operand, cwd));
+    }
+  }
+
+
+  if (commandName === "install") {
+    const operands = nonOptionOperands(words.slice(1));
+    if (operands.length >= 2) {
+      pushUniqueTarget(targets, normalizeShellTarget(operands[operands.length - 1], cwd));
+    }
+  }
+}
+
+export function extractShellFileMutationTargets(command: string, cwd = process.cwd()): string[] {
+  const normalized = normalizeCommandForContextHygiene(command);
+  if (/^(eval|source|\.)\b/.test(normalized)) return [];
+
+  const targets: string[] = [];
+  for (const match of command.matchAll(REDIRECTION_RE)) {
+    pushUniqueTarget(targets, normalizeShellTarget(match[1] ?? match[2] ?? match[3] ?? "", cwd));
+  }
+  extractTeeTargets(command, cwd, targets);
+  extractSedInPlaceTargets(command, cwd, targets);
+  extractPathCommandTargets(command, cwd, targets);
+  return targets;
+}
+
+function classifyStateKind(
+  normalizedCommand: string,
+  commandKind: ContextHygieneCommandKind,
+  fileTargets: readonly string[],
+): BashCommandStateKind {
+  if (fileTargets.length > 0) return "shell-file-mutation";
   if (/^git\s+status\b/.test(normalizedCommand)) return "repo-status";
   if (/^git\s+diff\b/.test(normalizedCommand)) return "repo-diff";
   if (/^git\s+log\b/.test(normalizedCommand)) return "git-history";
@@ -55,7 +221,8 @@ function classifyStateKind(normalizedCommand: string, commandKind: ContextHygien
 export function buildBashCommandState(input: BuildBashCommandStateInput): BashCommandState {
   const normalizedCommand = normalizeCommandForContextHygiene(input.command);
   const commandKind = classifyCommandForContextHygiene(normalizedCommand);
-  const stateKind = classifyStateKind(normalizedCommand, commandKind);
+  const fileTargets = extractShellFileMutationTargets(input.command, input.cwd ?? process.cwd());
+  const stateKind = classifyStateKind(normalizedCommand, commandKind, fileTargets);
   const outcome: BashCommandOutcome = input.isError === true ? "failure" : "success";
   const diagnostic = containsDiagnostics(input.text ?? "");
   const semanticInvalidationSensitive = stateKind === "repo-status" || stateKind === "repo-diff";
@@ -63,7 +230,8 @@ export function buildBashCommandState(input: BuildBashCommandStateInput): BashCo
     outcome === "failure" ||
     diagnostic ||
     stateKind === "debug" ||
-    stateKind === "git-worktree-mutation";
+    stateKind === "git-worktree-mutation" ||
+    stateKind === "shell-file-mutation";
 
   return {
     command: input.command,
@@ -75,5 +243,6 @@ export function buildBashCommandState(input: BuildBashCommandStateInput): BashCo
     semanticInvalidationSensitive,
     routineRetirementEligible: outcome === "success" && !protectedFromRoutineRetirement && !semanticInvalidationSensitive,
     protectedFromRoutineRetirement,
+    ...(fileTargets.length > 0 ? { fileTargets } : {}),
   };
 }

--- a/tests/bash-command-state.test.ts
+++ b/tests/bash-command-state.test.ts
@@ -71,4 +71,108 @@ describe("buildBashCommandState", () => {
       routineRetirementEligible: false,
     });
   });
+
+  it("classifies append redirection as a shell file mutation", () => {
+    const cwd = "/tmp/hashline-bash-targets";
+    const state = buildBashCommandState({ command: "printf next >> logs/out.txt", cwd, text: "" });
+
+    expect(state.stateKind).toBe("shell-file-mutation");
+    expect(state.normalizedCommand).toBe("printf next >> logs/out.txt");
+    expect(state.commandKind).toBe("other");
+    expect(state.protectedFromRoutineRetirement).toBe(true);
+    expect(state.routineRetirementEligible).toBe(false);
+    expect(state.fileTargets).toEqual(["/tmp/hashline-bash-targets/logs/out.txt"]);
+  });
+
+  it("classifies tee output files as shell file mutation targets", () => {
+    const cwd = "/tmp/hashline-bash-targets";
+    const teeState = buildBashCommandState({ command: "printf next | tee logs/out.txt", cwd, text: "next" });
+    const appendTeeState = buildBashCommandState({ command: "printf next | tee -a logs/a.txt logs/b.txt", cwd, text: "next" });
+
+    expect(teeState.stateKind).toBe("shell-file-mutation");
+    expect(teeState.protectedFromRoutineRetirement).toBe(true);
+    expect(teeState.routineRetirementEligible).toBe(false);
+    expect(teeState.fileTargets).toEqual(["/tmp/hashline-bash-targets/logs/out.txt"]);
+
+    expect(appendTeeState.stateKind).toBe("shell-file-mutation");
+    expect(appendTeeState.protectedFromRoutineRetirement).toBe(true);
+    expect(appendTeeState.routineRetirementEligible).toBe(false);
+    expect(appendTeeState.fileTargets).toEqual(["/tmp/hashline-bash-targets/logs/a.txt", "/tmp/hashline-bash-targets/logs/b.txt"]);
+  });
+
+  it("classifies heredoc redirection as a shell file mutation", () => {
+    const cwd = "/tmp/hashline-bash-targets";
+    const state = buildBashCommandState({ command: "cat > generated.ts <<'EOF'\nexport const value = 1;\nEOF", cwd, text: "" });
+
+    expect(state.stateKind).toBe("shell-file-mutation");
+    expect(state.protectedFromRoutineRetirement).toBe(true);
+    expect(state.routineRetirementEligible).toBe(false);
+    expect(state.fileTargets).toEqual(["/tmp/hashline-bash-targets/generated.ts"]);
+  });
+
+  it("classifies sed in-place edits as shell file mutations", () => {
+    const cwd = "/tmp/hashline-bash-targets";
+    const bsdState = buildBashCommandState({ command: "sed -i '' 's/old/new/' src/example.ts", cwd, text: "" });
+    const gnuState = buildBashCommandState({ command: "sed -i 's/old/new/' src/other.ts", cwd, text: "" });
+
+    expect(bsdState.stateKind).toBe("shell-file-mutation");
+    expect(bsdState.protectedFromRoutineRetirement).toBe(true);
+    expect(bsdState.routineRetirementEligible).toBe(false);
+    expect(bsdState.fileTargets).toEqual(["/tmp/hashline-bash-targets/src/example.ts"]);
+
+    expect(gnuState.stateKind).toBe("shell-file-mutation");
+    expect(gnuState.protectedFromRoutineRetirement).toBe(true);
+    expect(gnuState.routineRetirementEligible).toBe(false);
+    expect(gnuState.fileTargets).toEqual(["/tmp/hashline-bash-targets/src/other.ts"]);
+  });
+
+  it("classifies mv source and destination as shell file mutation targets", () => {
+    const cwd = "/tmp/hashline-bash-targets";
+    const state = buildBashCommandState({ command: "mv src/old.ts src/new.ts", cwd, text: "" });
+
+    expect(state.stateKind).toBe("shell-file-mutation");
+    expect(state.protectedFromRoutineRetirement).toBe(true);
+    expect(state.routineRetirementEligible).toBe(false);
+    expect(state.fileTargets).toEqual(["/tmp/hashline-bash-targets/src/old.ts", "/tmp/hashline-bash-targets/src/new.ts"]);
+  });
+
+  it("classifies cp destination as a shell file mutation target", () => {
+    const cwd = "/tmp/hashline-bash-targets";
+    const state = buildBashCommandState({ command: "cp src/source.ts src/copy.ts", cwd, text: "" });
+
+    expect(state.stateKind).toBe("shell-file-mutation");
+    expect(state.protectedFromRoutineRetirement).toBe(true);
+    expect(state.routineRetirementEligible).toBe(false);
+    expect(state.fileTargets).toEqual(["/tmp/hashline-bash-targets/src/copy.ts"]);
+  });
+
+  it("classifies rm operands as shell file mutation targets", () => {
+    const cwd = "/tmp/hashline-bash-targets";
+    const state = buildBashCommandState({ command: "rm -f src/delete-a.ts src/delete-b.ts", cwd, text: "" });
+
+    expect(state.stateKind).toBe("shell-file-mutation");
+    expect(state.protectedFromRoutineRetirement).toBe(true);
+    expect(state.routineRetirementEligible).toBe(false);
+    expect(state.fileTargets).toEqual(["/tmp/hashline-bash-targets/src/delete-a.ts", "/tmp/hashline-bash-targets/src/delete-b.ts"]);
+  });
+
+
+  it("classifies install destination as a shell file mutation target", () => {
+    const cwd = "/tmp/hashline-bash-targets";
+    const state = buildBashCommandState({ command: "install -m 0644 build/out.d.ts src/out.d.ts", cwd, text: "" });
+
+    expect(state.stateKind).toBe("shell-file-mutation");
+    expect(state.protectedFromRoutineRetirement).toBe(true);
+    expect(state.routineRetirementEligible).toBe(false);
+    expect(state.fileTargets).toEqual(["/tmp/hashline-bash-targets/src/out.d.ts"]);
+  });
+
+
+  it("does not invent file targets inside eval commands", () => {
+    const cwd = "/tmp/hashline-bash-targets";
+    const state = buildBashCommandState({ command: "eval 'printf changed > src/generated.ts'", cwd, text: "" });
+
+    expect(state.stateKind).toBe("debug");
+    expect(state.fileTargets).toBeUndefined();
+  });
 });

--- a/tests/context-hygiene-bash.test.ts
+++ b/tests/context-hygiene-bash.test.ts
@@ -84,6 +84,95 @@ describe("bash contextHygiene metadata", () => {
     expect(commandRerun?.eventIds).toHaveLength(2);
   });
 
+  it("records shell redirection file targets so prior reads can become stale", async () => {
+    const handlers = createHarness();
+    const targetPath = `${process.cwd()}/tmp/context-hygiene-bash-shell-target.txt`;
+    const fileResource = buildFileResource(targetPath);
+
+    await handlers.tool_result(
+      {
+        type: "tool_result" as const,
+        toolName: "read",
+        toolCallId: "read-before-shell-mutation",
+        input: { path: targetPath },
+        content: [{ type: "text" as const, text: "old content" }],
+        isError: false,
+        details: {
+          contextHygiene: buildContextHygieneMetadata({
+            tool: "read",
+            classification: "read-context",
+            resources: [fileResource],
+          }),
+        },
+      },
+      {},
+    );
+
+    const command = `printf changed > ${targetPath}`;
+    const result = await handlers.tool_result(
+      {
+        type: "tool_result" as const,
+        toolName: "bash",
+        toolCallId: "bash-shell-redirection",
+        input: { command },
+        content: [{ type: "text" as const, text: "" }],
+        isError: false,
+      },
+      {},
+    );
+
+    expect(result.details.contextHygiene.resources).toEqual(expect.arrayContaining([fileResource]));
+    expect(result.details.contextHygiene).toMatchObject({
+      tool: "bash",
+      classification: "mutation",
+      commandState: {
+        stateKind: "shell-file-mutation",
+        routineRetirementEligible: false,
+        protectedFromRoutineRetirement: true,
+        fileTargets: [targetPath],
+      },
+    });
+
+    const report = getContextHygieneTracker().generateReport();
+    expect(report.staleCandidates.flatMap((candidate) => candidate.staleResults)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          originalTool: "read",
+          originalResultId: "read-before-shell-mutation",
+          invalidatingMutationResultId: "bash-shell-redirection",
+          reason: "mutation-after-read",
+        }),
+      ]),
+    );
+  });
+
+
+  it("leaves unsafe shell expansion commands as command-only bash output", async () => {
+    const handlers = createHarness();
+    const command = "printf changed > $OUT_FILE";
+    const result = await handlers.tool_result(
+      {
+        type: "tool_result" as const,
+        toolName: "bash",
+        toolCallId: "bash-unsafe-expansion",
+        input: { command },
+        content: [{ type: "text" as const, text: "" }],
+        isError: false,
+      },
+      {},
+    );
+
+    expect(result.details.contextHygiene.classification).toBe("command-output");
+    expect(result.details.contextHygiene).toMatchObject({
+      tool: "bash",
+      resources: [buildCommandResource(command)],
+      commandState: {
+        normalizedCommand: command,
+        stateKind: "debug",
+      },
+    });
+  });
+
   it("records contextHygiene metadata from non-bash tool_result events without changing the event", async () => {
     const handlers = createHarness();
     const metadata = buildContextHygieneMetadata({


### PR DESCRIPTION
## Summary

Fixes Bash context hygiene so shell commands that mutate files are recorded as file mutations instead of command-only output.

Previously, a command like `printf changed > path/to/file` only produced a command resource. Prior `read`/`grep`/`ast_search` results for the same file therefore stayed fresh even though the Bash command had overwritten the file. This PR extracts conservative shell file targets, adds file resources to Bash metadata, and classifies recognized file-writing commands as `shell-file-mutation`/`mutation` so existing stale-read invalidation works.

## What changed

- Added `shell-file-mutation` state and optional `fileTargets` to Bash command state.
- Detects conservative file mutation targets for:
  - `>` and `>>` redirection
  - heredoc output redirection
  - `tee` / `tee -a`
  - `sed -i`
  - `mv`
  - `cp`
  - `rm`
  - `install`
- Keeps Bash command resources intact while appending file resources for extracted targets.
- Leaves unsafe or ambiguous shell syntax conservative, including `$OUT_FILE`, glob/meta targets, `~`, leading `-`, `eval`, `source`, and `.`.
- Adds focused unit and integration coverage for recognized mutations, stale-read invalidation, and fallback behavior.

## Acceptance criteria coverage

- **AC1 — record file resources for recognized write targets:** Bash metadata now keeps the command resource and appends `buildFileResource(...)` entries for extracted targets. Covered patterns include `>`, `>>`, heredoc output redirection, `tee`, `tee -a`, `sed -i`, `mv`, `cp`, `rm`, and `install`.
- **AC2 — distinguish shell file mutations from routine/debug output:** recognized shell writes return `stateKind: "shell-file-mutation"`, set `protectedFromRoutineRetirement: true`, and keep `routineRetirementEligible: false`.
- **AC3 — invalidate prior same-file reads/searches:** shell file mutations are classified as `mutation`, so `DefaultContextHygieneTracker.generateReport()` emits existing `mutation-after-read` stale records for matching file resources.
- **AC4 — preserve command-resource behavior:** every Bash command still records `buildCommandResource(command)`; file resources are additive only when targets are safely recognized.
- **AC5 — preserve repo-state semantics:** `git status`, `git diff`, `git log`, and git worktree mutation classification branches remain in `buildBashCommandState` and existing bash report/application tests still pass.
- **AC6 — conservative fallback for unsafe syntax:** unsafe targets such as `$OUT_FILE`, shell meta/globs, `~`, leading `-`, and `eval`/`source`/`.` commands do not create guessed file resources.
- **AC7 — reproduction and focused coverage:** the original stale-read reproduction now passes, and focused unit/integration tests cover accepted mutation patterns plus fallback cases.
- **AC8 — regression verification:** context-hygiene bash report/application tests, full `npm test`, and `npm run typecheck` all pass.

## Verification

- `npm test -- tests/context-hygiene-bash.test.ts tests/bash-command-state.test.ts tests/context-hygiene-bash-report.test.ts tests/context-hygiene-bash-context-application.test.ts`
  - 4 files passed / 23 tests passed
- `npm test`
  - 257 files passed / 1223 tests passed
- `npm run typecheck`
  - passed

## Notes

The original reproduction now passes: a prior read is marked stale after a Bash redirection writes the same file, with `mutation-after-read` pointing at the Bash tool result.
