### PR TITLE
chore: bump to 0.8.3, add Java to prompts/read.md language list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {

--- a/prompts/read.md
+++ b/prompts/read.md
@@ -8,7 +8,7 @@ When a file is truncated (exceeds {{DEFAULT_MAX_LINES}} lines or {{DEFAULT_MAX_B
 Use the appended map for targeted reads with `offset` and `limit` — e.g., `read(path, { offset: LINE, limit: N })`.
 When provided, `offset` and `limit` must be positive integers; `0` and negative values are invalid.
 
-Maps support 18 mapped language/file kinds — including TypeScript, JavaScript, Python, Rust, Go, C, C headers, C++, Swift, Shell, Clojure, SQL, JSON, JSONL, Markdown, YAML, TOML, and CSV/TSV — and use in-memory caching with optional persistent caching across sessions.
+Maps support 18 mapped language/file kinds — including TypeScript, JavaScript, Python, Rust, Go, Java, C, C headers, C++, Swift, Shell, Clojure, SQL, JSON, JSONL, Markdown, YAML, TOML, and CSV/TSV — and use in-memory caching with optional persistent caching across sessions.
 
 ## Map Parameter
 


### PR DESCRIPTION
Quick doc + version bump:

- Bumps `package.json` from `0.8.2` to `0.8.3` for republish.
- Updates `prompts/read.md` language enumeration to list Java (matches `README.md`); the language list previously omitted Java even though the Java mapper has been registered for some time.

No source changes. `npm run typecheck` and `npm test` (259/259 files, 1231/1231 tests) pass at the new version.