### PR TITLE
fix: harden replace fuzzy fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {

--- a/prompts/edit.md
+++ b/prompts/edit.md
@@ -20,6 +20,10 @@ Surgically edit files with hash-verified line references (anchors). Copy `LINE:H
 ### `replace` is the escape hatch
 `replace` does not use anchors and does not verify exact line positions. Use it only when an anchored edit is not practical, such as a repeated string replacement across many unrelated lines.
 
+By default, `replace` is exact-only: if `old_text` is not found exactly, the edit fails with `text-not-found`. Re-read the file and prefer anchored variants (`set_line`, `replace_lines`, `insert_after`) for hash-verified edits.
+
+Approximate/fuzzy replacement is available only with explicit opt-in via `fuzzy: true`. When fuzzy replacement is used, the edit output includes a warning that exact `old_text` was not found and fuzzy matching selected the replacement span.
+
 ## Input format
 
 ```json
@@ -38,6 +42,7 @@ Surgically edit files with hash-verified line references (anchors). Copy `LINE:H
 - `edits` is an array of edit operations
 - Each edit entry must contain exactly one of `set_line`, `replace_lines`, `insert_after`, `replace_symbol`, or `replace`
 - `new_text` is plain content — do not include hash prefixes or diff markers
+- `replace` also accepts optional `fuzzy: true` for explicit approximate matching; omit it unless you intentionally want fuzzy matching.
 
 ## Variant examples
 
@@ -84,13 +89,24 @@ edit({
 ```
 
 ### `replace`
-Use `replace` only as the escape hatch when anchored variants are not practical.
+Use `replace` only as the escape hatch when anchored variants are not practical. It is exact-only by default; if exact `old_text` is absent, re-read the file and prefer anchored variants.
 
 ```text
 edit({
   path: "src/foo.ts",
   edits: [
     { replace: { old_text: "legacyName", new_text: "newName", all: true } }
+  ]
+})
+```
+
+Explicit fuzzy opt-in:
+
+```text
+edit({
+  path: "src/foo.ts",
+  edits: [
+    { replace: { old_text: "legacyName", new_text: "newName", fuzzy: true } }
   ]
 })
 ```

--- a/src/edit-diff.ts
+++ b/src/edit-diff.ts
@@ -130,23 +130,26 @@ export function fuzzyFindText(
  * Fuzzy matching only determines target spans; replacement always applies to
  * the original content (never normalizes the whole file).
  */
+export type ReplaceTextResult = { content: string; count: number; usedFuzzyMatch: boolean };
+
 export function replaceText(
 	content: string,
 	oldText: string,
 	newText: string,
-	opts: { all?: boolean },
-): { content: string; count: number } {
-	if (!oldText.length) return { content, count: 0 };
+	opts: { all?: boolean; fuzzy?: boolean },
+): ReplaceTextResult {
+	if (!oldText.length) return { content, count: 0, usedFuzzyMatch: false };
 	const normalizedNew = normalizeToLF(newText);
 
 	if (opts.all) {
 		const exactCount = content.split(oldText).length - 1;
 		if (exactCount > 0) {
-			return { content: content.split(oldText).join(normalizedNew), count: exactCount };
+			return { content: content.split(oldText).join(normalizedNew), count: exactCount, usedFuzzyMatch: false };
 		}
+		if (!opts.fuzzy) return { content, count: 0, usedFuzzyMatch: false };
 
 		const normalizedNeedle = normalizeForFuzzyMatch(oldText);
-		if (!normalizedNeedle.length) return { content, count: 0 };
+		if (!normalizedNeedle.length) return { content, count: 0, usedFuzzyMatch: false };
 
 		const { normalized, indexMap } = buildNormalizedWithMap(content);
 		const spans: Array<{ index: number; matchLength: number }> = [];
@@ -165,22 +168,34 @@ export function replaceText(
 			searchFrom = pos + Math.max(1, normalizedNeedle.length);
 		}
 
-		if (!spans.length) return { content, count: 0 };
+		if (!spans.length) return { content, count: 0, usedFuzzyMatch: false };
 
 		let out = content;
 		for (let i = spans.length - 1; i >= 0; i--) {
 			const span = spans[i]!;
 			out = out.substring(0, span.index) + normalizedNew + out.substring(span.index + span.matchLength);
 		}
-		return { content: out, count: spans.length };
+		return { content: out, count: spans.length, usedFuzzyMatch: true };
 	}
 
+	const exactIndex = content.indexOf(oldText);
+	if (exactIndex !== -1) {
+		return {
+			content: content.substring(0, exactIndex) + normalizedNew + content.substring(exactIndex + oldText.length),
+			count: 1,
+			usedFuzzyMatch: false,
+		};
+	}
+
+	if (!opts.fuzzy) return { content, count: 0, usedFuzzyMatch: false };
+
 	const result = fuzzyFindText(content, oldText);
-	if (!result.found) return { content, count: 0 };
+	if (!result.found) return { content, count: 0, usedFuzzyMatch: false };
 
 	return {
 		content: content.substring(0, result.index) + normalizedNew + content.substring(result.index + result.matchLength),
 		count: 1,
+		usedFuzzyMatch: result.usedFuzzyMatch,
 	};
 }
 

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -39,7 +39,7 @@ const hashlineEditItemSchema = Type.Union([
 	),
 	Type.Object({ insert_after: Type.Object({ anchor: Type.String(), new_text: Type.String(), text: Type.Optional(Type.String()) }) }, { additionalProperties: true }),
 	Type.Object(
-		{ replace: Type.Object({ old_text: Type.String(), new_text: Type.String(), all: Type.Optional(Type.Boolean()) }) },
+		{ replace: Type.Object({ old_text: Type.String(), new_text: Type.String(), all: Type.Optional(Type.Boolean()), fuzzy: Type.Optional(Type.Boolean()) }) },
 		{ additionalProperties: true },
 	),
 	Type.Object(
@@ -199,7 +199,7 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				(e): e is HashlineEditItem => "set_line" in e || "replace_lines" in e || "insert_after" in e,
 			);
 			const replaceEdits = edits.filter(
-				(e): e is { replace: { old_text: string; new_text: string; all?: boolean } } => "replace" in e,
+				(e): e is { replace: { old_text: string; new_text: string; all?: boolean; fuzzy?: boolean } } => "replace" in e,
 			);
 			const replaceSymbolEdits = edits.filter(
 				(e): e is { replace_symbol: { symbol: string; new_body: string } } => "replace_symbol" in e,
@@ -360,16 +360,28 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			}
 			result = anchorResult.content;
 
+			const replaceWarnings: string[] = [];
 			for (const r of replaceEdits) {
 				throwIfAborted(signal);
 				if (!r.replace.old_text.length) {
 					const message = "replace.old_text must not be empty.";
 					return buildEditError(absolutePath, "invalid-edit-variant", message);
 				}
-				const rep = replaceText(result, r.replace.old_text, r.replace.new_text, { all: r.replace.all ?? false });
+				const rep = replaceText(result, r.replace.old_text, r.replace.new_text, {
+					all: r.replace.all ?? false,
+					fuzzy: r.replace.fuzzy ?? false,
+				});
 				if (!rep.count) {
-					const message = `Could not find text to replace in ${path}.`;
-					return buildEditError(absolutePath, "text-not-found", message);
+					const message = `Could not find exact text to replace in ${path}.`;
+					const hint =
+						"Re-read the file and prefer set_line/replace_lines/insert_after for hash-verified edits. " +
+						"The replace variant is exact-only by default because fuzzy fallback is unverified.";
+					return buildEditError(absolutePath, "text-not-found", message, hint);
+				}
+				if (rep.usedFuzzyMatch) {
+					replaceWarnings.push(
+						"replace used fuzzy matching because exact old_text was not found; re-read the file and prefer set_line/replace_lines/insert_after for hash-verified edits.",
+					);
 				}
 				result = rep.content;
 			}
@@ -459,6 +471,7 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			const warnings: string[] = [];
 			if (anchorResult.warnings?.length) warnings.push(...anchorResult.warnings);
 			if (legacyNormalizationWarning) warnings.push(legacyNormalizationWarning);
+			if (replaceWarnings.length) warnings.push(...replaceWarnings);
 			if (replaceSymbolWarnings.length) warnings.push(...replaceSymbolWarnings);
 			if (syntaxWarning) warnings.push(syntaxWarning);
 			// Semantic classification

--- a/tests/edit-replace-fuzzy-policy.test.ts
+++ b/tests/edit-replace-fuzzy-policy.test.ts
@@ -1,0 +1,86 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit } from "../src/hashline.js";
+import { registerEditTool } from "../src/edit.js";
+
+async function callEditTool(params: Record<string, unknown>) {
+  let capturedTool: any = null;
+  registerEditTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  if (!capturedTool) throw new Error("edit tool was not registered");
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+function makeFixture(content: string): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-fuzzy-policy-"));
+  const filePath = resolve(dir, "sample.txt");
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+function getTextContent(result: any): string {
+  return result.content.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+describe("edit replace fuzzy policy", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("rejects stale fuzzy-only replace by default and leaves the file unchanged", async () => {
+    const current = "alpha   \n beta\n gamma\n";
+    const filePath = makeFixture(current);
+
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ replace: { old_text: "alpha\n beta\n gamma\n", new_text: "alpha\n" } }],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.details?.ptcValue?.error?.code).toBe("text-not-found");
+    expect(getTextContent(result)).toContain("Could not find exact text to replace");
+    expect(result.details?.ptcValue?.error?.hint).toContain("Re-read the file");
+    expect(result.details?.ptcValue?.error?.hint).toContain("set_line/replace_lines/insert_after");
+    expect(readFileSync(filePath, "utf-8")).toBe(current);
+  });
+
+
+  it("allows explicit fuzzy non-all replace and emits a fuzzy warning", async () => {
+    const filePath = makeFixture("alpha   \n beta\n gamma\n");
+
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ replace: { old_text: "alpha\n beta\n gamma\n", new_text: "alpha\n", fuzzy: true } }],
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(readFileSync(filePath, "utf-8")).toBe("alpha\n");
+    const text = getTextContent(result);
+    expect(text).toContain("Warnings:");
+    expect(text).toContain("replace used fuzzy matching because exact old_text was not found");
+    expect(text).toContain("prefer set_line/replace_lines/insert_after");
+    expect(result.details?.ptcValue?.warnings).toContain(
+      "replace used fuzzy matching because exact old_text was not found; re-read the file and prefer set_line/replace_lines/insert_after for hash-verified edits.",
+    );
+  });
+
+
+  it("allows explicit fuzzy all:true replace and emits a fuzzy warning", async () => {
+    const filePath = makeFixture("alpha   \n beta\n gamma\n\nalpha   \n beta\n gamma\n");
+
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ replace: { old_text: "alpha\n beta\n gamma\n", new_text: "alpha\n", all: true, fuzzy: true } }],
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(readFileSync(filePath, "utf-8")).toBe("alpha\n\nalpha\n");
+    const text = getTextContent(result);
+    expect(text).toContain("Warnings:");
+    expect(text).toContain("replace used fuzzy matching because exact old_text was not found");
+    expect(result.details?.ptcValue?.warnings).toContain(
+      "replace used fuzzy matching because exact old_text was not found; re-read the file and prefer set_line/replace_lines/insert_after for hash-verified edits.",
+    );
+  });
+});

