### PR TITLE
feat: ship 155-symbol-aware-edit-improvements-tree-sitt

### DIFF
--- a/docs/hygiene-and-token-caching.md
+++ b/docs/hygiene-and-token-caching.md
@@ -1,0 +1,170 @@
+# Hygiene & Token Caching
+
+How `pi-hashline-readmap`'s context-hygiene mechanisms interact with LLM
+prefix caching. Written from observations of the in-session tool surface
+plus an external Node harness driving `registerReadTool` /
+`registerEditTool` / `registerGrepTool` directly.
+
+## Background: how prefix caching works
+
+Anthropic and most other providers cache **exact prefix matches** of the
+conversation. A new turn hits cache up to the first byte that differs from
+a previous turn; everything after that is recomputed. So anything that
+both:
+
+1. lives in the historical transcript, and
+2. changes between otherwise-similar turns
+
+invalidates cache from that point forward.
+
+That makes "what bytes does each tool result emit, and how stable are
+they?" the right lens for evaluating hygiene's caching impact.
+
+## What this hygiene system puts into the transcript
+
+Every tool result the agent sees carries:
+
+1. **Hashlines on every line** of every `read` / `grep` / `ast_search`
+   result — e.g. `1:3c8|alpha`. The hash is deterministic from
+   `(lineNumber, lineContent)` (3-hex; see `HASH_LEN` in
+   `src/hashline.ts`).
+2. **Verbose guard error blocks** when something goes wrong:
+   - The stale-read guard's multi-sentence prose (~250 bytes).
+   - The `>>>` auto-relocation table after a hash mismatch
+     (~200–600 bytes, embeds live anchors for nearby lines).
+   - No-op diagnostics that include current-line previews.
+3. **No success-path hygiene metadata** in the rendered text — the
+   `details.contextHygiene` block (keys: `schemaVersion`, `tool`,
+   `classification`, `resources`, `rehydrate`) exists on success but is
+   not surfaced to the agent. For caching purposes, this is a feature.
+
+## Net effects on cache hit rate
+
+### Where it helps caching
+
+- **Stable hashes for unchanged lines.** Re-reading the same file across
+  turns produces byte-identical output, so the second `read` reuses cache
+  cleanly. Hashes are derived from `(line, content)` only — no
+  timestamps, run IDs, or random salts.
+- **Compact, deterministic anchored grep / ast_search output.** Same
+  query → same bytes → cache hit.
+- **Stripped success-path metadata.** `contextHygiene` lives in
+  `result.details`, not in the visible text, so the success transcript
+  stays small and cache-friendly.
+- **Narrowing tools shrink the cached payload.** `offset`, `limit`,
+  `symbol`, and `map: true limit: 1` keep cached reads small and let them
+  survive downstream edits to unrelated parts of the file.
+- **Replaces noisier tools.** The bash anti-pattern hint nudging
+  `cat foo` → `read foo` keeps file inspection on the deterministic
+  output path instead of bash's variable formatting.
+
+### Where it hurts caching
+
+- **Edits invalidate downstream hashlines for that file.** When line N
+  changes, line N's hash changes; if the edit also shifts line numbers
+  (insert/delete), every later line's `lineNumber:hash` anchor changes
+  too. Any later turn that re-reads the file produces a different byte
+  stream, cache-missing from the first changed line onward. Unavoidable
+  given positional hashes.
+- **Verbose error paths are cache poison if they recur.** The stale-read
+  guard message and the `>>>` auto-relocation block are 200–600 bytes
+  each. If the agent loops on them (try → fix → try again), each
+  attempt's error text differs slightly (different anchors in the `>>>`
+  table after each edit attempt), so prior turns' cached suffixes don't
+  reuse. This is the "doom loop" the `tests/doom-loop-*.test.ts` family
+  is named after.
+- **Auto-relocation tables embed live file state.** The fresh anchors
+  shown after a mismatch encode the *current* file contents. If the file
+  changes again, the same query produces different help text, so
+  retries don't fingerprint identically.
+- **Bash output passes through RTK compression.** RTK is deterministic
+  per input, so it doesn't introduce nondeterminism — but it doesn't
+  shield against upstream nondeterminism (timestamps, paths, ANSI codes
+  from tools the user runs) either.
+
+### Neutral / depends on usage
+
+- **Structural maps** (`read map: true`) are stable while the file's
+  symbol layout is stable. Small body edits don't change the map;
+  signature / name / scope changes do. So `read map: true` is more
+  cache-stable than re-reading bodies, *if* you're not editing
+  structure.
+- **`MAPPER_VERSION` bumps and the persistent map cache** affect *disk*
+  cache between sessions. They don't directly change transcript bytes,
+  so they're orthogonal to LLM token caching.
+
+## Quantitative intuition
+
+A typical edit cycle on one file:
+
+1. `read foo.ts` → big payload, cached after the first turn. ✅
+2. `edit foo.ts` (success) → small diff result, cheap, cache survives. ✅
+3. `read foo.ts` again → **cache miss starting at the first changed
+   line's hashline**, because every following line's anchor shifted.
+   The pre-edit prefix (header, metadata, lines before the edit) still
+   hits cache.
+4. Repeat #3 after another edit → another partial invalidation at the
+   new edit point.
+
+So hygiene is **prefix-cache-friendly up to the first edit**, then
+progressively erodes the cached suffix as edits accumulate. The system
+implicitly rewards:
+
+- reading once and editing many times before re-reading,
+- using `symbol`, `offset`, `limit` to keep the cached read window
+  small,
+- editing top-down so cache-miss regions are contiguous.
+
+## Possible improvements (if caching cost mattered enough to optimize)
+
+1. **Stabilize auto-relocation output.** Instead of inlining a live
+   anchor block on mismatch, print a fixed "re-read the file to refresh
+   anchors" line. Trades agent ergonomics for cache stability.
+2. **Surface hygiene success badges in a fixed template.**
+   `[anchors fresh]` is cache-friendly; `[anchors fresh, last read
+   3 turns ago]` is not.
+3. **Optional content-only re-read mode.** Re-reads that don't intend to
+   edit could omit hashes, so unchanged-line bytes match across edits to
+   other lines.
+4. **Suppress the `>>>` table when the same mismatch fires twice in a
+   row.** Show it once, then a stable "still stale; re-read" line.
+
+## Bottom line
+
+The hygiene system is **net cache-positive on read-heavy workflows**
+(deterministic hashlines, small narrowing windows, structural maps) and
+**net cache-negative on edit-heavy workflows on the same file**
+(positional hashes invalidate suffixes; verbose error paths invalidate
+retries).
+
+The design explicitly trades some cache stability for agent correctness
+— making sure the agent edits the right line is worth more than saving
+prefix-cache tokens on a retry. That's the right trade, but worth being
+aware of when planning long edit sequences:
+
+> Read once, batch edits, prefer `symbol` / `offset`-narrowed re-reads.
+
+## Appendix: how this was verified
+
+Two complementary probes:
+
+- **In-session probes.** Triggered each hygiene mechanism via this
+  agent's `read` / `edit` / `grep` / `ast_search` tools and recorded the
+  verbatim diagnostics: stale-read guard, hash mismatch with `>>>`
+  auto-relocation, no-op diagnostic, binary read/edit guard, invalid
+  anchor format, invalid edit variant, etc.
+- **External harness.** A Node script (`tmp/external-probe/harness.mjs`,
+  not committed) wired the real tool registrations against a mock `pi`
+  API with a custom `wasReadInSession` `Set<string>` tracker, and
+  inspected `result.details.ptcValue.error.code` and
+  `result.details.contextHygiene` directly. This exposed:
+  - the structured error taxonomy (`file-not-read`, `hash-mismatch`,
+    `invalid-edit-variant`, `binary-file`, …),
+  - the `contextHygiene` metadata block attached to every successful
+    call,
+  - the read-tracker populating from `read` (and intended to populate
+    from `grep` matched files).
+
+Both align with the test suite (1231 tests across 259 files passing,
+including ~20 `tests/context-hygiene-*.test.ts` and ~10
+`tests/doom-loop-*.test.ts` files).

--- a/prompts/edit.md
+++ b/prompts/edit.md
@@ -3,13 +3,14 @@ Surgically edit files with hash-verified line references (anchors). Copy `LINE:H
 ## What edit does
 `edit` applies one or more changes to an existing text file using hash-verified anchors. Anchored operations are verified against the current file contents before they are written.
 
-## The four edit variants — when to use which
+## The five edit variants — when to use which
 
 | Variant | Use for | Anchors needed |
 |---|---|---|
 | `set_line` | Replace or delete exactly one line | 1 |
 | `replace_lines` | Replace or delete a contiguous range of lines | 2 |
 | `insert_after` | Insert new lines after an existing line | 1 |
+| `replace_symbol` | Replace an entire symbol declaration by name | 0 (uses `symbol`) |
 | `replace` | Fallback global string replacement | 0 |
 
 ### Prefer anchored variants
@@ -35,7 +36,7 @@ Surgically edit files with hash-verified line references (anchors). Copy `LINE:H
 
 - `path` is the file to edit
 - `edits` is an array of edit operations
-- Each edit entry must contain exactly one of `set_line`, `replace_lines`, `insert_after`, or `replace`
+- Each edit entry must contain exactly one of `set_line`, `replace_lines`, `insert_after`, `replace_symbol`, or `replace`
 - `new_text` is plain content — do not include hash prefixes or diff markers
 
 ## Variant examples
