### PR TITLE
Ship 152-bash-context-hygiene-and-preview-ux

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -20,6 +20,8 @@ import {
   getContextHygieneTracker,
   registerContextHygieneDebugTool,
   resetContextHygieneTracker,
+  type ContextHygieneAppliedEffects,
+  type ContextHygieneEvent,
   type ContextHygieneMetadata,
   type ContextHygieneResource,
 } from "./src/context-hygiene.js";
@@ -71,10 +73,57 @@ function contextHygieneFromDetails(details: unknown): ContextHygieneMetadata | u
   return isContextHygieneMetadata(metadata) ? metadata : undefined;
 }
 
-function recordContextHygiene(metadata: ContextHygieneMetadata, toolCallId: unknown): void {
-  getContextHygieneTracker().record(metadata, {
+function recordContextHygiene(metadata: ContextHygieneMetadata, toolCallId: unknown): ContextHygieneEvent {
+  return getContextHygieneTracker().record(metadata, {
     resultId: typeof toolCallId === "string" ? toolCallId : undefined,
   });
+}
+
+function buildAppliedEffectsBucket(resultIds: Set<string>, reasons: Set<string>) {
+  return {
+    count: resultIds.size,
+    resultIds: [...resultIds].sort(),
+    reasons: [...reasons].sort(),
+  };
+}
+
+const BASH_CURRENT_TURN_STALE_REASONS = new Set([
+  "bash-repo-state-after-mutation",
+  "bash-verification-success-rerun",
+]);
+function summarizeBashAppliedEffects(eventId: number): ContextHygieneAppliedEffects {
+  const report = getContextHygieneTracker().generateReport();
+  const retiredResultIds = new Set<string>();
+  const retiredReasons = new Set<string>();
+  const staleResultIds = new Set<string>();
+  const staleReasons = new Set<string>();
+
+  for (const candidate of report.retirementCandidates) {
+    if (candidate.supersededByEventId !== eventId) continue;
+    for (const record of candidate.retiredResults ?? []) {
+      if (record.originalTool !== "bash" || !record.originalResultId) continue;
+      retiredResultIds.add(record.originalResultId);
+      retiredReasons.add(record.reason);
+    }
+  }
+
+  for (const candidate of report.staleCandidates) {
+    if (candidate.mutationEventId !== eventId || !BASH_CURRENT_TURN_STALE_REASONS.has(candidate.reason)) continue;
+    for (const record of candidate.staleResults) {
+      if (record.originalTool !== "bash" || !record.originalResultId) continue;
+      staleResultIds.add(record.originalResultId);
+      staleReasons.add(record.reason);
+    }
+  }
+
+  return {
+    retired: buildAppliedEffectsBucket(retiredResultIds, retiredReasons),
+    stale: buildAppliedEffectsBucket(staleResultIds, staleReasons),
+  };
+}
+
+function hasAppliedEffects(effects: ContextHygieneAppliedEffects): boolean {
+  return effects.retired.count > 0 || effects.stale.count > 0;
 }
 
 export {
@@ -284,7 +333,11 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
       resources: contextHygieneResources,
       commandState,
     });
-    recordContextHygiene(contextHygiene, event.toolCallId);
+    const recordedContextHygieneEvent = recordContextHygiene(contextHygiene, event.toolCallId);
+    const appliedEffects = summarizeBashAppliedEffects(recordedContextHygieneEvent.id);
+    const contextHygieneForDetails: ContextHygieneMetadata = hasAppliedEffects(appliedEffects)
+      ? { ...contextHygiene, appliedEffects }
+      : contextHygiene;
     const applyWarning = (body: string): string => {
       if (!doomLoop) return body;
       const prefix = `${formatDoomLoopMessage(doomLoop)}\n\n---\n`;
@@ -312,7 +365,7 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
         content: [{ type: "text" as const, text: guarded.text }, ...nonTextContent],
         details: {
           ...existingDetails,
-          contextHygiene,
+          contextHygiene: contextHygieneForDetails,
           bashContextGuard: guarded.metadata,
           ...(bashOriginalOutput ? { bashOriginalOutput } : {}),
         },
@@ -344,7 +397,7 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
       details: {
         ...existingDetails,
         compressionInfo: info,
-        contextHygiene,
+        contextHygiene: contextHygieneForDetails,
         bashContextGuard: guarded.metadata,
         ...(bashOriginalOutput ? { bashOriginalOutput } : {}),
       },

--- a/src/context-hygiene.ts
+++ b/src/context-hygiene.ts
@@ -306,6 +306,16 @@ export function buildAstSearchRehydrateDescriptor(
   return { tool: "ast_search", input: descriptorInput };
 }
 
+export interface ContextHygieneAppliedEffectsBucket {
+  count: number;
+  resultIds: string[];
+  reasons: string[];
+}
+
+export interface ContextHygieneAppliedEffects {
+  retired: ContextHygieneAppliedEffectsBucket;
+  stale: ContextHygieneAppliedEffectsBucket;
+}
 export interface ContextHygieneMetadata {
   schemaVersion: typeof CONTEXT_HYGIENE_SCHEMA_VERSION;
   tool: string;
@@ -313,6 +323,7 @@ export interface ContextHygieneMetadata {
   resources: ContextHygieneResource[];
   rehydrate?: ContextHygieneRehydrateDescriptor;
   commandState?: BashCommandState;
+  appliedEffects?: ContextHygieneAppliedEffects;
 }
 
 export interface BuildContextHygieneMetadataInput {

--- a/src/rtk/bash-context-guard.ts
+++ b/src/rtk/bash-context-guard.ts
@@ -183,7 +183,7 @@ function renderPreview(options: {
     rendered.push(`Original/pre-RTK: ${options.originalMetadata.originalLineCount} lines, ${options.originalMetadata.originalByteCount} bytes`);
   }
   rendered.push(`Post-RTK: ${options.metadata.postRtkLineCount} lines, ${options.metadata.postRtkByteCount} bytes`);
-  rendered.push(`Limits: ${options.metadata.maxLines} lines, ${options.metadata.maxBytes} bytes`);
+  rendered.push(`Trigger thresholds: ${options.metadata.maxLines} lines, ${options.metadata.maxBytes} bytes`);
   if (command) rendered.push(`Command: ${command}`);
   if (preservedNotices.length > 0) rendered.push("", "Preserved notices:", ...preservedNotices);
   rendered.push("", "Head:", ...head);

--- a/tests/bash-context-guard-trim.test.ts
+++ b/tests/bash-context-guard-trim.test.ts
@@ -44,7 +44,8 @@ describe("applyBashContextGuard trimming", () => {
     expect(result.text).toContain("Original/pre-RTK output: /tmp/original-output.txt");
     expect(result.text).toContain("Original/pre-RTK: 10 lines, 300 bytes");
     expect(result.text).toContain(`Post-RTK: 6 lines, ${Buffer.byteLength(text, "utf8")} bytes`);
-    expect(result.text).toContain("Limits: 5 lines, 1024 bytes");
+    expect(result.text).toContain("Trigger thresholds: 5 lines, 1024 bytes");
+    expect(result.text).not.toContain("Limits: 5 lines, 1024 bytes");
     expect(result.text).toContain("Command: npm test -- --runInBand");
     expect(result.text).toContain("Head:");
     expect(result.text).toContain("line-1\nline-2");

--- a/tests/context-hygiene-bash.test.ts
+++ b/tests/context-hygiene-bash.test.ts
@@ -69,7 +69,21 @@ describe("bash contextHygiene metadata", () => {
     expect(first.details.contextHygiene).toEqual(expectedContextHygiene);
     expect((first.details.ptcValue as any)?.contextHygiene).toBeUndefined();
 
-    expect(second.details.contextHygiene).toEqual(expectedContextHygiene);
+    expect(second.content).toEqual([{ type: "text", text: "PASS" }]);
+
+    expect(second.details.contextHygiene).toMatchObject(expectedContextHygiene);
+    expect((second.details.contextHygiene as any).appliedEffects).toEqual({
+      retired: {
+        count: 1,
+        resultIds: ["bash-hygiene-1"],
+        reasons: ["same-command-success-rerun"],
+      },
+      stale: {
+        count: 0,
+        resultIds: [],
+        reasons: [],
+      },
+    });
 
     const commandRerun = getContextHygieneTracker()
       .generateReport()
@@ -82,6 +96,121 @@ describe("bash contextHygiene metadata", () => {
       resultIds: ["bash-hygiene-1", "bash-hygiene-2"],
     });
     expect(commandRerun?.eventIds).toHaveLength(2);
+  });
+
+  it("reports repo-state bash output staled by a later bash mutation in the current turn", async () => {
+    const handlers = createHarness();
+    const status = await handlers.tool_result(
+      {
+        type: "tool_result" as const,
+        toolName: "bash",
+        toolCallId: "status-before-mutation",
+        input: { command: "git status --short" },
+        content: [{ type: "text" as const, text: " M src/example.ts" }],
+        isError: false,
+      },
+      {},
+    );
+    const mutation = await handlers.tool_result(
+      {
+        type: "tool_result" as const,
+        toolName: "bash",
+        toolCallId: "bash-file-mutation-after-status",
+        input: { command: "printf changed > tmp/context-hygiene-current-turn.txt" },
+        content: [{ type: "text" as const, text: "" }],
+        isError: false,
+      },
+      {},
+    );
+
+    expect(status.details.contextHygiene.commandState.stateKind).toBe("repo-status");
+    expect(mutation.details.contextHygiene.commandState.stateKind).toBe("shell-file-mutation");
+    expect(mutation.content).toEqual([{ type: "text", text: "" }]);
+    expect((mutation.details.contextHygiene as any).appliedEffects).toEqual({
+      retired: {
+        count: 0,
+        resultIds: [],
+        reasons: [],
+      },
+      stale: {
+        count: 1,
+        resultIds: ["status-before-mutation"],
+        reasons: ["bash-repo-state-after-mutation"],
+      },
+    });
+
+    const report = getContextHygieneTracker().generateReport();
+    expect(report.staleCandidates.flatMap((candidate) => candidate.staleResults)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          originalTool: "bash",
+          originalResultId: "status-before-mutation",
+          invalidatingMutationResultId: "bash-file-mutation-after-status",
+          reason: "bash-repo-state-after-mutation",
+        }),
+      ]),
+    );
+  });
+
+  it("reports failed verification output staled by an exact successful rerun in the current turn", async () => {
+    const handlers = createHarness();
+    const command = "npm test -- --context-hygiene-current-turn";
+    const failure = await handlers.tool_result(
+      {
+        type: "tool_result" as const,
+        toolName: "bash",
+        toolCallId: "verification-failure-before-success",
+        input: { command },
+        content: [{ type: "text" as const, text: "FAIL tests/current-turn.test.ts" }],
+        isError: true,
+      },
+      {},
+    );
+    const success = await handlers.tool_result(
+      {
+        type: "tool_result" as const,
+        toolName: "bash",
+        toolCallId: "verification-success-after-failure",
+        input: { command },
+        content: [{ type: "text" as const, text: "PASS tests/current-turn.test.ts" }],
+        isError: false,
+      },
+      {},
+    );
+
+    expect(failure.details.contextHygiene.commandState).toMatchObject({
+      stateKind: "verification",
+      outcome: "failure",
+    });
+    expect(success.details.contextHygiene.commandState).toMatchObject({
+      stateKind: "verification",
+      outcome: "success",
+    });
+    expect(success.content).toEqual([{ type: "text", text: "PASS tests/current-turn.test.ts" }]);
+    expect((success.details.contextHygiene as any).appliedEffects).toEqual({
+      retired: {
+        count: 0,
+        resultIds: [],
+        reasons: [],
+      },
+      stale: {
+        count: 1,
+        resultIds: ["verification-failure-before-success"],
+        reasons: ["bash-verification-success-rerun"],
+      },
+    });
+
+    const report = getContextHygieneTracker().generateReport();
+    expect(report.staleCandidates.flatMap((candidate) => candidate.staleResults)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          originalTool: "bash",
+          originalResultId: "verification-failure-before-success",
+          invalidatingMutationResultId: "verification-success-after-failure",
+          reason: "bash-verification-success-rerun",
+        }),
+      ]),
+    );
   });
 
   it("records shell redirection file targets so prior reads can become stale", async () => {


### PR DESCRIPTION
## Summary

- Surface deterministic current-turn bash `appliedEffects` in `details.contextHygiene` for prior bash output retired or staled by the current bash result.
- Cover same-command success rerun retirement, repo-state stale after mutation, and verification-success stale after an exact failed rerun.
- Rename the bash context-guard preview threshold label from `Limits:` to `Trigger thresholds:` so it no longer implies the rendered preview is clipped to those values.

## Why

The context-hygiene tracker already computed retirement/stale candidates, but bash results discarded the recorded event id and returned unchanged metadata in the same turn. That made useful signals visible only later through reports/provider-context masking. This PR summarizes the effects caused by the just-recorded bash event and attaches them as structured metadata only.

The context guard also used accurate threshold values but described them with misleading wording. The preview still writes the full post-RTK output to a recoverable file and preserves head/tail framing; only the threshold label changes.

## Acceptance Criteria

### Issue #148 — Surface bash retirement/stale signals

- [x] After a bash event triggers retirement or stale records in the tracker, the new event’s `details.contextHygiene` carries deterministic `appliedEffects` with counts, affected result ids, and reasons.
- [x] The visible bash result text is unchanged; the new signal is structured-only metadata.
- [x] Subsequent tracker/report state agrees with the per-event `appliedEffects` for covered stale/retirement cases.
- [x] `applyContextHygieneStaleContext(...)` remains the source of truth for actual provider-context masking; `appliedEffects` is informational only.
- [x] Tests cover same-command success rerun retirement, repo-state stale after mutation, and verification success after exact failure.
- [x] `npm test` and `npm run typecheck` pass.

### Issue #149 — Bash context-guard preview label

- [x] The preview header no longer labels trigger threshold values as `Limits:`.
- [x] Head/tail framing for trim cases is unchanged.
- [x] Recoverable file path, original/pre-RTK path, byte/line counts, and `Command:` line are unchanged.
- [x] Existing M9 guard tests are updated for the new label.
- [x] Markdown/docs/prompts do not retain stale `Limits:` preview wording; the only remaining occurrence is the negative regression assertion.
- [x] `npm test` and `npm run typecheck` pass.

## Implementation notes

- `recordContextHygiene(...)` now returns the tracker event so the bash handler can filter report candidates by the current event id.
- `summarizeBashAppliedEffects(...)` builds sorted, deduplicated `retired` and `stale` buckets from tracker report candidates.
- `details.contextHygiene.appliedEffects` is only attached when the current bash event actually has effects.
- Visible bash `content` is unchanged for applied-effects cases.
- `applyContextHygieneStaleContext(...)` remains the source of truth for provider-context masking.

## Testing

- `npm test -- tests/context-hygiene-bash.test.ts tests/bash-context-guard-trim.test.ts`
- `npm test && npm run typecheck`

## Verification

- Full suite: 257 test files passed, 1227 tests passed.
- Typecheck: `tsc --noEmit` passed.
- Focused regressions: 2 test files passed, 11 tests passed.