### PR TITLE
`replace`: warn when fuzzy matching is used (fixes silent truncation)

### DIFF
--- a/src/edit-diff.ts
+++ b/src/edit-diff.ts
@@ -135,7 +135,7 @@ export function replaceText(
 	oldText: string,
 	newText: string,
 	opts: { all?: boolean },
-): { content: string; count: number } {
+): { content: string; count: number; usedFuzzyMatch?: boolean } {
 	if (!oldText.length) return { content, count: 0 };
 	const normalizedNew = normalizeToLF(newText);
 
@@ -172,7 +172,7 @@ export function replaceText(
 			const span = spans[i]!;
 			out = out.substring(0, span.index) + normalizedNew + out.substring(span.index + span.matchLength);
 		}
-		return { content: out, count: spans.length };
+		return { content: out, count: spans.length, usedFuzzyMatch: true };
 	}
 
 	const result = fuzzyFindText(content, oldText);
@@ -181,7 +181,7 @@ export function replaceText(
 	return {
 		content: content.substring(0, result.index) + normalizedNew + content.substring(result.index + result.matchLength),
 		count: 1,
-	};
+		usedFuzzyMatch: result.usedFuzzyMatch || undefined,
 }
 
 // ─── Diff generation ────────────────────────────────────────────────────

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -358,6 +358,7 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				}
 				throw err;
 			}
+			let replaceUsedFuzzy = false;
 			result = anchorResult.content;
 
 			for (const r of replaceEdits) {
@@ -372,6 +373,7 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 					return buildEditError(absolutePath, "text-not-found", message);
 				}
 				result = rep.content;
+				if (rep.usedFuzzyMatch) replaceUsedFuzzy = true;
 			}
 
 			if (originalNormalized === result) {
@@ -461,6 +463,7 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			if (legacyNormalizationWarning) warnings.push(legacyNormalizationWarning);
 			if (replaceSymbolWarnings.length) warnings.push(...replaceSymbolWarnings);
 			if (syntaxWarning) warnings.push(syntaxWarning);
+			if (replaceUsedFuzzy) warnings.push("Exact match not found for old_text — used fuzzy matching. Verify the result carefully. For guaranteed accuracy, re-read the file and use anchored edit variants (set_line, replace_lines) instead of replace.");
 			// Semantic classification
 			const internalClassification = classifyEdit(originalNormalized, result);
 			const difftAvailable = await isDifftAvailable();


### PR DESCRIPTION
## Problem

When using the `replace` edit variant, if the exact `old_text` is not found in the file, the tool falls back to fuzzy matching (normalizing trailing whitespace and unicode characters). **The caller is never informed that the match was approximate.**

This can silently truncate files: if the user provides stale `old_text` (from an earlier `read` that is no longer current) and the file has been auto-formatted, the fuzzy match can consume the entire file content — replacing everything instead of just the intended span. The user sees a successful edit but the file is truncated.

This happened in practice: using `replace` with stale old_text against an auto-formatted file matched the full file content (both were semantically identical after normalization) and consumed everything.

## Root cause

`replaceText()` in `edit-diff.ts` calls `fuzzyFindText()` for the non-`all` path and does its own inline fuzzy matching for the `all` path, but neither path signals to the caller that the match was approximate. The caller (`edit.ts`) can only check `rep.count` > 0.

See issue #89 for full diagnosis.

## Fix (6 insertions, 3 deletions)

Two files changed:

**`src/edit-diff.ts`** — `replaceText()` return type gains `usedFuzzyMatch?: boolean`:
- Non-`all` path: passes through `result.usedFuzzyMatch` from `fuzzyFindText()`
- `all` path: sets `usedFuzzyMatch: true` when fuzzy matching was required

**`src/edit.ts`** — emits a warning when any `replace` edit used fuzzy matching:
- Tracks flag across multiple `replace` edits in the same batch
- Warning text: *"Exact match not found for old_text — used fuzzy matching. Verify the result carefully. For guaranteed accuracy, re-read the file and use anchored edit variants (set_line, replace_lines) instead of replace."*

## Non-breaking

The change is purely additive: adds a warning when fuzzy matching is used but never blocks the edit. Backward compatible — the `usedFuzzyMatch` field is optional (`boolean | undefined`), so existing callers of `replaceText()` are unaffected.

## Related

- Closes #89