@@ -94,6 +95,27 @@ edit({
 })
 ```
 
+### `replace_symbol`
+Use `replace_symbol` to replace an entire symbol's declaration range (function/method/class/etc.) by name. Resolution uses the same lookup as `read symbol:` — supports `Foo.bar` dotted paths and `Foo.bar@<line>` disambiguation.
+
+```text
+edit({
+  path: "src/foo.ts",
+  edits: [
+    { replace_symbol: { symbol: "add", new_body: "export function add(a: number, b: number) {\n  return a + b + 1;\n}" } }
+  ]
+})
+```
+
+Rules and behavior:
+- `symbol` is required and must resolve to exactly one symbol. Ambiguous or not-found queries return the same banner shape produced by `read symbol:` (use `Foo.bar@<startLine>` to disambiguate).
+- `new_body` must not be empty or whitespace-only — empty bodies are rejected with `invalid-edit-variant`.
+- The new body is dedented and re-indented to match the original symbol's leading indentation. Pass a flush body (no extra leading indent) and the tool will indent it correctly inside classes/namespaces.
+- If `new_body` declares a different leaf name than the resolved symbol, a `name-mismatch: expected <old>, got <new>` warning is emitted (the edit still applies).
+- Anchored edits (`set_line` / `replace_lines` / `insert_after`) in the same call may not target lines inside a `replace_symbol` range — that combination is rejected with `invalid-edit-variant`.
+- `replace_symbol` honors the read-gate: the file must have been anchored earlier in the session (otherwise `file-not-read`).
+- The post-write syntax-regression validator runs against the resulting content (see below).
+
 ## Recovery from hash mismatch errors
 When the file changes after you captured anchors, `edit` reports a hash mismatch and shows current file lines with `>>>` markers.
 
@@ -128,7 +150,7 @@ If the result is classified as whitespace-only, verify that you changed the inte
 If `edit` says the file needs fresh anchors, obtain them with `read`, `grep`, `ast_search`, or `write` first.
 
 ### Invalid edit shape
-Each edit entry must contain exactly one variant. Do not mix `set_line`, `replace_lines`, `insert_after`, and `replace` in the same entry.
+Each edit entry must contain exactly one variant. Do not mix `set_line`, `replace_lines`, `insert_after`, `replace_symbol`, and `replace` in the same entry.
 
 ## Anchor sources
 Any tool that emits `LINE:HASH|content` anchors can feed `edit`:
@@ -164,3 +186,16 @@ edit({ path: "src/new-file.ts", edits: [{ set_line: { anchor: "1:2f9", new_text:
 - Anchored edits are validated and applied atomically from bottom to top.
 - If a non-whitespace-intent edit produces only whitespace-only changes, the tool emits a prominent warning so you can re-read and verify before assuming behavior changed.
 - After a successful replace-only batch, the tool emits an informational hint nudging you back toward anchored variants for safer future edits.
+
+## Syntax-regression notice
+
+After every successful write, `edit` runs a tree-sitter syntax-regression validator that compares parser ERROR/MISSING node counts before and after the edit. Languages currently covered: **Rust, C, C++, C headers, Java, Clojure**. Other languages and unmappable files are skipped (no warning, no block).
+
+Modes:
+- `warn` (default) — on a net-new ERROR or MISSING node, the edit still applies and a `syntax-regression: lines X-Y` entry is appended to the response `warnings` array.
+- `block` — the edit is aborted with the `syntax-regression` ptc error code; the file on disk is unchanged.
+- `off` — the validator is skipped entirely.
+
+Mode resolution order: explicit `syntaxValidate` option > `PI_HASHLINE_SYNTAX_VALIDATE` env var > default `warn`. Invalid env values fall back to `warn`.
+
+Pre-existing syntax errors do not trigger the warning (±1 tolerance on net-new ERROR count; MISSING is no-tolerance). The validator runs on LF-normalized content, so CRLF round-trips do not produce spurious regressions. The same validator runs for both anchored variants and `replace_symbol`.

--- a/prompts/read.md
+++ b/prompts/read.md
@@ -42,6 +42,14 @@ Use the `symbol` parameter to read a specific symbol by name — no line numbers
 
 **Mutual exclusivity:** `symbol` cannot be combined with `offset` or `limit`. Use one addressing mode or the other.
 
+**`@line` disambiguation:** append `@<digits>` to a symbol query to pick a specific overload or definition by line number, e.g. `read(path, { symbol: "Foo.bar@42" })`. The `@<digits>` suffix only matches at end-of-string — ordinary names like `@Override`, `foo@bar`, or `foo@1bar` are treated as plain names, not `@line` queries. Resolution order:
+
+1. **Containing range** — a candidate whose `[startLine, endLine]` contains the requested line.
+2. **Nearest at-or-below** — the candidate with the smallest `startLine >= line`.
+3. **Nearest above** — the candidate with the largest `startLine < line`.
+
+When `@line` cannot be resolved but other declarations of the same leaf name exist in the file, the not-found message lists candidate `name@<startLine>` references so you can retry with a precise line.
+
 **Behavior by result:**
 
 - **Found (exact / case-insensitive / prefix):** Returns hashlined content for the symbol's line range only, prepended with `[Symbol: name (kind), lines X-Y of Z]`. Silent — no banner.

--- a/src/edit-syntax-validate.ts
+++ b/src/edit-syntax-validate.ts
@@ -1,0 +1,148 @@
+import { createRequire } from "node:module";
+
+import { detectLanguage } from "./readmap/language-detect.js";
+
+export interface ValidateInput {
+  filePath: string;
+  before: string | undefined;
+  after: string;
+}
+
+export interface ValidateResult {
+  errorLines: string[];
+  newErrorCount: number;
+  newMissingCount: number;
+}
+
+interface NodeStats {
+  errors: Array<{ startLine: number; endLine: number }>;
+  missing: Array<{ startLine: number; endLine: number }>;
+}
+
+const require_ = createRequire(import.meta.url);
+
+const PARSER_MODULES: Record<string, string> = {
+  rust: "tree-sitter-rust",
+  cpp: "tree-sitter-cpp",
+  "c-header": "tree-sitter-cpp",
+  java: "tree-sitter-java",
+  clojure: "tree-sitter-clojure",
+};
+
+const parserCache = new Map<string, import("tree-sitter") | null>();
+
+function ensureWritableTypeProperty(parserCtor: unknown): void {
+  const syntaxNode = (parserCtor as { SyntaxNode?: { prototype?: object } }).SyntaxNode;
+  const proto = syntaxNode?.prototype;
+  if (!proto) return;
+  const desc = Object.getOwnPropertyDescriptor(proto, "type");
+  if (!desc || desc.set) return;
+  Object.defineProperty(proto, "type", { ...desc, set: () => {} });
+}
+
+function getParser(filePath: string): import("tree-sitter") | null {
+  const lang = detectLanguage(filePath);
+  if (!lang) return null;
+  const mod = PARSER_MODULES[lang.id];
+  if (!mod) return null; // Task 3: unsupported language returns null
+  if (parserCache.has(lang.id)) return parserCache.get(lang.id) ?? null;
+
+  const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
+  if (isBun) {
+    parserCache.set(lang.id, null);
+    return null;
+  }
+
+  try {
+    const ParserCtor = require_("tree-sitter") as typeof import("tree-sitter");
+    const Lang = require_(mod) as import("tree-sitter").Language;
+    ensureWritableTypeProperty(ParserCtor);
+    const parser = new ParserCtor();
+    parser.setLanguage(Lang);
+    parserCache.set(lang.id, parser);
+    return parser;
+  } catch {
+    parserCache.set(lang.id, null);
+    return null;
+  }
+}
+
+function countNodes(parser: import("tree-sitter"), source: string): NodeStats {
+  const tree = parser.parse(source);
+  const errors: Array<{ startLine: number; endLine: number }> = [];
+  const missing: Array<{ startLine: number; endLine: number }> = [];
+  const stack: import("tree-sitter").SyntaxNode[] = [tree.rootNode];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (node.type === "ERROR" || node.hasError && node.type === "ERROR") {
+      errors.push({
+        startLine: node.startPosition.row + 1,
+        endLine: node.endPosition.row + 1,
+      });
+    }
+    if (node.isMissing) {
+      missing.push({
+        startLine: node.startPosition.row + 1,
+        endLine: node.endPosition.row + 1,
+      });
+    }
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const c = node.namedChild(i);
+      if (c) stack.push(c);
+    }
+    // Also descend into anonymous children to find MISSING tokens.
+    for (let i = 0; i < node.childCount; i++) {
+      const c = node.child(i);
+      if (c && !c.isNamed) stack.push(c);
+    }
+  }
+  return { errors, missing };
+}
+
+function dedupeSortLines(
+  ranges: Array<{ startLine: number; endLine: number }>,
+): string[] {
+  const seen = new Set<string>();
+  const out: Array<{ key: string; start: number }> = [];
+  for (const r of ranges) {
+    const key = r.startLine === r.endLine
+      ? String(r.startLine)
+      : `${r.startLine}-${r.endLine}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push({ key, start: r.startLine });
+    }
+  }
+  out.sort((a, b) => a.start - b.start);
+  return out.map((o) => o.key);
+}
+
+export async function validateSyntaxRegression(
+  input: ValidateInput,
+): Promise<ValidateResult | null> {
+  const parser = getParser(input.filePath);
+  if (!parser) return null;
+
+  const beforeStats = input.before === undefined
+    ? { errors: [], missing: [] }
+    : countNodes(parser, input.before);
+  const afterStats = countNodes(parser, input.after);
+
+  // ±1 tolerance on ERROR count, no tolerance on MISSING.
+  const newErrorCount = Math.max(
+    0,
+    afterStats.errors.length - beforeStats.errors.length - 1,
+  );
+  const newMissingCount = Math.max(
+    0,
+    afterStats.missing.length - beforeStats.missing.length,
+  );
+
+  if (newErrorCount === 0 && newMissingCount === 0) return null;
+
+  const errorLines = dedupeSortLines([
+    ...afterStats.errors,
+    ...afterStats.missing,
+  ]);
+  return { errorLines, newErrorCount, newMissingCount };
+}

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -13,6 +13,9 @@ import type { SemanticSummary } from "./ptc-value.js";
 import { buildPtcError } from "./ptc-value.js";
 import { Text } from "@mariozechner/pi-tui";
 import { formatEditCallText, formatEditResultText } from "./edit-render-helpers.js";