--- a/tests/ptc-error-edit-noop-textnotfound.test.ts
+++ b/tests/ptc-error-edit-noop-textnotfound.test.ts
@@ -27,7 +27,7 @@ describe("edit ptcValue.error — text-not-found and no-op", () => {
     expect(r.isError).toBe(true);
     expect(getPtc(r)?.error?.code).toBe("text-not-found");
     const text = r.content.find((c: any) => c.type === "text")?.text ?? "";
-    expect(text).toMatch(/Could not find text to replace/);
+    expect(text).toMatch(/Could not find exact text to replace/);
   });
 
   it("no-op when edits produce identical content", async () => {

--- a/tests/repro-159-replace-fuzzy-fallback.test.ts
+++ b/tests/repro-159-replace-fuzzy-fallback.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { replaceText } from "../src/edit-diff.js";
+
+describe("repro 159: replace fuzzy fallback", () => {
+  it("does not silently replace a stale non-all old_text that only matches after fuzzy normalization", () => {
+    const current = "alpha   \n beta\n gamma\n";
+    const staleOldText = "alpha\n beta\n gamma\n";
+
+    const result = replaceText(current, staleOldText, "alpha\n", { all: false });
+
+    expect(result).toMatchObject({ content: current, count: 0 });
+  });
+
+  it("does not silently replace stale all:true old_text that only matches after fuzzy normalization", () => {
+    const current = "alpha   \n beta\n gamma\n";
+    const staleOldText = "alpha\n beta\n gamma\n";
+
+    const result = replaceText(current, staleOldText, "alpha\n", { all: true });
+
+    expect(result).toMatchObject({ content: current, count: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

Closes https://github.com/coctostan/pi-hashline-readmap/issues/89.

This hardens `edit`'s unanchored `replace` variant so stale `old_text` cannot silently trigger fuzzy fallback and replace a normalized span. Previously, if exact `old_text` was missing but matched after the fuzzy normalizer trimmed trailing whitespace or normalized punctuation/spaces, `replace` could report success and write a destructive replacement without telling the caller exact matching had failed.

This takes the safer product direction over the warning-only approach explored in PR #90: fuzzy replacement remains available, but only with explicit `fuzzy: true`, and fuzzy writes now emit a warning that exact `old_text` was not found.

Also bumps the package version to `0.8.5` for republishing.

## Issue details

The unsafe path was:

1. Agent captures or constructs `old_text` from an earlier file state.
2. The file changes in a way that is equivalent under the fuzzy normalizer, such as trailing whitespace changes.
3. `replace` exact matching fails.
4. The previous implementation silently falls back to fuzzy matching.
5. The edit tool sees only `{ content, count }`, treats `count > 0` as a normal success, and writes the replacement.
6. If `old_text` was a large block or full-file span and `new_text` was smaller, the file can be unexpectedly truncated.

The root problem was not fuzzy matching by itself; it was that fuzzy fallback was implicit and the result contract erased whether exact matching failed.

## What changed

- Add `ReplaceTextResult.usedFuzzyMatch` metadata.
- Make non-`all` and `all: true` replace exact-only by default.
- Add explicit fuzzy opt-in via `{ replace: { ..., fuzzy: true } }`.
- Surface fuzzy replacement warnings through edit output / `ptcValue.warnings`.
- Improve `text-not-found` guidance to recommend re-reading and anchored edit variants.
- Document the exact-by-default / fuzzy-opt-in policy in `prompts/edit.md`.
- Add regression coverage for stale fuzzy-only replacement, destructive full-span no-write behavior, and explicit fuzzy opt-in warnings.
- Bump package metadata to `0.8.5`.

## Acceptance criteria covered

- [x] Exact `replace` behavior remains unchanged when `old_text` is found exactly.
- [x] Exact-miss `replace` no longer silently applies fuzzy fallback by default.
- [x] Policy is consistent for both non-`all` and `all: true` replace paths.
- [x] Callers can distinguish exact matches from fuzzy matches via `usedFuzzyMatch`.
- [x] Stale full-span/block fuzzy-only replacements do not write by default.
- [x] User-facing output explains the remedy: re-read and prefer anchored variants (`set_line`, `replace_lines`, `insert_after`).
- [x] Prompt documentation describes exact-by-default behavior and explicit `fuzzy: true` opt-in.
- [x] Regression tests cover exact success, non-`all` stale/fuzzy input, `all: true` stale/fuzzy input, destructive full-span no-write behavior, and explicit fuzzy warning output.

## Verification

- `npm run typecheck && npm test`
  - 274 files passed
  - 1299 tests passed
- `npx vitest run tests/repro-159-replace-fuzzy-fallback.test.ts tests/edit-replace-fuzzy-policy.test.ts tests/edit-replace-hint.test.ts tests/ptc-error-edit-noop-textnotfound.test.ts`
  - 4 files passed
  - 12 tests passed
