### PR TITLE
Ship 146-java-symbol-lookup-misses-inner-type-qua

### DIFF
--- a/src/readmap/symbol-lookup.ts
+++ b/src/readmap/symbol-lookup.ts
@@ -88,12 +88,29 @@ function preferJavaTopLevelType(map: FileMap, candidates: SymbolCandidate[]): Sy
   return topLevelTypes.length === 1 ? topLevelTypes[0] : undefined;
 }
 
+function javaPackageName(map: FileMap): string | undefined {
+  if (map.language !== "Java") return undefined;
+  for (const entry of map.imports) {
+    const match = /^package\s+([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*;?$/.exec(entry);
+    if (match) return match[1];
+  }
+  return undefined;
+}
+
+function stripJavaPackagePrefix(map: FileMap, query: string): string | undefined {
+  const packageName = javaPackageName(map);
+  if (!packageName) return undefined;
+  const prefix = `${packageName}.`;
+  return query.startsWith(prefix) ? query.slice(prefix.length) : undefined;
+}
+
 export function findSymbol(map: FileMap, query: string): SymbolLookupResult {
   const q = query.trim();
   if (!q) return { type: "not-found" };
   if (map.symbols.length === 0) return { type: "not-found" };
 
   const allSymbols = flattenSymbols(map.symbols);
+  const javaRelativeQuery = stripJavaPackagePrefix(map, q);
 
   if (q.includes("@")) {
     const parts = q.split("@");
@@ -114,6 +131,16 @@ export function findSymbol(map: FileMap, query: string): SymbolLookupResult {
     return { type: "ambiguous", candidates: toMatches(exact.slice(0, 5)) };
   }
 
+  if (javaRelativeQuery) {
+    const javaExact = allSymbols.filter((c) => c.symbol.name === javaRelativeQuery);
+    if (javaExact.length === 1) return { type: "found", symbol: toMatch(javaExact[0].symbol, javaExact[0].parentName) };
+    if (javaExact.length > 1) {
+      const preferred = preferJavaTopLevelType(map, javaExact);
+      if (preferred) return { type: "found", symbol: toMatch(preferred.symbol, preferred.parentName) };
+      return { type: "ambiguous", candidates: toMatches(javaExact.slice(0, 5)) };
+    }
+  }
+
   if (q.includes(".")) {
     const parts = q.split(".").map((p) => p.trim());
     if (parts.length >= 2 && parts.every((p) => p.length > 0)) {
@@ -126,6 +153,21 @@ export function findSymbol(map: FileMap, query: string): SymbolLookupResult {
           type: "ambiguous",
           candidates: toMatches(candidates.slice(0, 5)),
         };
+      }
+      const javaParts = javaRelativeQuery?.includes(".")
+        ? javaRelativeQuery.split(".").map((p) => p.trim())
+        : [];
+      if (javaParts.length >= 2 && javaParts.every((p) => p.length > 0)) {
+        const javaCandidates = resolveDotPath(map.symbols, javaParts);
+        if (javaCandidates.length === 1) {
+          return { type: "found", symbol: toMatch(javaCandidates[0].symbol, javaCandidates[0].parentName) };
+        }
+        if (javaCandidates.length > 1) {
+          return {
+            type: "ambiguous",
+            candidates: toMatches(javaCandidates.slice(0, 5)),
+          };
+        }
       }
     }
   }

--- a/tests/fixtures/QualifiedOuter.java
+++ b/tests/fixtures/QualifiedOuter.java
@@ -1,0 +1,9 @@
+package com.example.qualified;
+
+public class QualifiedOuter {
+  public static class InnerType {
+    public String label() {
+      return "inner";
+    }
+  }
+}

--- a/tests/java-readmap-registration.test.ts
+++ b/tests/java-readmap-registration.test.ts
@@ -10,6 +10,7 @@ import { SymbolKind } from "../src/readmap/enums.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixture = resolve(__dirname, "fixtures/KafkaConsumerConfiguration.java");
+const qualifiedFixture = resolve(__dirname, "fixtures/QualifiedOuter.java");
 
 async function readTool(params: { path: string; symbol?: string; map?: boolean; bundle?: "local" }) {
   let capturedTool: any = null;
@@ -69,6 +70,23 @@ describe("Java readmap registration and workflow integration", () => {
     const methodRead = await readTool({ path: fixture, symbol: "KafkaConsumerConfiguration.consumerFactory" });
     expect(text(methodRead)).toMatch(/^\[Symbol: consumerFactory \(method\) in KafkaConsumerConfiguration, lines 13-16 of 2\d\]/);
     expect(text(methodRead)).toContain("return Map.of");
+  });
+
+  it("reads package-qualified Java inner type symbols", async () => {
+    const innerRead = await readTool({ path: qualifiedFixture, symbol: "com.example.qualified.QualifiedOuter.InnerType" });
+    const output = text(innerRead);
+
+    expect(output).toMatch(/^\[Symbol: InnerType \(class\) in QualifiedOuter, lines 4-8 of 10\]/);
+    expect(output).toContain("public static class InnerType");
+  });
+
+  it("reads package-qualified Java top-level types", async () => {
+    const outerRead = await readTool({ path: qualifiedFixture, symbol: "com.example.qualified.QualifiedOuter" });
+    const output = text(outerRead);
+
+    expect(output).toMatch(/^\[Symbol: QualifiedOuter \(class\), lines 3-9 of 10\]/);
+    expect(output).toContain("public class QualifiedOuter");
+    expect(output).toContain("public static class InnerType");
   });
 
   it("uses registered Java maps for local bundles and symbol-scoped grep", async () => {


### PR DESCRIPTION
## Summary

Fix Java symbol lookup for fully qualified type names by normalizing queries against the file's declared Java package before resolving symbols.

Previously, `read({ symbol: "com.example.qualified.QualifiedOuter.InnerType" })` treated `com` as the root symbol segment and fell through to `not-found`, even though the Java map contained `QualifiedOuter` and child `InnerType`. This change strips the matching `package ...;` prefix only for Java maps, then reuses the existing exact and dot-path lookup paths.

## Acceptance Criteria

- [x] `read({ path: "tests/fixtures/QualifiedOuter.java", symbol: "com.example.qualified.QualifiedOuter.InnerType" })` returns the `InnerType` symbol body instead of a not-found warning.
- [x] `read({ path: "tests/fixtures/QualifiedOuter.java", symbol: "com.example.qualified.QualifiedOuter" })` returns the top-level `QualifiedOuter` symbol body.
- [x] Existing working lookups still pass: `InnerType`, `QualifiedOuter.InnerType`, `KafkaConsumerConfiguration`, and `KafkaConsumerConfiguration.consumerFactory`.
- [x] Existing generic/non-Java dot-notation semantics remain intact, including ambiguity handling and not-found behavior for invalid paths.
- [x] The fix is covered by regression tests in the Java readmap/symbol-read integration path, with production changes limited to lookup logic.

## Verification

- [x] `npm test`
  - 257 files passed, 1225 tests passed
- [x] `npm run typecheck`
- [x] `npm test -- --run tests/java-readmap-registration.test.ts`
  - 1 file passed, 5 tests passed
- [x] `npm test -- --run tests/symbol-lookup.test.ts tests/symbol-lookup-recursive.test.ts tests/repro-020-symbol-ambiguity.test.ts`
  - 3 files passed, 21 tests passed

## Files Changed

- `src/readmap/symbol-lookup.ts` — Java package-prefix normalization for symbol lookup.
- `tests/java-readmap-registration.test.ts` — integration regression tests for package-qualified Java type reads.
- `tests/fixtures/QualifiedOuter.java` — minimal package + nested type fixture.