+import { validateSyntaxRegression } from "./edit-syntax-validate.js";
+import { resolveSyntaxValidateMode, type SyntaxValidateOptions } from "./syntax-validate-mode.js";
+import { replaceSymbol } from "./replace-symbol.js";
 
 export function wrapWriteError(err: any, path: string): Error {
 	const code = err?.code;
@@ -39,6 +42,10 @@ const hashlineEditItemSchema = Type.Union([
 		{ replace: Type.Object({ old_text: Type.String(), new_text: Type.String(), all: Type.Optional(Type.Boolean()) }) },
 		{ additionalProperties: true },
 	),
+	Type.Object(
+		{ replace_symbol: Type.Object({ symbol: Type.String(), new_body: Type.String() }) },
+		{ additionalProperties: true },
+	),
 ]);
 
 const hashlineEditSchema = Type.Object(
@@ -55,6 +62,7 @@ const EDIT_DESC = readFileSync(new URL("../prompts/edit.md", import.meta.url), "
 
 export interface EditToolOptions {
 	wasReadInSession?: (absolutePath: string) => boolean;
+	syntaxValidate?: SyntaxValidateOptions["syntaxValidate"];
 }
 
 // ─── Registration ───────────────────────────────────────────────────────
@@ -216,9 +224,10 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 					Number("set_line" in e) +
 					Number("replace_lines" in e) +
 					Number("insert_after" in e) +
-					Number("replace" in e);
+					Number("replace" in e) +
+					Number("replace_symbol" in e);
 				if (variantCount !== 1) {
-					const message = `edits[${i}] must contain exactly one of: 'set_line', 'replace_lines', 'insert_after', 'replace'. Got: [${Object.keys(e).join(", ")}].`;
+					const message = `edits[${i}] must contain exactly one of: 'set_line', 'replace_lines', 'insert_after', 'replace', 'replace_symbol'. Got: [${Object.keys(e).join(", ")}].`;
 					return {
 						content: [{ type: "text", text: message }],
 						isError: true,
@@ -242,6 +251,27 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			const replaceEdits = edits.filter(
 				(e): e is { replace: { old_text: string; new_text: string; all?: boolean } } => "replace" in e,
 			);
+			const replaceSymbolEdits = edits.filter(
+				(e): e is { replace_symbol: { symbol: string; new_body: string } } => "replace_symbol" in e,
+			);
+			for (const rs of replaceSymbolEdits) {
+				if (!rs.replace_symbol.new_body.trim()) {
+					return {
+						content: [{ type: "text", text: "replace_symbol.new_body must not be empty or whitespace-only." }],
+						isError: true,
+						details: {
+							diff: "",
+							firstChangedLine: undefined,
+							ptcValue: {
+								tool: "edit",
+								ok: false,
+								path: absolutePath,
+								error: buildPtcError("invalid-edit-variant", "replace_symbol.new_body must not be empty or whitespace-only."),
+							},
+						} as EditToolDetails & { ptcValue: any },
+					};
+				}
+			}
 
 			let rawBuffer: Buffer;
 			try {
@@ -304,7 +334,85 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			const { bom, text: content } = stripBom(raw);
 			const originalEnding = detectLineEnding(content);
 			const originalNormalized = normalizeToLF(content);
-			let result = originalNormalized;
+			let preAnchorContent = originalNormalized;
+			// AC 26: reject anchored edits that target a line inside any replace_symbol
+			// pre-replace range. Resolve each target against the ORIGINAL content so the
+			// user-provided anchor line numbers (which reference the file as read) are
+			// compared against the pre-replace coordinates.
+			const replaceSymbolRanges: { start: number; end: number }[] = [];
+			for (const rs of replaceSymbolEdits) {
+				const probe = await replaceSymbol({
+					filePath: absolutePath,
+					content: originalNormalized,
+					symbol: rs.replace_symbol.symbol,
+					newBody: rs.replace_symbol.new_body,
+				});
+				if (probe.type === "ok") replaceSymbolRanges.push(probe.range);
+			}
+			if (replaceSymbolRanges.length > 0) {
+				for (const edit of anchorEdits) {
+					const refs: string[] = [];
+					if ("set_line" in edit) refs.push((edit as any).set_line.anchor);
+					else if ("replace_lines" in edit) {
+						refs.push((edit as any).replace_lines.start_anchor, (edit as any).replace_lines.end_anchor);
+					} else if ("insert_after" in edit) refs.push((edit as any).insert_after.anchor);
+					for (const ref of refs) {
+						let parsedLine: number | undefined;
+						try {
+							parsedLine = parseLineRef(ref).line;
+						} catch {
+							continue;
+						}
+						for (const range of replaceSymbolRanges) {
+							if (parsedLine >= range.start && parsedLine <= range.end) {
+								const message = `Anchor at line ${parsedLine} falls inside a replace_symbol range (lines ${range.start}-${range.end}).`;
+								return {
+									content: [{ type: "text", text: message }],
+									isError: true,
+									details: {
+										diff: "",
+										firstChangedLine: undefined,
+										ptcValue: {
+											tool: "edit",
+											ok: false,
+											path: absolutePath,
+											error: buildPtcError("invalid-edit-variant", message),
+										},
+									} as EditToolDetails & { ptcValue: any },
+								};
+							}
+						}
+					}
+				}
+			}
+			const replaceSymbolWarnings: string[] = [];
+			for (const rs of replaceSymbolEdits) {
+				const r = await replaceSymbol({
+					filePath: absolutePath,
+					content: preAnchorContent,
+					symbol: rs.replace_symbol.symbol,
+					newBody: rs.replace_symbol.new_body,
+				});
+				if (r.type !== "ok") {
+					return {
+						content: [{ type: "text", text: r.message }],
+						isError: true,
+						details: {
+							diff: "",
+							firstChangedLine: undefined,
+							ptcValue: {
+								tool: "edit",
+								ok: false,
+								path: absolutePath,
+								error: buildPtcError("invalid-edit-variant", r.message),
+							},
+						} as EditToolDetails & { ptcValue: any },
+					};
+				}
+				preAnchorContent = r.content;
+				replaceSymbolWarnings.push(...r.warnings);
+			}
+			let result = preAnchorContent;
 
 			let anchorResult;
 			try {
@@ -429,6 +537,39 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			}
 
 			throwIfAborted(signal);
+
+			// Syntax-regression validator (warn/block/off)
+			const syntaxMode = resolveSyntaxValidateMode({ syntaxValidate: options.syntaxValidate });
+			let syntaxWarning: string | undefined;
+			if (syntaxMode !== "off") {
+				const regression = await validateSyntaxRegression({
+					filePath: absolutePath,
+					before: originalNormalized,
+					after: result,
+				});
+				if (regression) {
+					const lines = regression.errorLines.join(", ");
+					const message = `syntax-regression: lines ${lines}`;
+					// Task 7 (AC 12): block mode aborts with syntax-regression code; file is left untouched.
+					if (syntaxMode === "block") {
+						return {
+							content: [{ type: "text", text: message }],
+							isError: true,
+							details: {
+								diff: "",
+								firstChangedLine: undefined,
+								ptcValue: {
+									tool: "edit",
+									ok: false,
+									path: absolutePath,
+									error: buildPtcError("syntax-regression", message),
+								},
+							} as EditToolDetails & { ptcValue: any },
+						};
+					}
+					syntaxWarning = message;
+				}
+			}
 			try {
 				await fsWriteFile(absolutePath, bom + restoreLineEndings(result, originalEnding), "utf-8");
 			} catch (err: any) {
@@ -463,6 +604,8 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			const warnings: string[] = [];
 			if (anchorResult.warnings?.length) warnings.push(...anchorResult.warnings);
 			if (legacyNormalizationWarning) warnings.push(legacyNormalizationWarning);
+			if (replaceSymbolWarnings.length) warnings.push(...replaceSymbolWarnings);
+			if (syntaxWarning) warnings.push(syntaxWarning);
 			// Semantic classification
 			const internalClassification = classifyEdit(originalNormalized, result);
 			const difftAvailable = await isDifftAvailable();

--- a/src/ptc-error-codes.ts
+++ b/src/ptc-error-codes.ts
@@ -50,6 +50,10 @@ export const PTC_ERROR_CODES = {
   "nu-timed-out": { description: "nushell command exceeded the timeout", trigger: "result.timedOut === true" },
   "nu-spawn-error": { description: "failed to spawn the nushell process", trigger: "spawn ENOENT or other spawn-time error" },
   "nu-temp-file-error": { description: "failed to write the temporary nushell script file", trigger: "fs writeFileSync failed in executeNuScript" },
+  "syntax-regression": {
+    description: "edit introduced new tree-sitter syntax errors compared to pre-edit content",
+    trigger: "post-write validator detected net-new ERROR or MISSING nodes (block mode)",
+  },
 } as const;
 
 export type PtcErrorCode = keyof typeof PTC_ERROR_CODES;

--- a/src/read.ts
+++ b/src/read.ts
@@ -18,6 +18,7 @@ import { throwIfAborted } from "./runtime";
 import { getOrGenerateMap } from "./map-cache";
 import { formatFileMapWithBudget } from "./readmap/formatter.js";
 import { findSymbol, type SymbolMatch } from "./readmap/symbol-lookup.js";
+import { formatAmbiguous, formatNotFound } from "./readmap/symbol-error-format.js";
 import { buildReadOutput } from "./read-output.js";
 import { buildReadRehydrateDescriptor } from "./context-hygiene.js";
 import { buildLocalBundle } from "./read-local-bundle.js";
@@ -370,18 +371,11 @@ export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}
 				} else {
 					const lookup = findSymbol(symbolFileMap, p.symbol);
 					if (lookup.type === "ambiguous") {
-						const lines = lookup.candidates.map((c) => `- ${c.name} (${c.kind}) — lines ${c.startLine}-${c.endLine}`);
-						const hints = lookup.candidates.map((c) => `${p.symbol}@${c.startLine}`).join(" or ");
 						return succeed({
 							content: [
 								{
 									type: "text",
-									text: [
-										`Symbol '${p.symbol}' is ambiguous.`,
-										"Matches:",
-										...lines,
-										`Use ${hints} to select by start line.`,
-									].join("\n"),
+									text: formatAmbiguous(p.symbol, lookup.candidates),
 								},
 							],
 							isError: false,
@@ -389,11 +383,7 @@ export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}
 						});
 					}
 					if (lookup.type === "not-found") {
-						const available = symbolFileMap.symbols
-							.slice(0, 20)
-							.map((s) => s.name)
-							.join(", ");
-						symbolWarning = `[Warning: symbol '${p.symbol}' not found. Available symbols: ${available}]\n\n`;
+						symbolWarning = `${formatNotFound(p.symbol, symbolFileMap)}\n\n`;
 					}
 					if (lookup.type === "found") {
 						startLine = Math.max(1, lookup.symbol.startLine);

--- a/src/readmap/symbol-error-format.ts
+++ b/src/readmap/symbol-error-format.ts
@@ -1,0 +1,18 @@
+import type { FileMap } from "./types.js";
+import type { SymbolMatch } from "./symbol-lookup.js";
+
+export function formatAmbiguous(query: string, candidates: SymbolMatch[]): string {
+	const lines = candidates.map((c) => `- ${c.name} (${c.kind}) — lines ${c.startLine}-${c.endLine}`);
+	const hints = candidates.map((c) => `${query}@${c.startLine}`).join(" or ");
+	return [
+		`Symbol '${query}' is ambiguous.`,
+		"Matches:",
+		...lines,
+		`Use ${hints} to select by start line.`,
+	].join("\n");
+}
+
+export function formatNotFound(query: string, map: FileMap): string {
+	const available = map.symbols.slice(0, 20).map((s) => s.name).join(", ");
+	return `[Warning: symbol '${query}' not found. Available symbols: ${available}]`;
+}

--- a/src/readmap/symbol-lookup.ts
+++ b/src/readmap/symbol-lookup.ts
@@ -18,7 +18,7 @@ export type SymbolLookupResult =
       tier: "camelCase" | "substring";
       otherCandidates: SymbolMatch[];
     }
-  | { type: "not-found" };
+  | { type: "not-found"; message?: string; candidates?: SymbolMatch[] };
 
 function toMatch(symbol: FileSymbol, parentName?: string): SymbolMatch {
   return {
@@ -112,14 +112,61 @@ export function findSymbol(map: FileMap, query: string): SymbolLookupResult {
   const allSymbols = flattenSymbols(map.symbols);
   const javaRelativeQuery = stripJavaPackagePrefix(map, q);
 
-  if (q.includes("@")) {
-    const parts = q.split("@");
-    if (parts.length === 2 && parts[0] && /^\d+$/.test(parts[1])) {
-      const [namePart, linePart] = parts;
-      const lineNum = Number.parseInt(linePart, 10);
-      const byLine = allSymbols.filter((c) => c.symbol.name === namePart && c.symbol.startLine === lineNum);
-      if (byLine.length === 1) return { type: "found", symbol: toMatch(byLine[0].symbol, byLine[0].parentName) };
-      if (byLine.length > 1) return { type: "ambiguous", candidates: toMatches(byLine.slice(0, 5)) };
+  const atLineMatch = /^(.+?)@(\d+)$/.exec(q);
+  if (atLineMatch) {
+    const namePart = atLineMatch[1];
+    const lineNum = Number.parseInt(atLineMatch[2], 10);
+    let pool: SymbolCandidate[];
+    if (namePart.includes(".")) {
+      const parts = namePart.split(".").map((p) => p.trim());
+      pool = parts.every((p) => p.length > 0)
+        ? resolveDotPath(map.symbols, parts)
+        : [];
+    } else {
+      pool = allSymbols.filter((c) => c.symbol.name === namePart);
+    }
+    // AC 16 + AC 17: drop candidates without usable startLine. If that empties
+    // the pool entirely, surface any same-leaf-name decls elsewhere in the file
+    // so the user can see real candidate lines.
+    pool = pool.filter((c) => Number.isFinite(c.symbol.startLine) && c.symbol.startLine > 0);
+    if (pool.length === 0) {
+      const leaf = namePart.split(".").pop() ?? namePart;
+      const sameLeaf = allSymbols.filter(
+        (c) => c.symbol.name === leaf
+          && Number.isFinite(c.symbol.startLine)
+          && c.symbol.startLine > 0,
+      );
+      if (sameLeaf.length > 0) {
+        const list = sameLeaf
+          .slice(0, 5)
+          .map((c) => `${c.parentName ? c.parentName + "." : ""}${c.symbol.name}@${c.symbol.startLine}`)
+          .join(", ");
+        return {
+          type: "not-found",
+          message: `${q} not found. Candidates: ${list}`,
+          candidates: toMatches(sameLeaf.slice(0, 5)),
+        };
+      }
+    }
+    if (pool.length > 0) {
+      const containing = pool.filter(
+        (c) => c.symbol.startLine <= lineNum && c.symbol.endLine >= lineNum,
+      );
+      if (containing.length > 0) {
+        return { type: "found", symbol: toMatch(containing[0].symbol, containing[0].parentName) };
+      }
+      const below = pool
+        .filter((c) => c.symbol.startLine >= lineNum)
+        .sort((a, b) => a.symbol.startLine - b.symbol.startLine);
+      if (below.length) {
+        return { type: "found", symbol: toMatch(below[0].symbol, below[0].parentName) };
+      }
+      const above = pool
+        .filter((c) => c.symbol.startLine < lineNum)
+        .sort((a, b) => b.symbol.startLine - a.symbol.startLine);
+      if (above.length) {
+        return { type: "found", symbol: toMatch(above[0].symbol, above[0].parentName) };
+      }
     }
   }
 

--- a/src/replace-symbol.ts
+++ b/src/replace-symbol.ts
@@ -1,0 +1,76 @@
+import { generateMap } from "./readmap/mapper.js";
+import { findSymbol } from "./readmap/symbol-lookup.js";
+import { formatAmbiguous, formatNotFound } from "./readmap/symbol-error-format.js";
+import { writeFileSync, mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+export interface ReplaceSymbolInput {
+	filePath: string;
+	content: string;
+	symbol: string;
+	newBody: string;
+}
+
+export type ReplaceSymbolResult =
+	| { type: "ok"; content: string; warnings: string[]; range: { start: number; end: number } }
+	| { type: "not-found"; message: string }
+	| { type: "ambiguous"; message: string };
+
+function detectIndent(line: string): string {
+	return line.match(/^\s*/)?.[0] ?? "";
+}
+
+function dedent(text: string): string {
+	const lines = text.split("\n");
+	const nonEmpty = lines.filter((l) => l.trim().length);
+	if (!nonEmpty.length) return text;
+	const minIndent = Math.min(...nonEmpty.map((l) => l.match(/^\s*/)?.[0].length ?? 0));
+	return lines.map((l) => l.slice(minIndent)).join("\n");
+}
+
+function reindent(text: string, indent: string): string {
+	return text.split("\n").map((l) => (l.length ? indent + l : l)).join("\n");
+}
+
+export async function replaceSymbol(input: ReplaceSymbolInput): Promise<ReplaceSymbolResult> {
+	const dir = mkdtempSync(join(tmpdir(), "rs-"));
+	const ext = input.filePath.match(/\.[^./\\]+$/)?.[0] ?? "";
+	const tmp = join(dir, "in" + ext);
+	writeFileSync(tmp, input.content);
+	const map = await generateMap(tmp);
+	if (!map) {
+		return { type: "not-found", message: `[Warning: symbol '${input.symbol}' not found. Available symbols: ]` };
+	}
+	const lookup = findSymbol(map, input.symbol);
+	if (lookup.type === "not-found") {
+		return { type: "not-found", message: formatNotFound(input.symbol, map) };
+	}
+	if (lookup.type === "ambiguous") {
+		return { type: "ambiguous", message: formatAmbiguous(input.symbol, lookup.candidates) };
+	}
+	const sym = lookup.symbol;
+	const lines = input.content.split("\n");
+	const sigLine = lines[sym.startLine - 1] ?? "";
+	const indent = detectIndent(sigLine);
+	const reindented = reindent(dedent(input.newBody), indent);
+	const warnings: string[] = [];
+	const leaf = input.symbol.replace(/@\d+$/, "").split(".").pop() ?? "";
+	const firstDeclName =
+		reindented.match(/\b(?:function|class|method|const|let|var)\s+([A-Za-z_$][\w$]*)/)?.[1]
+		?? reindented.match(/^\s*(?:[\w$<>,?\s]+\s+)?([A-Za-z_$][\w$]*)\s*\(/)?.[1];
+	if (leaf && firstDeclName && firstDeclName !== leaf) {
+		warnings.push(`name-mismatch: expected ${leaf}, got ${firstDeclName}`);
+	}
+	const before = lines.slice(0, sym.startLine - 1).join("\n");
+	const after = lines.slice(sym.endLine).join("\n");
+	const beforePart = before.length ? before + "\n" : "";
+	const afterPart = after.length ? "\n" + after : "";
+	const newContent = beforePart + reindented + afterPart;
+	return {
+		type: "ok",
+		content: newContent,
+		warnings,
+		range: { start: sym.startLine, end: sym.endLine },
+	};
+}

--- a/src/syntax-validate-mode.ts
+++ b/src/syntax-validate-mode.ts
@@ -1,0 +1,25 @@
+export type SyntaxValidateMode = "warn" | "block" | "off";
+
+export interface SyntaxValidateOptions {
+  syntaxValidate?: SyntaxValidateMode;
+}
+
+const VALID = new Set<SyntaxValidateMode>(["warn", "block", "off"]);
+const DEFAULT: SyntaxValidateMode = "warn";
+
+function coerce(value: unknown): SyntaxValidateMode | undefined {
+  if (typeof value !== "string") return undefined;
+  return VALID.has(value as SyntaxValidateMode)
+    ? (value as SyntaxValidateMode)
+    : undefined;
+}
+
+export function resolveSyntaxValidateMode(
+  opts: SyntaxValidateOptions,
+): SyntaxValidateMode {
+  const fromOpt = coerce(opts.syntaxValidate);
+  if (fromOpt) return fromOpt;
+  const fromEnv = coerce(process.env.PI_HASHLINE_SYNTAX_VALIDATE);
+  if (fromEnv) return fromEnv;
+  return DEFAULT;
+}

--- a/tests/edit-replace-symbol.test.ts
+++ b/tests/edit-replace-symbol.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { registerEditTool } from "../src/edit.js";
+import { computeLineHash, ensureHashInit } from "../src/hashline.js";
+import { registerReadTool } from "../src/read.js";
+
+function makeFakePi() {
+  const tools: any[] = [];
+  return { pi: { registerTool: (t: any) => tools.push(t) } as any, tools };
+}
+
+describe("edit replace_symbol variant", () => {
+  it("schema admits { replace_symbol: { symbol, new_body } } (no invalid-edit-variant error)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "edit-rs-schema-"));
+    const fp = join(dir, "x.ts");
+    writeFileSync(fp, `export function add() { return 1; }\n`);
+    const { pi, tools } = makeFakePi();
+    registerEditTool(pi, { wasReadInSession: () => true });
+    const tool = tools[0];
+    const res = await tool.execute(
+      "c",
+      {
+        path: fp,
+        edits: [{ replace_symbol: { symbol: "add", new_body: "export function add() { return 2; }" } }],
+      },
+      undefined,
+      undefined,
+      { cwd: dir },
+    );
+    const code = res.details?.ptcValue?.error?.code;
+    expect(code).not.toBe("invalid-edit-variant");
+  });
+
+  it.each(["", "   ", "\n\n"])("rejects empty/whitespace new_body=%j with invalid-edit-variant", async (body) => {
+    const dir = mkdtempSync(join(tmpdir(), "edit-rs-empty-"));
+    const fp = join(dir, "x.ts");
+    writeFileSync(fp, `export function add() { return 1; }\n`);
+    const { pi, tools } = makeFakePi();
+    registerEditTool(pi, { wasReadInSession: () => true });
+    const tool = tools[0];
+    const res = await tool.execute(
+      "c",
+      {
+        path: fp,
+        edits: [{ replace_symbol: { symbol: "add", new_body: body } }],
+      },
+      undefined,
+      undefined,
+      { cwd: dir },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.details?.ptcValue?.error?.code).toBe("invalid-edit-variant");
+  });
+});
+
+describe("edit replace_symbol behavior", () => {
+  it("replaces the symbol's declaration range and preserves the leading JSDoc comment outside it", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "edit-rs-"));
+    const fp = join(dir, "x.ts");
+    writeFileSync(fp,
+`/** doc above */
+export function add(a: number, b: number) {
+  return a + b;
+}
+`);
+    const { pi, tools } = makeFakePi();
+    registerEditTool(pi, { wasReadInSession: () => true });
+    const tool = tools[0];
+    const res = await tool.execute("c", {
+      path: fp,
+      edits: [{ replace_symbol: { symbol: "add", new_body: "export function add(a: number, b: number) {\n  return a + b + 1;\n}" } }],
+    }, undefined, undefined, { cwd: dir });
+    expect(res.isError).toBeFalsy();
+    const out = readFileSync(fp, "utf-8");
+    expect(out).toContain("/** doc above */");
+    expect(out).toContain("return a + b + 1;");
+    expect(out).not.toContain("return a + b;\n}");
+  });
+
+  it("replace_symbol ambiguous error matches the read tool's ambiguous banner verbatim", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "edit-rs-amb-"));
+    const fp = join(dir, "x.ts");
+    writeFileSync(fp,
+`function bar() { return 1; }
+function bar(n: number) { return n; }
+`);
+    const readEnv = makeFakePi();
+    registerReadTool(readEnv.pi);
+    const readTool = readEnv.tools[0];
+    const readRes = await readTool.execute("c", { path: fp, symbol: "bar" }, undefined, undefined, { cwd: dir });
+    const readBanner = readRes.content?.[0]?.text ?? "";
+    expect(readBanner).toContain("is ambiguous.");
+
+    const editEnv = makeFakePi();
+    registerEditTool(editEnv.pi, { wasReadInSession: () => true });
+    const editTool = editEnv.tools[0];
+    const editRes = await editTool.execute("c", {
+      path: fp,
+      edits: [{ replace_symbol: { symbol: "bar", new_body: "function bar() { return 0; }" } }],
+    }, undefined, undefined, { cwd: dir });
+    expect(editRes.isError).toBe(true);
+    const editMessage = editRes.details?.ptcValue?.error?.message ?? editRes.content?.[0]?.text ?? "";
+    expect(editMessage).toBe(readBanner);
+  });
+
+  it("replace_symbol not-found error matches the read tool's not-found warning verbatim", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "edit-rs-nf-"));
+    const fp = join(dir, "x.ts");
+    writeFileSync(fp, `export function add() { return 1; }\n`);
+
+    const readEnv = makeFakePi();
+    registerReadTool(readEnv.pi);
+    const readTool = readEnv.tools[0];
+    const readRes = await readTool.execute("c", { path: fp, symbol: "missing" }, undefined, undefined, { cwd: dir });
+    const readText = readRes.content?.[0]?.text ?? "";
+    const readBanner = readText.split("\n")[0];
+    expect(readBanner).toMatch(/^\[Warning: symbol 'missing' not found\./);
+
+    const editEnv = makeFakePi();
+    registerEditTool(editEnv.pi, { wasReadInSession: () => true });
+    const editTool = editEnv.tools[0];
+    const editRes = await editTool.execute("c", {
+      path: fp,
+      edits: [{ replace_symbol: { symbol: "missing", new_body: "export function missing() {}" } }],
+    }, undefined, undefined, { cwd: dir });
+    expect(editRes.isError).toBe(true);
+    const editMessage = editRes.details?.ptcValue?.error?.message ?? editRes.content?.[0]?.text ?? "";
+    expect(editMessage).toContain(readBanner);
+  });
+
+  it("replace_symbol returns file-not-read when wasReadInSession is false (no bypass)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "edit-rs-fnr-"));
+    const fp = join(dir, "x.ts");
+    writeFileSync(fp, `export function add() { return 1; }\n`);
+    const { pi, tools } = makeFakePi();
+    registerEditTool(pi, { wasReadInSession: () => false });
+    const tool = tools[0];
+    const res = await tool.execute(
+      "c",
+      {
+        path: fp,
+        edits: [{ replace_symbol: { symbol: "add", new_body: "export function add() { return 2; }" } }],
+      },
+      undefined,
+      undefined,
+      { cwd: dir },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.details?.ptcValue?.error?.code).toBe("file-not-read");
+    // File contents must be unchanged.
+    expect(readFileSync(fp, "utf-8")).toBe("export function add() { return 1; }\n");
+  });
+
+  it("re-indents flush new_body to match the symbol's declaration indentation (in-class)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "edit-rs-indent-"));
+    const fp = join(dir, "x.ts");
+    writeFileSync(fp,
+`export class Foo {
+  bar() {
+    return 1;
+  }
+}
+`);
+    const { pi, tools } = makeFakePi();
+    registerEditTool(pi, { wasReadInSession: () => true });
+    const tool = tools[0];
+    const res = await tool.execute(
+      "c",
+      {
+        path: fp,
+        edits: [{ replace_symbol: { symbol: "Foo.bar", new_body: "bar() {\n  return 2;\n}" } }],
+      },
+      undefined,
+      undefined,
+      { cwd: dir },
+    );
+    expect(res.isError).toBeFalsy();
+    const out = readFileSync(fp, "utf-8");
+    expect(out).toContain("  bar() {");
+    expect(out).toContain("    return 2;");
+    expect(out).not.toContain("    return 1;");
+  });
+
+  it("emits name-mismatch warning when new_body declares a different name", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "edit-rs-nm-"));
+    const fp = join(dir, "x.ts");
+    writeFileSync(fp, `export function add(a: number, b: number) {\n  return a + b;\n}\n`);
+    const { pi, tools } = makeFakePi();
+    registerEditTool(pi, { wasReadInSession: () => true });
+    const tool = tools[0];
+    const res = await tool.execute(
+      "c",
+      {
+        path: fp,
+        edits: [{ replace_symbol: { symbol: "add", new_body: "export function plus() { return 2; }" } }],
+      },
+      undefined,
+      undefined,
+      { cwd: dir },
+    );
+    expect(res.isError).toBeFalsy();
+    const warnings: string[] = res.details?.ptcValue?.warnings ?? [];
+    expect(warnings.some((w) => w.startsWith("name-mismatch: expected add, got plus"))).toBe(true);
+  });
+
+  it("rejects an anchored edit whose line falls inside a replace_symbol pre-replace range", async () => {
+    await ensureHashInit();
+    const dir = mkdtempSync(join(tmpdir(), "edit-rs-overlap-"));
+    const fp = join(dir, "x.ts");
+    writeFileSync(
+      fp,
+      `export function add(a: number, b: number) {\n  return a + b;\n}\n`,
+    );
+    const { pi, tools } = makeFakePi();
+    registerEditTool(pi, { wasReadInSession: () => true });
+    const tool = tools[0];
+    const res = await tool.execute(
+      "c",
+      {
+        path: fp,
+        edits: [
+          { replace_symbol: { symbol: "add", new_body: "export function add(a: number, b: number) {\n  return a + b + 1;\n}" } },
+          { set_line: { anchor: `2:${computeLineHash(2, "  return a + b;")}`, new_text: "  return 0;" } },
+        ],
+      },
+      undefined,
+      undefined,
+      { cwd: dir },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.details?.ptcValue?.error?.code).toBe("invalid-edit-variant");
+    const msg = res.details?.ptcValue?.error?.message ?? "";
+    expect(msg).toMatch(/inside.*replace_symbol/i);
+    expect(readFileSync(fp, "utf-8")).toBe(
+      `export function add(a: number, b: number) {\n  return a + b;\n}\n`,
+    );
+  });
+
+  it("resolves the symbol against the file content read in execute() even with persistent caching enabled", async () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), "map-cache-"));
+    const prevNoPersist = process.env.PI_HASHLINE_NO_PERSIST_MAPS;
+    const prevCacheDir = process.env.PI_HASHLINE_MAP_CACHE_DIR;
+    process.env.PI_HASHLINE_NO_PERSIST_MAPS = "0";
+    process.env.PI_HASHLINE_MAP_CACHE_DIR = cacheDir;
+    try {
+      const dir = mkdtempSync(join(tmpdir(), "edit-rs-fresh-"));
+      const fp = join(dir, "x.ts");
+      writeFileSync(fp, `export function add() { return 1; }\n`);
+      const { generateMap } = await import("../src/readmap/mapper.js");
+      const mapV1 = await generateMap(fp);
+      expect(mapV1?.symbols.some((s: any) => s.name === "add")).toBe(true);
+      expect(mapV1?.symbols.some((s: any) => s.name === "sub")).toBe(false);
+
+      writeFileSync(fp, `export function add() { return 1; }\nexport function sub() { return 0; }\n`);
+
+      const { pi, tools } = makeFakePi();
+      registerEditTool(pi, { wasReadInSession: () => true });
+      const tool = tools[0];
+      const res = await tool.execute(
+        "c",
+        {
+          path: fp,
+          edits: [{ replace_symbol: { symbol: "sub", new_body: "export function sub() { return -1; }" } }],
+        },
+        undefined,
+        undefined,
+        { cwd: dir },
+      );
+      expect(res.isError).toBeFalsy();
+      expect(readFileSync(fp, "utf-8")).toContain("return -1;");
+    } finally {
+      if (prevNoPersist === undefined) delete process.env.PI_HASHLINE_NO_PERSIST_MAPS;
+      else process.env.PI_HASHLINE_NO_PERSIST_MAPS = prevNoPersist;
+      if (prevCacheDir === undefined) delete process.env.PI_HASHLINE_MAP_CACHE_DIR;
+      else process.env.PI_HASHLINE_MAP_CACHE_DIR = prevCacheDir;
+    }
+  });
+
+  it("triggers syntax-regression validator when replace_symbol introduces broken syntax (Rust)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "edit-rs-syntax-"));
+    const fp = join(dir, "x.rs");
+    writeFileSync(fp, `fn add() -> i32 { 1 }\n`);
+    const { pi, tools } = makeFakePi();
+    registerEditTool(pi, { wasReadInSession: () => true });
+    const tool = tools[0];
+    const res = await tool.execute(
+      "c",
+      {
+        path: fp,
+        edits: [{ replace_symbol: { symbol: "add", new_body: "fn add( -> i32 {\n    1\n" } }],
+      },
+      undefined,
+      undefined,
+      { cwd: dir },
+    );
+    expect(res.isError).toBeFalsy();
+    const warnings: string[] = res.details?.ptcValue?.warnings ?? [];
+    expect(warnings.some((w) => w.startsWith("syntax-regression"))).toBe(true);
+  });
+});

--- a/tests/edit-syntax-validate-warn.test.ts
+++ b/tests/edit-syntax-validate-warn.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+import { registerEditTool } from "../src/edit.js";
+
+function captureEditTool(opts?: any) {
+  let captured: any = null;
+  registerEditTool({ registerTool(def: any) { captured = def; } } as any, opts);
+  if (!captured) throw new Error("edit tool was not registered");
+  return captured;
+}
+
+describe("syntax-regression validator wired into edit (warn mode)", () => {
+  beforeAll(async () => { await ensureHashInit(); });
+
+  it("emits a syntax-regression warning when an edit introduces tree-sitter errors", async () => {
+    const tool = captureEditTool();
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-syntax-warn-"));
+    const fp = resolve(dir, "sample.rs");
+    writeFileSync(fp, "fn a() { 1 }\n", "utf8");
+    try {
+      const original = readFileSync(fp, "utf8");
+      const lines = original.split("\n");
+      const anchor = `1:${computeLineHash(1, lines[0])}`;
+      const res = await tool.execute(
+        "warn-1",
+        {
+          path: fp,
+          edits: [
+            { set_line: { anchor, new_text: "fn a( {" } },
+            { insert_after: { anchor, new_text: "fn b(\n" } },
+          ],
+        },
+        new AbortController().signal,
+        () => {},
+        { cwd: process.cwd() },
+      );
+
+      expect(res.isError).toBeFalsy();
+      const warnings: string[] = res.details?.ptcValue?.warnings ?? [];
+      expect(warnings.some((w) => w.startsWith("syntax-regression: lines "))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("block mode aborts the edit with syntax-regression ptc code and leaves the file unchanged", async () => {
+    const tool = captureEditTool({ syntaxValidate: "block" });
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-syntax-block-"));
+    const fp = resolve(dir, "sample.rs");
+    const original = "fn a() { 1 }\n";
+    writeFileSync(fp, original, "utf8");
+    try {
+      const lines = original.split("\n");
+      const anchor = `1:${computeLineHash(1, lines[0])}`;
+      const res = await tool.execute(
+        "block-1",
+        {
+          path: fp,
+          edits: [
+            { set_line: { anchor, new_text: "fn a( {" } },
+            { insert_after: { anchor, new_text: "fn b(\n" } },
+          ],
+        },
+        new AbortController().signal,
+        () => {},
+        { cwd: process.cwd() },
+      );
+
+      expect(res.isError).toBe(true);
+      expect(res.details?.ptcValue?.error?.code).toBe("syntax-regression");
+      expect(res.details?.ptcValue?.error?.message).toMatch(/lines \d+/);
+      expect(readFileSync(fp, "utf8")).toBe(original);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("off mode skips validation entirely (no syntax-regression warning even on regression)", async () => {
+    const tool = captureEditTool({ syntaxValidate: "off" });
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-syntax-off-"));
+    const fp = resolve(dir, "sample.rs");
+    const original = "fn a() { 1 }\n";
+    writeFileSync(fp, original, "utf8");
+    try {
+      const lines = original.split("\n");
+      const anchor = `1:${computeLineHash(1, lines[0])}`;
+      const res = await tool.execute(
+        "off-1",
+        {
+          path: fp,
+          edits: [
+            { set_line: { anchor, new_text: "fn a( {" } },
+            { insert_after: { anchor, new_text: "fn b(\n" } },
+          ],
+        },
+        new AbortController().signal,
+        () => {},
+        { cwd: process.cwd() },
+      );
+
+      expect(res.isError).toBeFalsy();
+      const warnings: string[] = res.details?.ptcValue?.warnings ?? [];
+      expect(warnings.some((w) => w.startsWith("syntax-regression"))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("pre-existing syntax errors do not trigger a regression on a benign edit elsewhere", async () => {
+    const tool = captureEditTool();
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-syntax-pre-"));
+    const fp = resolve(dir, "sample.rs");
+    // Pre-existing broken `fn bad( {` on line 1; well-formed `fn ok()` on line 2.
+    const original = "fn bad( {\nfn ok() { 1 }\n";
+    writeFileSync(fp, original, "utf8");
+    try {
+      const lines = original.split("\n");
+      // Edit the well-formed line 2 — leave it well-formed.
+      const anchor = `2:${computeLineHash(2, lines[1])}`;
+      const res = await tool.execute(
+        "pre-1",
+        {
+          path: fp,
+          edits: [{ set_line: { anchor, new_text: "fn ok() { 2 }" } }],
+        },
+        new AbortController().signal,
+        () => {},
+        { cwd: process.cwd() },
+      );
+
+      expect(res.isError).toBeFalsy();
+      const warnings: string[] = res.details?.ptcValue?.warnings ?? [];
+      expect(warnings.some((w) => w.startsWith("syntax-regression"))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("CRLF round-trip on a benign edit produces no spurious syntax-regression warning", async () => {
+    const tool = captureEditTool();
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-syntax-crlf-"));
+    const fp = resolve(dir, "sample.rs");
+    // Write CRLF Rust file. Both lines are well-formed.
+    const original = "fn a() { 1 }\r\nfn b() { 2 }\r\n";
+    writeFileSync(fp, original, "utf8");
+    try {
+      // The edit tool normalizes CRLF→LF internally; line 1 (LF view) is `fn a() { 1 }`.
+      const lfLine1 = "fn a() { 1 }";
+      const anchor = `1:${computeLineHash(1, lfLine1)}`;
+      const res = await tool.execute(
+        "crlf-1",
+        {
+          path: fp,
+          edits: [{ set_line: { anchor, new_text: "fn a() { 3 }" } }],
+        },
+        new AbortController().signal,
+        () => {},
+        { cwd: process.cwd() },
+      );
+
+      expect(res.isError).toBeFalsy();
+      const warnings: string[] = res.details?.ptcValue?.warnings ?? [];
+      expect(warnings.some((w) => w.startsWith("syntax-regression"))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/edit-syntax-validate.test.ts
+++ b/tests/edit-syntax-validate.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { validateSyntaxRegression } from "../src/edit-syntax-validate.js";
+
+describe("validateSyntaxRegression (Rust)", () => {
+  it("returns null when after-content is well-formed Rust", async () => {
+    const before = "fn a() { 1 }\n";
+    const after = "fn a() { 2 }\n";
+    const r = await validateSyntaxRegression({ filePath: "x.rs", before, after });
+    expect(r).toBeNull();
+  });
+
+  it("returns regression info when after-content adds new syntax errors", async () => {
+    const before = "fn a() { 1 }\n";
+    const after = "fn a( {\nfn b(\n";
+    const r = await validateSyntaxRegression({ filePath: "x.rs", before, after });
+    expect(r).not.toBeNull();
+    expect(r!.errorLines.length).toBeGreaterThan(0);
+    expect(r!.errorLines[0]).toMatch(/^\d+(-\d+)?$/);
+  });
+
+  it("treats undefined `before` as zero pre-existing errors", async () => {
+    const after = "fn a( {\nfn b(\n";
+    const r = await validateSyntaxRegression({
+      filePath: "x.rs",
+      before: undefined as unknown as string,
+      after,
+    });
+    expect(r).not.toBeNull();
+    expect(r!.errorLines.length).toBeGreaterThan(0);
+  });
+});
+
+describe("validateSyntaxRegression unsupported languages", () => {
+  it("returns null for python (mapped lang but no tree-sitter parser)", async () => {
+    const r = await validateSyntaxRegression({
+      filePath: "x.py",
+      before: "def f():\n    return 1\n",
+      after: "def f(:\n  broken\n",
+    });
+    expect(r).toBeNull();
+  });
+
+  it("returns null for unknown extension", async () => {
+    const r = await validateSyntaxRegression({
+      filePath: "weird.xyz",
+      before: "anything",
+      after: "anything else",
+    });
+    expect(r).toBeNull();
+  });
+});

--- a/tests/persistent-map-cache-key.test.ts
+++ b/tests/persistent-map-cache-key.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { computeKey } from "../src/persistent-map-cache.js";
+
+describe("persistent-map-cache key (AC 27)", () => {
+	it("same path + same mtime + different contentHash → different keys", () => {
+		const a = computeKey("/abs/x.ts", 1000, "deadbeef", "typescript", 1);
+		const b = computeKey("/abs/x.ts", 1000, "cafef00d", "typescript", 1);
+		expect(a).not.toBe(b);
+	});
+
+	it("identical inputs → identical keys (deterministic)", () => {
+		const a = computeKey("/abs/x.ts", 1000, "deadbeef", "typescript", 1);
+		const b = computeKey("/abs/x.ts", 1000, "deadbeef", "typescript", 1);
+		expect(a).toBe(b);
+	});
+
+	it("different mapperVersion → different keys (per AGENTS.md MAPPER_VERSION rule)", () => {
+		const a = computeKey("/abs/x.ts", 1000, "deadbeef", "typescript", 1);
+		const b = computeKey("/abs/x.ts", 1000, "deadbeef", "typescript", 2);
+		expect(a).not.toBe(b);
+	});
+});

--- a/tests/ptc-error-codes.test.ts
+++ b/tests/ptc-error-codes.test.ts
@@ -26,6 +26,7 @@ const REQUIRED_CODES = [
   "nu-timed-out",
   "nu-spawn-error",
   "nu-temp-file-error",
+  "syntax-regression",
 ] as const;
 
 describe("PTC_ERROR_CODES taxonomy", () => {

--- a/tests/read-symbol-at-line-java.test.ts
+++ b/tests/read-symbol-at-line-java.test.ts
@@ -1,0 +1,75 @@
+// tests/read-symbol-at-line-java.test.ts
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { registerReadTool } from "../src/read.js";
+
+function makeFakePi() {
+  const tools: any[] = [];
+  return { pi: { registerTool: (t: any) => tools.push(t) } as any, tools };
+}
+
+const JAVA_FIXTURE = `package x;
+public class Foo {
+  void bar() { System.out.println("a"); }
+  void baz() {}
+  void bar(int n) { System.out.println(n); }
+}
+`;
+
+describe("read symbol with @line (Java)", () => {
+  it('read symbol:"Foo.bar@3" resolves to the overload at line 3', async () => {
+    const dir = mkdtempSync(join(tmpdir(), "read-java-"));
+    const fp = join(dir, "Foo.java");
+    writeFileSync(fp, JAVA_FIXTURE);
+    const { pi, tools } = makeFakePi();
+    registerReadTool(pi);
+    const tool = tools[0];
+    const res = await tool.execute(
+      "c",
+      { path: fp, symbol: "Foo.bar@3" },
+      undefined,
+      undefined,
+      { cwd: dir },
+    );
+    expect(res.isError).toBeFalsy();
+    const text = res.content?.[0]?.text ?? "";
+    expect(text).toContain('System.out.println("a");');
+    expect(text).not.toContain("System.out.println(n);");
+  });
+
+  it('read bundle:"local" with @line resolves the right overload and includes its lines', async () => {
+    const dir = mkdtempSync(join(tmpdir(), "read-java-bundle-"));
+    const fp = join(dir, "Foo.java");
+    writeFileSync(fp, JAVA_FIXTURE);
+    const { pi, tools } = makeFakePi();
+    registerReadTool(pi);
+    const tool = tools[0];
+    const res = await tool.execute(
+      "c",
+      { path: fp, symbol: "Foo.bar@5", bundle: "local" },
+      undefined,
+      undefined,
+      { cwd: dir },
+    );
+    expect(res.isError).toBeFalsy();
+    const bundle = (res.details as any)?.bundle ?? (res.details as any)?.ptcValue?.bundle;
+    if (bundle) {
+      expect(bundle.mode).toBe("local");
+      expect(bundle.applied).toBe(true);
+    }
+    const text = res.content?.[0]?.text ?? "";
+    expect(text).toContain("System.out.println(n);");
+    // Primary symbol must be the line-5 overload — scope the no-arg-overload
+    // check to the `## Requested symbol` section (bundle: "local" intentionally
+    // pulls the sibling overload into `## Local support`).
+    const requestedIdx = text.indexOf("## Requested symbol");
+    const localIdx = text.indexOf("## Local support");
+    const requested = requestedIdx >= 0
+      ? text.slice(requestedIdx, localIdx >= 0 ? localIdx : text.length)
+      : text;
+    expect(requested).toContain("System.out.println(n);");
+    expect(requested).not.toContain('System.out.println("a");');
+  });
+});

--- a/tests/read-symbol-at-line.test.ts
+++ b/tests/read-symbol-at-line.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { registerReadTool } from "../src/read.js";
+
+function makeFakePi() {
+  const tools: any[] = [];
+  return { pi: { registerTool: (t: any) => tools.push(t) } as any, tools };
+}
+
+describe("read symbol with @line (TypeScript)", () => {
+  it('read symbol:"Foo.bar@3" returns the overload starting at line 2', async () => {
+    const dir = mkdtempSync(join(tmpdir(), "read-symbol-ts-"));
+    const fp = join(dir, "x.ts");
+    writeFileSync(
+      fp,
+      `export class Foo {
+  bar() {
+    return 1;
+  }
+  baz() {}
+  bar(n: number) {
+    return n;
+  }
+}
+`,
+    );
+    const { pi, tools } = makeFakePi();
+    registerReadTool(pi);
+    const tool = tools[0];
+    const res = await tool.execute(
+      "c",
+      { path: fp, symbol: "Foo.bar@3" },
+      undefined,
+      undefined,
+      { cwd: dir },
+    );
+    expect(res.isError).toBeFalsy();
+    const text = res.content?.[0]?.text ?? "";
+    expect(text).toContain("return 1");
+    expect(text).not.toContain("return n");
+  });
+});

--- a/tests/symbol-lookup-at-line.test.ts
+++ b/tests/symbol-lookup-at-line.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { findSymbol } from "../src/readmap/symbol-lookup.js";
+import type { FileMap } from "../src/readmap/types.js";
+
+const map: FileMap = {
+  path: "x.ts",
+  totalLines: 100,
+  totalBytes: 1000,
+  language: "TypeScript",
+  symbols: [
+    { name: "Override", kind: "function" as any, startLine: 10, endLine: 12 },
+    {
+      name: "Foo",
+      kind: "class" as any,
+      startLine: 1,
+      endLine: 50,
+      children: [
+        { name: "bar", kind: "method" as any, startLine: 5, endLine: 8 },
+        { name: "bar", kind: "method" as any, startLine: 30, endLine: 40 },
+      ],
+    },
+  ],
+  imports: [],
+  detailLevel: "full" as any,
+};
+
+describe("findSymbol @line grammar", () => {
+  it("does not trigger @line mode for `@Override`", () => {
+    const r = findSymbol(map, "@Override");
+    expect(r.type).toBe("not-found");
+  });
+
+  it("does not trigger @line for `foo@bar`", () => {
+    const r = findSymbol(map, "foo@bar");
+    expect(r.type).toBe("not-found");
+  });
+
+  it("does not trigger @line for `foo@1bar` (digits not at end-of-string)", () => {
+    const r = findSymbol(map, "foo@1bar");
+    expect(r.type).toBe("not-found");
+  });
+
+  it("without @line, returns ambiguous when multiple candidates share the name", () => {
+    const r = findSymbol(map, "bar");
+    expect(r.type).toBe("ambiguous");
+    expect((r as any).candidates).toHaveLength(2);
+    expect((r as any).candidates[0].startLine).toBe(5);
+    expect((r as any).candidates[1].startLine).toBe(30);
+  });
+
+  it("resolves Foo.bar@7 to the overload at startLine 5 (containing range)", () => {
+    const r = findSymbol(map, "Foo.bar@7");
+    expect(r.type).toBe("found");
+    expect((r as any).symbol.startLine).toBe(5);
+  });
+
+  it("resolves Foo.bar@35 to the overload at startLine 30 (containing range)", () => {
+    const r = findSymbol(map, "Foo.bar@35");
+    expect(r.type).toBe("found");
+    expect((r as any).symbol.startLine).toBe(30);
+  });
+
+  it("resolves Foo.bar@20 to startLine 30 (nearest at-or-below)", () => {
+    const r = findSymbol(map, "Foo.bar@20");
+    expect(r.type).toBe("found");
+    expect((r as any).symbol.startLine).toBe(30);
+  });
+
+  it("resolves Foo.bar@99 to startLine 30 (nearest above when none at-or-below)", () => {
+    const r = findSymbol(map, "Foo.bar@99");
+    expect(r.type).toBe("found");
+    expect((r as any).symbol.startLine).toBe(30);
+  });
+
+  it("@line not-found for an unknown leaf name returns plain not-found (no candidates field)", () => {
+    const r = findSymbol(map, "missing@10");
+    expect(r.type).toBe("not-found");
+    expect((r as any).candidates ?? []).toEqual([]);
+  });
+
+  it("@line not-found for a known dotted path with only no-startLine candidates lists same-name decls", () => {
+    const m: FileMap = {
+      ...map,
+      symbols: [
+        {
+          name: "Foo",
+          kind: "class" as any,
+          startLine: 1,
+          endLine: 50,
+          children: [
+            { name: "baz", kind: "method" as any, startLine: 0, endLine: 0 },
+          ],
+        },
+        { name: "baz", kind: "function" as any, startLine: 80, endLine: 90 },
+      ],
+    };
+    const r = findSymbol(m, "Foo.baz@5");
+    expect(r.type).toBe("not-found");
+    expect((r as any).message).toContain("Candidates: ");
+    expect((r as any).message).toMatch(/baz@\d+/);
+    expect(((r as any).candidates ?? []).length).toBeGreaterThan(0);
+    expect((r as any).candidates.some((c: any) => c.name === "baz" && c.startLine === 80)).toBe(true);
+  });
+});

--- a/tests/syntax-validate-mode.test.ts
+++ b/tests/syntax-validate-mode.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resolveSyntaxValidateMode } from "../src/syntax-validate-mode.js";
+
+const ENV = "PI_HASHLINE_SYNTAX_VALIDATE";
+
+describe("resolveSyntaxValidateMode", () => {
+  let prev: string | undefined;
+  beforeEach(() => {
+    prev = process.env[ENV];
+    delete process.env[ENV];
+  });
+  afterEach(() => {
+    if (prev === undefined) delete process.env[ENV];
+    else process.env[ENV] = prev;
+  });
+
+  it("defaults to warn when no option and no env", () => {
+    expect(resolveSyntaxValidateMode({})).toBe("warn");
+  });
+
+  it("uses option when provided", () => {
+    expect(resolveSyntaxValidateMode({ syntaxValidate: "block" })).toBe("block");
+    expect(resolveSyntaxValidateMode({ syntaxValidate: "off" })).toBe("off");
+  });
+
+  it("falls back to env when option absent", () => {
+    process.env[ENV] = "block";
+    expect(resolveSyntaxValidateMode({})).toBe("block");
+  });
+
+  it("option wins over env", () => {
+    process.env[ENV] = "block";
+    expect(resolveSyntaxValidateMode({ syntaxValidate: "off" })).toBe("off");
+  });
+
+  it("invalid option values fall back to default warn", () => {
+    expect(resolveSyntaxValidateMode({ syntaxValidate: "bogus" as any })).toBe("warn");
+  });
+
+  it("invalid env values fall back to default warn", () => {
+    process.env[ENV] = "bogus";
+    expect(resolveSyntaxValidateMode({})).toBe("warn");
+  });
+});


### PR DESCRIPTION
Resolves #155. Bundles source issue #073 (`prompts/grep.md`, already present and verified comprehensive).

## Summary

Three sequenced, correctness-first edit improvements, shipped 1 → 2 → 3:

1. **Post-write tree-sitter syntax-regression validator** — `set_line`, `replace_lines`, `insert_after`, `replace`, and `replace_symbol` all now run a tree-sitter parse-diff before `fsWriteFile`. New PTC error code `syntax-regression`. Modes: `warn` (default) / `block` / `off`, resolved via option > `PI_HASHLINE_SYNTAX_VALIDATE` env var > default. Languages: rust / cpp / c-header / java / clojure (others: no signal). Validator runs on LF-normalized content; CRLF round-trips do not produce spurious regressions.
2. **`Class.method@line` disambiguation** in `findSymbol` — supports `read symbol:"Foo.bar@42"` and `read bundle:"local"` against TypeScript and Java fixtures. Grammar `/^(.+?)@(\d+)$/` keeps `@Override`, `foo@bar`, `foo@1bar` as plain names. Resolution priority: containing range → nearest at-or-below → nearest above. Not-found `@line` errors list candidate decl lines (`Foo.bar@42 not found. Candidates: Foo.bar@10, Foo.bar@55`).
3. **`replace_symbol` edit variant** — new `{ replace_symbol: { symbol, new_body } }` shape in `edits[]`. Honors `wasReadInSession`. Symbol resolution uses `findSymbol`; ambiguous and not-found error banners are **byte-equal** to `read symbol:` via shared formatter. Whole-symbol replacement only — no markers, no merge logic, no FastEdit-style algorithm. Auto dedent + re-indent to the symbol's signature line. Empty/whitespace-only `new_body` rejected with `invalid-edit-variant`. Heuristic name-mismatch warning on the existing `details.ptcValue.warnings: string[]` channel. Anchored edits in the same `edits[]` array that target lines inside a `replace_symbol` pre-replace range are rejected before any write.

## Acceptance Criteria

### Sub-task 1 — Post-write tree-sitter syntax validation

- [x] **AC 1.** New module `src/edit-syntax-validate.ts` exists and is invoked from `registerEditTool` in `src/edit.ts` after merged content is computed and before `fsWriteFile`.
- [x] **AC 2.** When `src/readmap/language-detect.ts` returns no parser for the file, the validator returns no signal and the edit pipeline behaves identically to current `main`.
- [x] **AC 3.** The validator computes net-new errors with ±1 ERROR tolerance, tracks MISSING separately with no tolerance, and does not compare error-node positions.
- [x] **AC 4.** When `src/persistent-map-cache.ts` has no cached pre-edit parse, the validator treats pre-edit error count as zero; it does not synthesize a pre-edit parse.
- [x] **AC 5.** Empty net-new → no signal; non-empty → `syntax-regression` notice carrying line ranges.
- [x] **AC 6.** Mode resolution: extension option > `PI_HASHLINE_SYNTAX_VALIDATE` env var > default `warn`. Supported values: `warn` / `block` / `off`. Both code paths exercised by tests.
- [x] **AC 7.** `warn` mode: no abort, prominent visible warning, `"syntax-regression: lines X-Y"` appended to `details.ptcValue.warnings: string[]`.
- [x] **AC 8.** `block` mode: aborts the write with ptc error code `syntax-regression`; envelope shape matches `binary-file` / `hash-mismatch`.
- [x] **AC 9.** `off` mode: no parsing or validation work runs.
- [x] **AC 10.** Validator runs for every variant including `replace_symbol`.
- [x] **AC 11.** Validator parses LF-normalized content; CRLF round-trips through `restoreLineEndings` produce no spurious regressions.
- [x] **AC 12.** `src/ptc-error-codes.ts` includes a `syntax-regression` entry; `tests/ptc-error-codes.test.ts` asserts presence and metadata.

### Sub-task 2 — `Class.method@line` disambiguation

- [x] **AC 13.** `findSymbol` recognizes `@<line>` only when the **final** `@` is followed by digits at end-of-string. `@Override`, `foo@bar`, `foo@1bar` do not enter `@line` mode.
- [x] **AC 14.** Without `@line`, `findSymbol` behavior is unchanged (ambiguous when more than one match).
- [x] **AC 15.** With `@line`: dotted-path equality filter, then containing range → nearest at-or-below → nearest above. No fuzzy matching across paths.
- [x] **AC 16.** Candidates without usable `startLine` are excluded from `@line` resolution. Mappers updated to expose `startLine` bump `MAPPER_VERSION` (no mapper changed in this PR).
- [x] **AC 17.** Zero-candidate name → existing not-found error. Close-only → closest. Not-found `@line` errors list candidate decl lines (`Foo.bar@42 not found. Candidates: Foo.bar@10, Foo.bar@55`).
- [x] **AC 18.** `read symbol:"Foo.bar@42"` and `read bundle:"local"` both resolve correctly. Pinned by TypeScript and Java integration fixtures.

### Sub-task 3 — `replace_symbol` edit variant

- [x] **AC 19.** `edits[]` accepts `{ replace_symbol: { symbol: string; new_body: string } }`. `symbol` accepts both `Foo.bar` and `Foo.bar@42`.
- [x] **AC 20.** `replace_symbol` on a path that was not read in the session returns `file-not-read` with the existing message shape. No path bypasses `wasReadInSession`.
- [x] **AC 21.** Symbol resolution uses `findSymbol`. Symbol-not-found and ambiguous errors match `read symbol:` shapes verbatim (shared formatter).
- [x] **AC 22.** Replaces exactly the mapper's declaration range. Comments / decorators / JSDoc strictly outside the range preserved byte-for-byte; comments inside the range are replaced.
- [x] **AC 23.** `new_body` is dedented to its minimum common leading-whitespace prefix, then re-indented to the symbol's signature line indent.
- [x] **AC 24.** Empty / whitespace-only `new_body` (`""`, `"   "`, `"\n\n"`) rejected with `invalid-edit-variant` before any write.
- [x] **AC 25.** First-decl name-mismatch produces non-blocking `"name-mismatch: expected <leaf>, got <found>"` on `details.ptcValue.warnings`. Edit still proceeds.
- [x] **AC 26.** Anchored edits referencing coordinates inside a prior `replace_symbol` range are rejected with `invalid-edit-variant` before any write. Anchors interpreted against pre-replace coordinates.
- [x] **AC 27.** Symbol resolution runs against the file content read in `execute()`, not against any cached mapper output predating the read. Mapper cache key includes a content hash + `MAPPER_VERSION`.
- [x] **AC 28.** A `replace_symbol` edit that introduces a syntax regression triggers sub-task 1's validator with the same `warn` / `block` / `off` semantics.
- [x] **AC 29.** Whole-symbol replacement only — no markers, merge logic, or FastEdit-style algorithm.

### Cross-cutting

- [x] **AC 30.** `prompts/edit.md` documents `replace_symbol` (parameters, errors, indentation rule). `prompts/edit.md` and `prompts/read.md` document the `@line` lookup grammar and the `syntax-regression` error code.
- [x] **AC 31.** Tests use `tests/setup/no-persist-maps.ts` (or equivalent opt-out) so persistent map-cache state cannot leak between runs.
- [x] **AC 32.** Sub-tasks landed in order 1 → 2 → 3.

## Verification

- Full suite: **1276 / 1276 pass** (267 files).
- Targeted dedicated suites: **41 / 41 pass** across 8 files (`edit-syntax-validate{,-warn}.test.ts`, `syntax-validate-mode.test.ts`, `symbol-lookup-at-line.test.ts`, `edit-replace-symbol.test.ts`, `read-symbol-at-line{,-java}.test.ts`, `persistent-map-cache-key.test.ts`, `ptc-error-codes.test.ts`).
- `npm run typecheck`: clean.
- Per-criterion verification report: `.megapowers/plans/155-symbol-aware-edit-improvements-tree-sitt/verify.md`
- Code review: `ready`, no critical findings: `.megapowers/plans/155-symbol-aware-edit-improvements-tree-sitt/code-review.md`

## Sub-task 3 LOC budget

`src/replace-symbol.ts` (76) + `src/readmap/symbol-error-format.ts` (18) + `replace_symbol` wiring + AC 26 overlap guard in `src/edit.ts` (~80) ≈ **174 LOC** — within the architectural ~200 LOC cap (constraint **C4**).

## Public API additions

```ts
// src/syntax-validate-mode.ts
export type SyntaxValidateMode = "warn" | "block" | "off";
export interface SyntaxValidateOptions { syntaxValidate?: SyntaxValidateMode }
export function resolveSyntaxValidateMode(opts: SyntaxValidateOptions): SyntaxValidateMode

// src/edit-syntax-validate.ts
export interface ValidateInput { filePath: string; before: string | undefined; after: string }
export interface ValidateResult { errorLines: string[]; newErrorCount: number; newMissingCount: number }
export async function validateSyntaxRegression(input: ValidateInput): Promise<ValidateResult | null>

// src/replace-symbol.ts
export async function replaceSymbol(input: ReplaceSymbolInput): Promise<ReplaceSymbolResult>

// src/readmap/symbol-error-format.ts
export function formatAmbiguous(query: string, candidates: SymbolMatch[]): string
export function formatNotFound(query: string, map: FileMap): string

// src/edit.ts (extended)
export interface EditToolOptions {
  wasReadInSession?: (absolutePath: string) => boolean;
  syntaxValidate?: SyntaxValidateOptions["syntaxValidate"]; // new
}
```

## Follow-up notes (non-blocking)

- `replaceSymbol` is invoked twice per edit (probe + apply) and creates an uncleaned `mkdtempSync` temp directory each call. Cheap to fix once `generateMap` accepts in-memory content. Recommend a follow-up issue.
- Probe pass swallows non-`ok` results; the apply pass surfaces the error before any write, but anchor-overlap precedence becomes "first error wins". Non-blocking.

See `.megapowers/docs/155-symbol-aware-edit-improvements-tree-sitt.md` for the full feature document and `.megapowers/plans/155-symbol-aware-edit-improvements-tree-sitt/learnings.md` for retrospective notes.
