### PR TITLE
chore: condense tool prompts, add contract tests, and bump to 0.8.6

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -197,7 +197,7 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
   const sgAvailable = isSgAvailable();
   const astSearchGuideline = sgAvailable
     ? 'Use `ast_search` for structural code patterns (function calls, imports, JSX). Use `grep` for text matching.'
-    : 'For AST-aware structural code search (function calls, imports, JSX elements), install ast-grep: `brew install ast-grep`';
+    : 'Use grep for plain text search; for AST-aware structural code search (function calls, imports, JSX elements), install ast-grep: `brew install ast-grep`';
 
   const grepTool = registerGrepTool(pi, { astSearchGuideline, onFileAnchored: noteRead });
   const sgTool = registerSgTool(pi, { onFileAnchored: noteRead });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",
+        "ignore": "^7.0.5",
+        "picomatch": "^4.0.4",
         "tree-sitter": "0.22.4",
         "tree-sitter-clojure": "github:ghoseb/tree-sitter-clojure#78928e6",
         "tree-sitter-cpp": "0.23.4",
@@ -204,29 +206,29 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1038.0.tgz",
-      "integrity": "sha512-oGiqs9v9WzPOdv7PDdm9iPibHgrbDvCDyNg43wFZn2PiiEUisFM+xUP2CRMsj41SmwZPhohmZkXiUu1+MghbAQ==",
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1045.0.tgz",
+      "integrity": "sha512-aPC6gAz9uKRiwfnKB7peTs6yD0FpSzmVnSkx0f2QtJfosFM6J6KtBvR1lMKby050K4C4PAyEScwA5YTsGfTcGA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
         "@aws-sdk/eventstream-handler-node": "^3.972.14",
         "@aws-sdk/middleware-eventstream": "^3.972.10",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/middleware-websocket": "^3.972.16",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/token-providers": "3.1038.0",
+        "@aws-sdk/token-providers": "3.1045.0",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/eventstream-serde-browser": "^4.2.14",
@@ -237,7 +239,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -253,7 +255,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -263,14 +265,14 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.6.tgz",
-      "integrity": "sha512-8Vu7zGxu+39ChR/s5J7nXBw3a2kMHAi0OfKT8ohgTVjX0qYed/8mIfdBb638oBmKrWCwwKjYAM5J/4gMJ8nAJA==",
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.20",
+        "@aws-sdk/xml-builder": "^3.972.22",
         "@smithy/core": "^3.23.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/property-provider": "^4.2.14",
@@ -280,7 +282,7 @@
         "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -289,13 +291,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.32.tgz",
-      "integrity": "sha512-7vA4GHg8NSmQxquJHSBcSM3RgB4ZaaRi6u4+zGFKOmOH6aqlgr2Sda46clkZDYzlirgfY96w15Zj0jh6PT48ng==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
+      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/types": "^4.14.1",
@@ -306,13 +308,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.34.tgz",
-      "integrity": "sha512-vBrhWujFCLp1u8ptJRWYlipMutzPptb8pDQ00rKVH9q67T7rGd3VTWIj63aKrlLuY6qSsw1Rt5F/D/7wnNgryA==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
+      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/fetch-http-handler": "^5.3.17",
         "@smithy/node-http-handler": "^4.6.1",
@@ -328,20 +330,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.36.tgz",
-      "integrity": "sha512-FBHyCmV8EB0gUvh1d+CZm87zt2PrdC7OyWexLRoH3I5zWSOUGa+9t58Y5jbxRfwUp3AWpHAFvKY6YzgR845sVA==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
+      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-env": "^3.972.32",
-        "@aws-sdk/credential-provider-http": "^3.972.34",
-        "@aws-sdk/credential-provider-login": "^3.972.36",
-        "@aws-sdk/credential-provider-process": "^3.972.32",
-        "@aws-sdk/credential-provider-sso": "^3.972.36",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.36",
-        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-login": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -354,14 +356,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.36.tgz",
-      "integrity": "sha512-IFap01lJKxQc0C/OHmZwZQr/cKq0DhrcmKedRrdnnl42D+P0SImnnnWQjv07uIPqpEdtqmkPXb9TiPYTU+prxQ==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
+      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
@@ -374,18 +376,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.37.tgz",
-      "integrity": "sha512-/WFixFAAiw8WpmjZcI0l4t3DerXLmVinOIfuotmRZnu2qmsFPoqqmstASz0z8bi1pGdFXzeLzf6bwucM3mZcUQ==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
+      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.32",
-        "@aws-sdk/credential-provider-http": "^3.972.34",
-        "@aws-sdk/credential-provider-ini": "^3.972.36",
-        "@aws-sdk/credential-provider-process": "^3.972.32",
-        "@aws-sdk/credential-provider-sso": "^3.972.36",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.36",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-ini": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -398,13 +400,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.32.tgz",
-      "integrity": "sha512-uZp4tlGbpczV8QxmtIwOpSkcyGtBRR8/T4BAumRKfAt1nwCig3FSCZvrKl6ARDIDVRYn5p2oRcAsfFR01EgMGA==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
+      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -416,15 +418,34 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.36.tgz",
-      "integrity": "sha512-DsLr0UHMyKzRJKe2bjlwU8q1cfoXg8TIJKV/xwvnalAemiZLOZunFzj/whGnFDZIBVLdnbLiwv5SvRf1+CSwkg==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
+      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/nested-clients": "^3.997.4",
-        "@aws-sdk/token-providers": "3.1038.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/token-providers": "3.1041.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -436,14 +457,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.36.tgz",
-      "integrity": "sha512-uzrURO7frJhHQVVNR5zBJcCYeMYflmXcWBK1+MiBym2Dfjh6nXATrMixrmGZi+97Q7ETZ+y/4lUwAy0Nfnznjw==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
+      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -535,13 +556,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.35.tgz",
-      "integrity": "sha512-lLppaNTAz+wNgLdi4FtHzrlwrGF0ODTnBWHBaFg85SKs0eJ+M+tP5ifrA8f/0lNd+Ak3MC1NGC6RavV3ny4HTg==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
         "@smithy/core": "^3.23.17",
@@ -561,19 +582,19 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.36.tgz",
-      "integrity": "sha512-O2beToxguBvrZFFZ+fFgPbbae8MvyIBjQ6lImee4APHEXXNAD5ZJ2ayLF1mb7rsKw86TM81y5czg82bZncjSjg==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
+      "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@smithy/core": "^3.23.17",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -605,25 +626,25 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.4.tgz",
-      "integrity": "sha512-4Sf+WY1lMJzXlw5MiyCMe/UzdILCwvuaHThbqMXS6dfh9gZy3No360I42RXquOI/ULUOhWy2HCyU0Fp20fQGPQ==",
+      "version": "3.997.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
+      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -631,7 +652,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -647,7 +668,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -673,13 +694,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.23.tgz",
-      "integrity": "sha512-wBbys3Y53Ikly556vyADurKpYQHXS7Jjaskbz+Ga9PZCz7PB/9f3VdKbDlz7dqIzn+xwz7L/a6TR4iXcOi8IRw==",
+      "version": "3.996.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.35",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
@@ -691,14 +712,14 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1038.0.tgz",
-      "integrity": "sha512-Qniru+9oGGb/HNK/gGZWbV3jsD0k71ngE7qMQ/x6gYNYLd2EOwHCS6E2E6jfkaqO4i0d+nNKmfRy8bNcshKdGQ==",
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1045.0.tgz",
+      "integrity": "sha512-/o4qcty0DmQola0DBniRVeBakYY6ALOvKEFo1AtJpTmMn/cJ+Fk3RWGe5ieT/f/eYbHG9k5E7poKge/E+WGv4Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -796,13 +817,13 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.22.tgz",
-      "integrity": "sha512-YTYqTmOUrwbm1h99Ee4y/mVYpFRl0oSO/amtP5cc1BZZWdaAVWs9zj3TkyRHWvR9aI/ZS8m3mS6awXtYUlWyaw==",
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
+      "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
@@ -822,9 +843,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.21.tgz",
-      "integrity": "sha512-qxNiHUtlrsjTeSlrPWiFkWps7uD6YB4eKzg7eLAFH8jbiHTlt0ePNlo2Xu+WlftP38JIcMaIX4jTUjOlE2ySWw==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -868,453 +889,46 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.50.1.tgz",
-      "integrity": "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.3.0",
@@ -1561,13 +1175,14 @@
       }
     },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.70.5.tgz",
-      "integrity": "sha512-ZUnJ7fFeJog97KG8FewEyqaObY2sLWvfDurKHl9kImVEbgt3l1LJ9A5pb+4/5KXnCVsoF/Brd0h+7yBEd1Aj5g==",
+      "version": "0.70.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.70.6.tgz",
+      "integrity": "sha512-PovJZJqhY4ajgTJRUcLzfWKnlQuJHxHW3T030CafR9LYeLmOHi/HGS8DbCdRgSJNbnoIG+kl67/7++9DKZ2+sg==",
+      "deprecated": "please use @earendil-works/pi-agent-core instead going forward",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.70.5",
+        "@mariozechner/pi-ai": "^0.70.6",
         "typebox": "^1.1.24"
       },
       "engines": {
@@ -1575,9 +1190,10 @@
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.70.5.tgz",
-      "integrity": "sha512-eyeyOfu/YiqzY6q391oRYdmnPIIU1VTKAn3hWIvzqkRHkcArd41/YynG8mw6bgoLdmCnIBoY3fD6nzEHEHLIMA==",
+      "version": "0.70.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.70.6.tgz",
+      "integrity": "sha512-LVAadu0Y+hb7Bj7EDiLsx6AuGxHlxDq0euLzyqX698i9qt0BW6a+oQSUIZQz4rJwExF18OvyL7ygJ5781ojrIQ==",
+      "deprecated": "please use @earendil-works/pi-ai instead going forward",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1601,16 +1217,17 @@
       }
     },
     "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.70.5.tgz",
-      "integrity": "sha512-5sQjY2LQLvYfMjo4Dn6P6iy3LFm3MZYgrYmgCQSwQSUM5yqzWceidYYXS4knloW7gNkko+nnhKB2u4NF3w+dVw==",
+      "version": "0.70.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.70.6.tgz",
+      "integrity": "sha512-S4hUZghBeHPqsL6+DNg/TbGLziSh5+/mEHPVlYq5y6ImirWXhISLdLCnyZUW83OblKWihmG7unhJXiHQTH82mQ==",
+      "deprecated": "please use @earendil-works/pi-coding-agent instead going forward",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.70.5",
-        "@mariozechner/pi-ai": "^0.70.5",
-        "@mariozechner/pi-tui": "^0.70.5",
+        "@mariozechner/pi-agent-core": "^0.70.6",
+        "@mariozechner/pi-ai": "^0.70.6",
+        "@mariozechner/pi-tui": "^0.70.6",
         "@silvia-odwyer/photon-node": "^0.3.4",
         "chalk": "^5.5.0",
         "cli-highlight": "^2.1.11",
@@ -1669,9 +1286,10 @@
       }
     },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.70.5.tgz",
-      "integrity": "sha512-5Ol9weTqpsQ85gg1C6Mo8M8o/HYz4uN7nM7QTPrw/Rm/UoFgO1/T/Irago5aGfzlIj/nmsGcqb7NlkWtT4vXUg==",
+      "version": "0.70.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.70.6.tgz",
+      "integrity": "sha512-orBJEwMdpBC38AXfdVBKT5ZvqNTcKg6g3NdoF5a9aNQzDI/dOTu1UNYFYyEOTFRiTxSR1nw8eovbCcaSyekWfw==",
+      "deprecated": "please use @earendil-works/pi-tui instead going forward",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1700,6 +1318,25 @@
         "zod-to-json-schema": "^3.25.0"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -1712,6 +1349,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.129.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
+      "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -1787,24 +1434,10 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
       "cpu": [
         "arm64"
       ],
@@ -1813,12 +1446,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
       "cpu": [
         "arm64"
       ],
@@ -1827,12 +1463,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
       "cpu": [
         "x64"
       ],
@@ -1841,26 +1480,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
+      "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
       "cpu": [
         "x64"
       ],
@@ -1869,12 +1497,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
       "cpu": [
         "arm"
       ],
@@ -1883,194 +1514,135 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-      "cpu": [
-        "loong64"
+      "libc": [
+        "musl"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
+      "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
-      "cpu": [
-        "ppc64"
+      "libc": [
+        "glibc"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
-      "cpu": [
-        "riscv64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
+      "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
+      "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
       "cpu": [
         "arm64"
       ],
@@ -2079,12 +1651,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
+      "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
       "cpu": [
         "arm64"
       ],
@@ -2093,26 +1687,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
       "cpu": [
         "x64"
       ],
@@ -2121,21 +1704,17 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-      "cpu": [
-        "x64"
       ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
+      "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "license": "MIT"
     },
     "node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
@@ -2379,9 +1958,9 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.6.tgz",
-      "integrity": "sha512-5zhmo2AkstmM/RMKYP0NHfmuYWBR+/umlmSuALgajLxf0X0rLE6d17MfzTxpzkILWVhwvCJkCyPH0AfMlbaucQ==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
+      "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2392,7 +1971,7 @@
         "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -2759,9 +2338,9 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.5.tgz",
-      "integrity": "sha512-h1IJsbgMDA+jaTjrco/JsyfWOgHRJBv8myB1y4AEI2fjIzD6ktZ7pFAyTw+gwN9GKIAygvC6db0mq0j8N2rFOg==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
+      "integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2881,6 +2460,17 @@
         "minimatch": "^10.0.1",
         "path-browserify": "^1.0.1",
         "tinyglobby": "^0.2.14"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/chai": {
@@ -3180,9 +2770,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3358,6 +2948,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/diff": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
@@ -3400,48 +3000,6 @@
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
-      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -3558,9 +3116,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "dev": true,
       "funding": [
         {
@@ -3570,7 +3128,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -3926,16 +3485,15 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
-      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4009,6 +3567,279 @@
       "optional": true,
       "funding": {
         "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/long": {
@@ -4123,9 +3954,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -4404,9 +4235,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4416,9 +4247,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -4467,9 +4298,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.7.tgz",
+      "integrity": "sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -4559,49 +4390,38 @@
         "node": ">= 4"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+    "node_modules/rolldown": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
+      "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.129.0",
+        "@rolldown/pluginutils": "1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.0",
+        "@rolldown/binding-darwin-arm64": "1.0.0",
+        "@rolldown/binding-darwin-x64": "1.0.0",
+        "@rolldown/binding-freebsd-x64": "1.0.0",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-musl": "1.0.0",
+        "@rolldown/binding-openharmony-arm64": "1.0.0",
+        "@rolldown/binding-wasm32-wasi": "1.0.0",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -4651,9 +4471,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
-      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4744,9 +4564,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "dev": true,
       "funding": [
         {
@@ -4827,13 +4647,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5001,9 +4821,9 @@
       "license": "0BSD"
     },
     "node_modules/typebox": {
-      "version": "1.1.34",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.34.tgz",
-      "integrity": "sha512-V0fM5W5DTXlEMDxqtX1dQ25HR1RQ11DPUVrIup4sJi1yQtIyI30SHfxBy/HjXKL1CtUqc5or2igA/wa/v4hMKQ==",
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5066,18 +4886,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
+      "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -5093,9 +4912,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -5108,13 +4928,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -5303,6 +5126,22 @@
         }
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
@@ -5320,9 +5159,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5389,9 +5228,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {
@@ -38,6 +38,8 @@
   },
   "dependencies": {
     "diff": "^8.0.3",
+    "ignore": "^7.0.5",
+    "picomatch": "^4.0.4",
     "tree-sitter": "0.22.4",
     "tree-sitter-clojure": "github:ghoseb/tree-sitter-clojure#78928e6",
     "tree-sitter-cpp": "0.23.4",

--- a/prompts/edit.md
+++ b/prompts/edit.md
@@ -1,30 +1,22 @@
-Surgically edit files with hash-verified line references (anchors). Copy `LINE:HASH` strings exactly from `read`, `grep`, `ast_search`, or `write` output and use them to make precise changes.
+Surgically edit existing text files. Prefer hash-verified anchored edits from fresh `read`, `grep`, `ast_search`, or `write` output; copy `LINE:HASH` anchors exactly.
 
-## What edit does
-`edit` applies one or more changes to an existing text file using hash-verified anchors. Anchored operations are verified against the current file contents before they are written.
+`edit` requires the target file to have been anchored earlier in the current session. If you get `file-not-read`, run `read`, `grep`, `ast_search`, or `write` first.
 
-## The five edit variants — when to use which
+## Variants
 
-| Variant | Use for | Anchors needed |
+| Variant | Use | Anchors |
 |---|---|---|
-| `set_line` | Replace or delete exactly one line | 1 |
-| `replace_lines` | Replace or delete a contiguous range of lines | 2 |
-| `insert_after` | Insert new lines after an existing line | 1 |
-| `replace_symbol` | Replace an entire symbol declaration by name | 0 (uses `symbol`) |
-| `replace` | Fallback global string replacement | 0 |
+| `set_line` | Replace/delete one line | 1 |
+| `replace_lines` | Replace/delete a contiguous range | 2 |
+| `insert_after` | Insert after an existing line | 1 |
+| `replace_symbol` | Replace one function/class/method/etc. | 0 (`symbol`) |
+| `replace` | String replacement escape hatch; one match by default, all with `all: true` | 0 |
 
-### Prefer anchored variants
-`set_line`, `replace_lines`, and `insert_after` use `LINE:HASH` anchors and verify that the file still matches the content you saw earlier.
-`edit` also requires the target file to have been anchored earlier in the current session. If it says the file was not read, run `read`, `grep`, `ast_search`, or `write` first to produce fresh anchors for that file.
+Prefer `set_line`, `replace_lines`, and `insert_after`: they verify the file still matches the anchored content. Use `replace` only when anchors are impractical, such as repeated text across many unrelated lines.
 
-### `replace` is the escape hatch
-`replace` does not use anchors and does not verify exact line positions. Use it only when an anchored edit is not practical, such as a repeated string replacement across many unrelated lines.
+`replace` is exact-only by default: missing `old_text` fails with `text-not-found`. Fuzzy replacement requires explicit `fuzzy: true`; when used, the response warns that exact text was not found and fuzzy matching was used.
 
-By default, `replace` is exact-only: if `old_text` is not found exactly, the edit fails with `text-not-found`. Re-read the file and prefer anchored variants (`set_line`, `replace_lines`, `insert_after`) for hash-verified edits.
-
-Approximate/fuzzy replacement is available only with explicit opt-in via `fuzzy: true`. When fuzzy replacement is used, the edit output includes a warning that exact `old_text` was not found and fuzzy matching selected the replacement span.
-
-## Input format
+## Input shape
 
 ```json
 {
@@ -32,197 +24,52 @@ Approximate/fuzzy replacement is available only with explicit opt-in via `fuzzy:
   "edits": [
     { "set_line": { "anchor": "42:ab1", "new_text": "const x = 2;" } },
     { "replace_lines": { "start_anchor": "50:c3d", "end_anchor": "55:e4f", "new_text": "const y = 3;\nreturn y;" } },
-    { "insert_after": { "anchor": "60:f5a", "new_text": "// TODO: revisit\n" } },
+    { "insert_after": { "anchor": "60:f5a", "new_text": "// TODO\n" } },
+    { "replace_symbol": { "symbol": "add", "new_body": "export function add(a, b) {\n  return a + b;\n}" } },
     { "replace": { "old_text": "value", "new_text": "result", "all": true } }
   ]
 }
 ```
 
-- `path` is the file to edit
-- `edits` is an array of edit operations
-- Each edit entry must contain exactly one of `set_line`, `replace_lines`, `insert_after`, `replace_symbol`, or `replace`
-- `new_text` is plain content — do not include hash prefixes or diff markers
-- `replace` also accepts optional `fuzzy: true` for explicit approximate matching; omit it unless you intentionally want fuzzy matching.
+Use only the variant(s) needed for the task; the example shows all shapes together for reference. Each `edits[]` entry must contain exactly one variant key. `new_text` / `new_body` is plain file content — no hash prefixes or diff markers.
 
-## Variant examples
+## `replace_symbol`
 
-### `set_line`
-Use `set_line` when you are changing one existing line.
+Use `replace_symbol` to replace one function, class, method, interface, type, enum, or similar symbol. Query symbols like `read symbol:`: `Name`, `Class.method`, or `Name@<line>`.
 
-```text
-edit({
-  path: "src/foo.ts",
-  edits: [
-    { set_line: { anchor: "12:abc", new_text: "const enabled = true;" } }
-  ]
-})
-```
+Rules:
+- Use an exact name, dotted path, or `@<line>`. If `read({symbol})` returned a fuzzy match, confirm the exact symbol before editing.
+- Supported for TypeScript, JavaScript, Rust, and Java. For other languages, use anchored edits.
+- `new_body` must not be empty or whitespace-only.
+- Write `new_body` without extra leading indentation; `edit` re-indents it to match the original symbol.
+- If `new_body` appears to declare a different symbol name, the edit still applies but returns a `name-mismatch` warning.
+- Do not combine `replace_symbol` with anchored edits that touch the same lines. Duplicate/overlapping `replace_symbol` ranges are rejected.
 
-### `replace_lines`
-Use `replace_lines` when you are replacing a contiguous block.
+## Stale anchors
+
+If anchors no longer match, `edit` fails with a hash mismatch (`hash-mismatch`) and shows nearby current lines. Lines marked `>>>` include updated anchors:
 
 ```text
-edit({
-  path: "src/foo.ts",
-  edits: [
-    {
-      replace_lines: {
-        start_anchor: "20:def",
-        end_anchor: "24:123",
-        new_text: "if (!enabled) {\n  return;\n}"
-      }
-    }
-  ]
-})
-```
-
-### `insert_after`
-Use `insert_after` when you are adding new lines after a known anchor.
-
-```text
-edit({
-  path: "src/foo.ts",
-  edits: [
-    { insert_after: { anchor: "30:456", new_text: "console.log(enabled);\n" } }
-  ]
-})
-```
-
-### `replace`
-Use `replace` only as the escape hatch when anchored variants are not practical. It is exact-only by default; if exact `old_text` is absent, re-read the file and prefer anchored variants.
-
-```text
-edit({
-  path: "src/foo.ts",
-  edits: [
-    { replace: { old_text: "legacyName", new_text: "newName", all: true } }
-  ]
-})
-```
-
-Explicit fuzzy opt-in:
-
-```text
-edit({
-  path: "src/foo.ts",
-  edits: [
-    { replace: { old_text: "legacyName", new_text: "newName", fuzzy: true } }
-  ]
-})
-```
-
-### `replace_symbol`
-Use `replace_symbol` to replace an entire symbol's declaration range (function/method/class/etc.) by name. Resolution uses the same symbol-query syntax as `read symbol:` — supports `Foo.bar` dotted paths and `Foo.bar@<line>` disambiguation — but mutating replacements are limited to precise in-memory mappers currently registered for TypeScript, JavaScript, Rust, and Java.
-
-```text
-edit({
-  path: "src/foo.ts",
-  edits: [
-    { replace_symbol: { symbol: "add", new_body: "export function add(a: number, b: number) {\n  return a + b + 1;\n}" } }
-  ]
-})
-```
-
-Rules and behavior:
-- `symbol` is required and must resolve to exactly one symbol. Ambiguous or not-found queries return the same banner shape produced by `read symbol:` (use `Foo.bar@<startLine>` to disambiguate).
-- `new_body` must not be empty or whitespace-only — empty bodies are rejected with `invalid-edit-variant`.
-- The new body is dedented and re-indented to match the original symbol's leading indentation. Pass a flush body (no extra leading indent) and the tool will indent it correctly inside classes/namespaces.
-- If `new_body` declares a different leaf name than the resolved symbol, a `name-mismatch: expected <old>, got <new>` warning is emitted (the edit still applies).
-- Anchored edits (`set_line` / `replace_lines` / `insert_after`) in the same call may not target lines inside a `replace_symbol` range — that combination is rejected with `invalid-edit-variant`.
-- `replace_symbol` honors the read-gate: the file must have been anchored earlier in the session (otherwise `file-not-read`).
-- The post-write syntax-regression validator runs against the resulting content (see below).
-- For languages supported by `read symbol:` but not by a precise in-memory mapper (for example Python/Go/Swift), use anchored edits instead of `replace_symbol`.
-
-## Recovery from hash mismatch errors
-When the file changes after you captured anchors, `edit` reports a hash mismatch and shows current file lines with `>>>` markers.
-
-Example:
-
-```text
-3 lines have changed since last read. Auto-relocation checks only within ±20 lines.
-
-    40:a12|function foo() {
 >>> 41:b34|  const renamed = 3;
-    42:c56|  return renamed;
 ```
 
-Recovery steps:
-1. Copy the updated `LINE:HASH` from the `>>>` line and retry the edit.
-2. If the relevant content moved farther away, run `read` again.
-3. If the error suggests nearby anchors, use the suggested anchor.
-4. If a `replace_lines` edit partially relocates, re-read and recompute both anchors.
+Copy the updated `LINE:HASH` and retry. If the target moved farther away, re-run `read`, `grep`, `ast_search`, or `write` for fresh anchors.
 
-## Auto-relocation
-If an anchor hash still matches uniquely within the relocation window, `edit` can auto-relocate the change and continue. Treat that as a warning to double-check the landing point.
+If `edit` auto-relocates an anchor, check the warning and verify the edit landed in the intended place.
 
-## Common failure modes
+## Validation and warnings
 
-### No changes made
-If `edit` says the file did not change, your replacement may already match the current file contents.
+- All edits are checked before writing; if a hard validation fails, nothing is written.
+- Anchored edits are applied bottom-up so line numbers stay stable.
+- `no-op` means the requested edit matched the current file already or produced identical content.
+- A whitespace-only warning means formatting changed but behavior probably did not.
+- A `replace`-only success may include a reminder to prefer anchored edits next time.
 
-### Whitespace-only change
-If the result is classified as whitespace-only, verify that you changed the intended content and not just formatting.
+Syntax validation runs before writing when supported:
+- Supported: Rust, C++, C headers, Java, Clojure.
+- Default `warn`: write succeeds, but warnings include `syntax-regression: lines X-Y`.
+- `block`: aborts without writing.
+- `off`: skips validation.
+- `PI_HASHLINE_SYNTAX_VALIDATE` can set the default mode.
 
-### Missing anchor source
-If `edit` says the file needs fresh anchors, obtain them with `read`, `grep`, `ast_search`, or `write` first.
-
-### Invalid edit shape
-Each edit entry must contain exactly one variant. Do not mix `set_line`, `replace_lines`, `insert_after`, `replace_symbol`, and `replace` in the same entry.
-
-## Anchor sources
-Any tool that emits `LINE:HASH|content` anchors can feed `edit`:
-- `read`
-- `grep`
-- `ast_search`
-- `write`
-
-## Worked examples
-
-### Search, then edit with `grep`
-```text
-grep({ pattern: "addRoute", path: "src", literal: true })
-edit({ path: "src/server.ts", edits: [{ set_line: { anchor: "45:e4f", new_text: "router.addRoute('/api', nextHandler);" } }] })
-```
-
-### Structure search, then edit with `ast_search`
-```text
-ast_search({ pattern: "const $NAME = $_", lang: "typescript", path: "src" })
-edit({ path: "src/foo.ts", edits: [{ set_line: { anchor: "18:9ac", new_text: "const value = compute();" } }] })
-```
-
-### Create, then refine with `write`
-```text
-write({ path: "src/new-file.ts", content: "export const value = 1;\n" })
-edit({ path: "src/new-file.ts", edits: [{ set_line: { anchor: "1:2f9", new_text: "export const value = 2;" } }] })
-```
-
-## Notes
-- Always copy anchors exactly as shown.
-- Prefer anchored variants over `replace`.
-- Re-run `read`, `grep`, `ast_search`, or `write` whenever you need fresh anchors.
-- Anchored edits are validated and applied atomically from bottom to top.
-- If a non-whitespace-intent edit produces only whitespace-only changes, the tool emits a prominent warning so you can re-read and verify before assuming behavior changed.
-- After a successful replace-only batch, the tool emits an informational hint nudging you back toward anchored variants for safer future edits.
-
-## Syntax-regression notice
-
-After every successful write, `edit` runs a tree-sitter syntax-regression validator that compares parser ERROR/MISSING node counts before and after the edit. Languages currently covered: **Rust, C, C++, C headers, Java, Clojure**. Other languages and unmappable files are skipped (no warning, no block).
-
-Modes:
-- `warn` (default) — on a net-new ERROR or MISSING node, the edit still applies and a `syntax-regression: lines X-Y` entry is appended to the response `warnings` array.
-- `block` — the edit is aborted with the `syntax-regression` ptc error code; the file on disk is unchanged.
-- `off` — the validator is skipped entirely.
-
-Mode resolution order: explicit `syntaxValidate` option > `PI_HASHLINE_SYNTAX_VALIDATE` env var > default `warn`. Invalid env values fall back to `warn`.
-
-Pre-existing syntax errors do not trigger the warning (±1 tolerance on net-new ERROR count; MISSING is no-tolerance). The validator runs on LF-normalized content, so CRLF round-trips do not produce spurious regressions. The same validator runs for both anchored variants and `replace_symbol`.
-
-## Error-precedence order for mixed edit batches
-
-When an `edits[]` array mixes `replace_symbol` entries with anchored variants (`set_line` / `replace_lines` / `insert_after`), errors are surfaced in this priority order:
-
-1. **`replace_symbol` symbol-resolution errors** (not-found, ambiguous) — returned immediately from the probe pass, before any overlap or anchor check runs and before any write occurs. Error code: `invalid-edit-variant`. Message: same format produced by `read symbol:"..."`.
-2. **Anchor-overlap errors** — returned when an anchored edit's line falls inside a `replace_symbol` pre-replace range. Error code: `invalid-edit-variant`.
-3. **Anchored-edit errors** — hash-mismatch or other anchor failures.
-
-The probe pass runs all `replace_symbol` entries against the original file content first. If every probe succeeds, each resolved result is shared with the apply pass — replacements are applied from bottom to top using the probe's original line ranges and no `replace_symbol` entry invokes a second parse. This means `generateMapFromContent` is invoked at most once per `replace_symbol` entry across the probe+apply lifecycle.
+Existing syntax errors are tolerated; the warning is for newly introduced parser errors.

--- a/prompts/find.md
+++ b/prompts/find.md
@@ -1,53 +1,19 @@
-Find files recursively matching a glob or regex pattern. Respects `.gitignore` (including nested), always includes hidden files. Supports sorting by name/mtime/size and filtering by mtime/size. Returns sorted relative paths with structured metadata.
+Find files recursively by name. Uses glob patterns by default, respects nested `.gitignore`, includes hidden files, and returns relative paths.
 
 ## Parameters
 
-- `pattern` — Glob pattern (default) or JavaScript regular expression when `regex: true`. Matches against file **basename**. Example glob: `'*.ts'`. Example regex: `'(Router|Handler)\\.ts$'`. **Required.**
-- `path` — Directory to search (default: current directory).
-- `limit` — Maximum entries to return after filtering and sorting (default: 1000).
-- `type` — Filter by entry type: `"file"` (default), `"dir"`, or `"any"`.
-- `maxDepth` — Maximum directory depth to search.
-- `regex` — Treat `pattern` as a JavaScript regular expression against the basename (default: `false`). Uses JS `RegExp` semantics uniformly on every platform.
-- `sortBy` — `"name"` (default, lexicographic), `"mtime"`, or `"size"`. Ascending by default; combine with `reverse: true` to flip.
-- `reverse` — Reverse the sort order (default: `false`). With `sortBy: "mtime"` → newest first. With `sortBy: "size"` → largest first.
-- `modifiedSince` — Filter to entries modified **strictly after** this instant. Accepts ISO date (`"2024-01-01"`), ISO timestamp (`"2024-01-01T00:00:00Z"`), or relative shorthand `<n><unit>` where unit ∈ `m`, `h`, `d`: `"30m"`, `"1h"`, `"24h"`, `"7d"`.
-- `minSize` / `maxSize` — File size bounds, inclusive on both ends. Accepts a number (bytes) or a string with a **1024-based** suffix: `B`, `K`, `KB`, `M`, `MB`, `G`, `GB` (case-insensitive). Fractional values are allowed (e.g. `"1.5MB"`). Size filters apply to files only; directories are never removed by size.
+- `pattern` — required. Glob by default; with `regex: true`, JavaScript regex against each basename.
+- `path` — directory to search, default cwd.
+- `type` — `"file"` default, `"dir"`, or `"any"`.
+- `limit` — max returned entries after filtering/sorting, default 1000.
+- `maxDepth` — non-negative directory depth limit.
+- `sortBy` — `"name"` default, `"mtime"`, or `"size"`; use `reverse: true` for descending/newest/largest first.
+- `modifiedSince` — keep entries modified strictly after an ISO date/time or relative age like `30m`, `1h`, `24h`, `7d`.
+- `minSize` / `maxSize` — file-size filters, inclusive; numbers are bytes, strings accept 1024-based `KB`, `MB`, `GB`, etc. Directories are not removed by size filters.
 
-## Output
+## Output and usage
 
-One path per line, sorted and filtered per the parameters. Paths are relative to `cwd` with forward slashes. Directories (when `type: "dir"` or `type: "any"`) show a trailing `/` suffix.
+One relative path per line. Directories end with `/`. If results exceed `limit` or 50 KB, output says it was truncated.
+Filtering and sorting happen before `limit`, so queries like largest/newest files work as expected.
 
-When the entry count exceeds `limit`, a truncation notice is appended. Output is also bounded at 50 KB.
-
-## Agent Examples (paste-ready)
-
-- Newest files in the project: `{ pattern: "*", type: "any", sortBy: "mtime", reverse: true, limit: 20 }`
-- Files changed in the last hour: `{ pattern: "*", modifiedSince: "1h" }`
-- Largest source files: `{ pattern: "*.ts", sortBy: "size", reverse: true, limit: 10 }`
-- Files over 1 MB: `{ pattern: "*", minSize: "1MB" }`
-- `Router` or `Handler` in the filename: `{ pattern: "(Router|Handler)", regex: true }`
-- All `.test.ts` files modified in the last day: `{ pattern: "*.test.ts", modifiedSince: "24h", sortBy: "mtime", reverse: true }`
-
-## Pipeline
-
-Results are produced in this order:
-
-1. Enumerate candidates using `fd` (if installed) or a built-in walker. Both respect `.gitignore`.
-2. Apply filters: regex (if `regex: true`), `modifiedSince`, `minSize`, `maxSize`.
-3. Sort by `sortBy` (with `reverse`).
-4. Apply `limit`.
-
-`limit` always applies **after** filtering and sorting, so adding `modifiedSince` or a size filter surfaces lower-ranked entries into the limit window.
-
-## Usage Guidance
-
-- Use `find` for recursive file discovery across the tree.
-- Use `type: "dir"` to discover directory structure.
-- Use `maxDepth: 1` for shallow exploration without switching to `ls`.
-- Use `ls` instead for single-directory inspection.
-- Use `grep` to search file *contents*, not file names.
-- Size units are 1024-based (`1KB` = 1024 B, `1MB` = 1024² B, `1GB` = 1024³ B).
-
-## Backend
-
-Uses `fd` when available for maximum speed. Falls back to a pure Node.js implementation when `fd` is not installed. Filters, regex, and sort are applied in-process in JavaScript, so regex semantics and sort behavior are identical on both backends.
+Use `find` for recursive file-name discovery, `ls` for one directory, and `grep` for file contents. Remember: `pattern` matches basenames, not full paths.

--- a/prompts/grep.md
+++ b/prompts/grep.md
@@ -1,85 +1,26 @@
-Search file contents for a pattern. Returns matching lines with `LINE:HASH` anchors for hashline edit workflows.
+Search file contents. Non-summary results return `LINE:HASH` anchors usable directly by `edit`; no follow-up `read` is needed.
 
-## Search Modes
+## Modes
 
-### Default mode
-Returns matching lines prefixed with `LINE:HASH|content` anchors. Use `>>` markers to identify match lines vs context lines.
-
-### Context mode (`context: N`)
-Includes N surrounding lines before and after each match. Nearby matches are merged and deduplicated automatically. Use when you need to see the code around a match, not just the matching line.
-
-### Summary mode (`summary: true`)
-Returns per-file match counts only — no line content, no anchors. Use this first to scope a broad search across many files, then drill into specific files with a targeted search.
-
-### Symbol-scoped mode (`scope: "symbol"`)
-Groups matches by their enclosing function, method, or class. By default, shows the full symbol block containing each match. Pass `scopeContext: N` to window output to ±N lines around each match (clipped at the symbol boundary); pass `scopeContext: 0` to get only match lines. The group header carries the line range and the `scoped to ±N lines` suffix. Falls back gracefully for files without structural maps. Ignored when `summary: true`.
+- Default: matching lines only. Output lines are `path:>>LINE:HASH|content`; `>>` marks matches.
+- `context: N`: include N lines before/after each match. Context lines use `path:  LINE:HASH|content`; nearby ranges are merged/deduped.
+- `summary: true`: return per-file match counts only — no line content or anchors. Use first for broad searches, then narrow with `path`/`glob`.
+- `scope: "symbol"`: group matches by enclosing symbol. By default returns the full symbol block. `scopeContext: N` windows to ±N lines around each match, clipped to the symbol; `0` returns only match lines. Ignored when `summary: true`.
 
 ## Parameters
 
-- `pattern` — Search pattern (regex by default, or literal string with `literal: true`)
-- `path` — Directory or file to search (default: current directory)
-- `glob` — Filter files by glob pattern, e.g. `'*.ts'` or `'**/*.test.ts'`
-- `ignoreCase` — Case-insensitive search (default: false)
-- `literal` — Treat pattern as literal string instead of regex (default: false). Use for exact matches to avoid regex escaping issues.
-- `context` — Number of lines to show before and after each match (default: 0)
-- `limit` — Maximum number of matches to return (default: 100)
-- `summary` — Return per-file match counts only (no hashline anchors)
-- `scope` — Set to `"symbol"` to group matches by enclosing symbol block
-- `scopeContext` — Number of context lines to show around each match within the enclosing symbol (requires `scope: "symbol"`). `0` = match lines only; `N > 0` = ±N lines clipped at the symbol boundary. Rejected when `scope` is not `"symbol"` — use `context` for non-symbol-scoped searches.
+- `pattern` — regex by default; use `literal: true` for exact strings or regex metacharacters.
+- `path` — file or directory, default cwd.
+- `glob` — file filter, e.g. `'*.ts'` or `'**/*.test.ts'`.
+- `ignoreCase` — case-insensitive search.
+- `context` — surrounding lines for normal grep.
+- `limit` — max matches, default 100.
+- `summary` — counts only, no anchors.
+- `scope` — only `"symbol"` is supported.
+- `scopeContext` — non-negative context within symbol scope; requires `scope: "symbol"`.
 
-## Truncation behavior
-- If total matches hit `limit`, grep appends `[Results truncated at N matches — refine pattern or increase limit]`.
-- Independently, if the rendered output exceeds the overall line/byte budget, grep head-truncates the text and appends `[Output truncated: ...]`.
+## Truncation and guidance
 
-## Usage Guidance
+If matches hit `limit`, output appends `[Results truncated at N matches — refine pattern or increase limit]`. Large non-summary results may cap displayed matches per file and/or head-truncate by output budget; narrow with `summary`, `path`, `glob`, or a more specific pattern.
 
-- Use `summary: true` first to scope a broad search, then drill into specific files with `path` or `glob`
-- Use `scope: "symbol"` when you need to understand the context of matches, not just find them
-- Use `literal: true` for exact string matches (e.g., searching for `$variable` or `array[0]`) to avoid regex escaping issues
-- Anchors from grep can be used directly in `edit` — no intermediate `read` needed
-- For structural code patterns (function calls, imports, JSX), prefer `ast_search` if available
-
-## Workflow: grep → edit
-
-1. Search: `grep({ pattern: "oldFunction", glob: "*.ts" })`
-2. Review output — each match has a `LINE:HASH` anchor
-3. Use anchors directly: `edit({ path: "file.ts", edits: [{ set_line: { anchor: "45:a3f", new_text: "newFunction();" } }] })`
-
-## Output Format
-
-```
-[3 matches in 2 files]
---- src/server.ts (2 matches) ---
-src/server.ts:>>45:a3f|router.addRoute("/api", handler);
-src/server.ts:  46:b12|router.addRoute("/health", healthCheck);
---- src/client.ts (1 match) ---
-src/client.ts:>>12:c7e|const api = new ApiClient();
-```
-
-Lines with `>>` are matches; lines with `  ` (two spaces) are context lines.
-
-### scope: "symbol" with scopeContext
-
-```
-[2 matches in 1 files]
---- src/server.ts :: function handleRequest (42-180, 2 matches, scoped to ±3 lines) ---
-src/server.ts:  55:a12|  // validate input
-src/server.ts:  56:b34|  if (!req.body) return 400;
-src/server.ts:  57:c56|  // route lookup
-src/server.ts:>>58:d78|  const route = findRoute(req);
-src/server.ts:  59:e9a|  if (!route) return 404;
-src/server.ts:  60:f01|  // auth
-src/server.ts:  61:012|  const user = await authenticate(req);
---
-src/server.ts:  75:234|  // response
-src/server.ts:>>76:456|  const result = await handle(route, user);
-src/server.ts:  77:678|  res.json(result);
-```
-
-With `scopeContext: 0`, only match lines are shown under the header:
-
-```
---- src/server.ts :: function handleRequest (42-180, 2 matches, scoped to ±0 lines) ---
-src/server.ts:>>58:d78|  const route = findRoute(req);
-src/server.ts:>>76:456|  const result = await handle(route, user);
-```
+Use `grep` for text search. For structural code patterns such as calls, imports, or JSX, prefer `ast_search`.

--- a/prompts/ls.md
+++ b/prompts/ls.md
@@ -1,20 +1,11 @@
-List directory contents. Shows directories first (with `/` suffix), then files, sorted alphabetically. Always includes dotfiles. Returns structured metadata for programmatic use.
+List one directory. Shows directories first with `/`, then files, sorted alphabetically; dotfiles are included.
 
 ## Parameters
 
-- `path` — Directory to list (default: current directory)
-- `limit` — Maximum entries to return (default: 500)
-- `glob` — Filter entries by glob pattern, e.g. `'*.ts'` or `'.env*'`
+- `path` — directory to list, default cwd.
+- `limit` — max entries, default 500; must be positive.
+- `glob` — optional entry-name filter such as `*.ts` or `.env*`.
 
-## Output
+## Usage
 
-One entry per line. Directories appear first with a trailing `/` suffix. Files follow, sorted alphabetically (case-insensitive). Hidden files (dotfiles) are always included.
-
-When the entry count exceeds `limit`, a truncation notice is appended. Output is also bounded at 50 KB.
-
-## Usage Guidance
-
-- Use `ls` to inspect a single directory's structure
-- Use `glob` to narrow results without switching to `find` (e.g. `glob: "*.ts"`)
-- Use `find` instead for recursive file discovery across multiple directories
-- Use `read` to inspect file contents — `ls` only shows names
+Output is one entry per line. Use `ls` to inspect a single directory, `find` for recursive discovery, and `read` for file contents. If output exceeds `limit` or 50 KB, it says so.

--- a/prompts/nu.md
+++ b/prompts/nu.md
@@ -1,15 +1,18 @@
-Explore files, structured data (JSON/CSV/TOML/YAML), and system state using Nushell pipelines. Returns structured output ideal for inspection and analysis. Use for exploration and investigation — for running project commands, build tools, scripts, or git operations, use `bash` instead.
+Explore files, structured data, and system state with Nushell pipelines. Use `nu` for inspection and data wrangling; use `bash` for tests, builds, git, package managers, and project commands.
 
-## Default prompt surface (Tier 1)
+## Parameters
 
-The default `nu` prompt loads three compact blocks:
+- `command` — Nushell script; may be multi-line.
+- `timeout` — max seconds, default 30.
 
-1. **Routing table** — when to pick `nu` vs `bash`.
-2. **Primer** — one-line syntax and example cheatsheet covering `ls | where ... | first`, `open package.json | get scripts`, and `http get URL | get results`, plus the key operators (`where`, `sort-by`, `first`, `length`, `math sum`, `group-by`).
-3. **Plugin pointer** — lists optional plugins (`gstat`, `query`, `formats`, `semver`, `file`) and tells the agent to run `plugin list` inside nu to check what is installed.
+## Good uses
 
-## On-demand hints (Tier 2)
+Use `nu` when structured output helps: JSON/CSV/TOML/YAML inspection, filesystem summaries, filtering/sorting/grouping, API response exploration, or system checks.
 
-Plugin-specific recipes are no longer loaded every turn. When a `nu` invocation fails (non-zero exit or timeout) and the output contains a known needle such as `command not found: gstat`, an install/usage hint is appended to the returned text as a line prefixed with `[nu-hint] …`. Agents can rely on that marker to distinguish tooling-appended guidance from `nu`'s own output.
+Examples: `open package.json | get scripts`, `ls | where size > 10kb | first 5`, `open data.csv | group-by status`, `http get URL | get results`.
 
-Hints are defined in `src/nu.ts` as `NU_ERROR_HINTS` and applied by `augmentNuOutput` inside `execute`. The prompt surfaces (`NU_GUIDELINES`, `NU_DESC`, `NU_SNIPPET`) never contain hint text.
+## Notes
+
+Nushell syntax is not POSIX shell syntax. Quote strings in filters, use pipelines like `where`, `sort-by`, `first`, `length`, `math sum`, and `group-by`, and check plugins with `plugin list` when needed.
+
+Output is stripped/truncated to 2000 lines or 50 KB. On failure, tool-added hints appear as `[nu-hint] ...` lines.

--- a/prompts/read.md
+++ b/prompts/read.md
@@ -1,61 +1,33 @@
-Read a file. For text files, each line is prefixed with `LINE:HASH|` (e.g., `12:abc|content`). Use these references as anchors for the `edit` tool.
-Images (`jpg`, `png`, `gif`, `webp`) are delegated to the built-in image reader and returned as image attachments.
+Read text files with `LINE:HASH|content` anchors usable by `edit`. Default cap: {{DEFAULT_MAX_LINES}} lines or {{DEFAULT_MAX_BYTES}}. Images return attachments, not edit anchors.
 
-Default limit: {{DEFAULT_MAX_LINES}} lines or {{DEFAULT_MAX_BYTES}}.
+## Parameters
 
-When a file is truncated (exceeds {{DEFAULT_MAX_LINES}} lines or {{DEFAULT_MAX_BYTES}}), a **structural map** is appended after the hashlined content showing file symbols (classes, functions, interfaces, etc.) with line ranges.
+- `offset` / `limit` — positive line numbers for targeted reads; `offset` is 1-indexed.
+- `map: true` — append a full-file structural map even for small files. May combine with `offset` / `limit`; cannot combine with `symbol` or `bundle`.
+- `symbol: "Name"` — read one symbol range by name, with hash anchors. Supports `ClassName.method`, Java package-relative names, and `Name@<line>` disambiguation. Cannot combine with `offset` / `limit`.
+- `bundle: "local"` — with `symbol`, also include direct same-file local support when available. Cannot combine with `map`.
 
-Use the appended map for targeted reads with `offset` and `limit` — e.g., `read(path, { offset: LINE, limit: N })`.
-When provided, `offset` and `limit` must be positive integers; `0` and negative values are invalid.
+When a full-file read is truncated, a structural map is appended automatically when available. Use that map's line ranges for follow-up `read({ offset, limit })`. Structural maps support many common code/data formats and may fall back to ctags/heuristics.
 
-Maps support 18 mapped language/file kinds — including TypeScript, JavaScript, Python, Rust, Go, Java, C, C headers, C++, Swift, Shell, Clojure, SQL, JSON, JSONL, Markdown, YAML, TOML, and CSV/TSV — and use in-memory caching with optional persistent caching across sessions.
+## Symbol examples
 
-## Map Parameter
+| Query | Reads |
+|---|---|
+| `{ "symbol": "processEvent" }` | function or top-level symbol |
+| `{ "symbol": "EventEmitter" }` | class/interface/type/enum/etc. |
+| `{ "symbol": "EventEmitter.emit" }` | child method/member |
+| `{ "symbol": "Foo.bar@42" }` | specific overload/definition near line 42 |
+| `{ "symbol": "handleRequest", "bundle": "local" }` | symbol plus direct local support |
 
-Use the `map` parameter to request a structural map alongside the file content:
+## Symbol resolution
 
-- `read(path, { map: true })` — appends the structural map after hashlined content, even for small files
-- `read(path, { map: true, offset: 50, limit: 20 })` — scoped hashlines with full-file map
+`@<line>` only applies as a trailing suffix like `Foo.bar@42`; names such as `foo@bar` are ordinary queries. Resolution order: containing range → nearest symbol starting at/after the requested line → nearest symbol above it. If unresolved but same-name candidates exist, the response lists retry hints like `name@<startLine>`.
 
-**Mutual exclusivity:** `map` cannot be combined with `symbol`. Use one or the other.
+Result behavior:
+- **Found**: returns only the symbol range with `[Symbol: name (kind), lines X-Y of Z]`.
+- **Ambiguous**: returns candidate names/kinds/ranges; retry with dot notation or `@<line>`.
+- **Fuzzy**: returns the best camelCase/substring match with a warning banner and confirmation hint. Verify before editing from fuzzy-match anchors.
+- **Not found**: falls back to normal read with a warning listing available symbols.
+- **Unmappable**: falls back to normal read with a warning.
 
-When `map` is not specified, structural maps are only appended automatically when a file exceeds the truncation threshold.
-
-## Symbol Parameter
-
-Use the `symbol` parameter to read a specific symbol by name — no line numbers needed:
-
-- `read(path, { symbol: "functionName" })` — reads just that function
-- `read(path, { symbol: "ClassName.methodName" })` — reads a method inside a class (dot notation)
-
-**Examples by symbol type:**
-
-| Type | Example | What it reads |
-|------|---------|---------------|
-| Function | `{ symbol: "processEvent" }` | The full function body |
-| Class | `{ symbol: "EventEmitter" }` | The entire class declaration |
-| Method | `{ symbol: "EventEmitter.emit" }` | A single method within a class |
-| Interface | `{ symbol: "RequestOptions" }` | The full interface declaration |
-| Type alias | `{ symbol: "EventHandler" }` | The type alias definition |
-| Const/variable | `{ symbol: "DEFAULT_TIMEOUT" }` | The const/let/var declaration |
-| Enum | `{ symbol: "LogLevel" }` | The full enum declaration |
-
-**Mutual exclusivity:** `symbol` cannot be combined with `offset` or `limit`. Use one addressing mode or the other.
-
-**`@line` disambiguation:** append `@<digits>` to a symbol query to pick a specific overload or definition by line number, e.g. `read(path, { symbol: "Foo.bar@42" })`. The `@<digits>` suffix only matches at end-of-string — ordinary names like `@Override`, `foo@bar`, or `foo@1bar` are treated as plain names, not `@line` queries. Resolution order:
-
-1. **Containing range** — a candidate whose `[startLine, endLine]` contains the requested line.
-2. **Nearest at-or-below** — the candidate with the smallest `startLine >= line`.
-3. **Nearest above** — the candidate with the largest `startLine < line`.
-
-When `@line` cannot be resolved but other declarations of the same leaf name exist in the file, the not-found message lists candidate `name@<startLine>` references so you can retry with a precise line.
-
-**Behavior by result:**
-
-- **Found (exact / case-insensitive / prefix):** Returns hashlined content for the symbol's line range only, prepended with `[Symbol: name (kind), lines X-Y of Z]`. Silent — no banner.
-- **Ambiguous (multiple matches):** Returns a disambiguation list with each candidate's name, kind, and line range. Use dot notation (e.g., `ClassName.methodName`) to narrow the match.
-- **Fuzzy (low-confidence match):** Returns the best match's content prefixed with a `[Symbol '<query>' not exact-matched ...]` banner that names the matched symbol, the match tier (`camelCase word boundary` or `substring`), up to 4 other candidates, and a `read({ symbol: "..." })` / `name@line` confirmation hint. Content is still returned so no extra round-trip is required when the guess is right, but the banner is a required signal that the match was approximate — re-verify before editing based on it.
-- **Not found:** Falls back to a normal read with a warning listing up to 20 available symbol names.
-- **Unmappable file:** Falls back to a normal read with a warning noting the file type doesn't support symbol lookup.
-
-Hash anchors from symbol reads are valid for use with the `edit` tool.
+Hash anchors from symbol and bundled reads are valid for `edit`.

--- a/prompts/sg.md
+++ b/prompts/sg.md
@@ -1,39 +1,25 @@
-AST-aware structural code search. Use this when grep is too brittle and you need to match code shape rather than raw text. Prefer over grep for finding function calls, imports, JSX elements, or syntax patterns. Returns anchored matches suitable for edit.
+AST-aware structural code search. Use when text search is too broad or brittle and you need code shape, such as calls, imports, declarations, or JSX. Returns matches grouped by file with edit-ready hashline anchors.
 
-Use for AST-aware code pattern search when text search is too brittle.
+## Parameters
 
-## Pattern Syntax (metavariables)
+- `pattern` — ast-grep pattern to match.
+- `lang` — language hint such as `typescript`, `tsx`, `javascript`, `jsx`, `rust`, or `python`; set it when syntax is ambiguous.
+- `path` — file or directory, default cwd.
 
-- `$NAME` — matches a single AST node
-- `$$$ARGS` — matches zero or more nodes (variadic)
-- `$_` — wildcard (matches any single node)
+## Pattern syntax
 
-## Common Patterns
+- `$NAME` matches one AST node.
+- `$_` matches any one node.
+- `$$$ARGS` matches zero or more nodes; use `$$$` for variable-length args, body statements, object fields, JSX children, etc.
 
-- `console.log($$$ARGS)` — all console.log calls
-- `export function $NAME($$$PARAMS) { $$$BODY }` — exported function declarations
-- `$OBJ.$METHOD($$$ARGS)` — method calls
-- `import $NAME from '$SOURCE'` — default imports
-- `class $NAME { $$$BODY }` — class declarations
-- `if ($COND) { $$$BODY }` — if statements (no else)
-- `try { $$$BODY } catch ($ERR) { $$$HANDLER }` — try-catch blocks
-- `const $NAME = ($$$PARAMS) => $BODY` — arrow function assignments
-- `const $NAME = ($$$PARAMS) => { $$$BODY }` — arrow functions with block body
-- `<$TAG $$$ATTRS>$$$CHILDREN</$TAG>` — JSX elements (React/TSX)
-- `async function $NAME($$$PARAMS) { $$$BODY }` — async function declarations
+## Examples
 
-## Workflow: search → edit
+- `console.log($$$ARGS)` — calls.
+- `import $NAME from '$SOURCE'` — default imports.
+- `export function $NAME($$$PARAMS) { $$$BODY }` — exported functions.
+- `$OBJ.$METHOD($$$ARGS)` — method calls.
+- `<$TAG $$$ATTRS>$$$CHILDREN</$TAG>` — JSX/TSX elements.
 
-1. Run `ast_search({ pattern: "console.log($$$ARGS)" })`
-2. Review output grouped by file (`--- path ---`) with anchors (`>>LINE:HASH|...`)
-3. Use anchors directly with `edit({ path: "file.ts", edits: [{ set_line: { anchor: "42:ab", new_text: "..." } }] })`
+## Tips
 
-## Tips & Common Pitfalls
-
-1. **Whitespace is mostly ignored** — `function $NAME ($$$P)` and `function $NAME($$$P)` match the same AST nodes. Don't try to match exact formatting.
-2. **Semicolons matter for statements** — In languages that use semicolons (TypeScript, JavaScript, Java, C), patterns like `const x = 1` won't match `const x = 1;`. Include the semicolon: `const $NAME = $VALUE;`.
-3. **Use `$$$` for optional/variable-length parts** — `$$$ARGS` matches zero or more arguments. Use it when you don't know how many children a node has (function args, array elements, object properties).
-4. **Language-specific syntax** — Patterns are parsed as the target language's AST. A TypeScript pattern with type annotations (e.g., `function $NAME($P: $T)`) won't match JavaScript files. Use the `lang` parameter to be explicit.
-5. **Blocks vs expressions** — `($$$PARAMS) => $BODY` matches single-expression arrow functions, while `($$$PARAMS) => { $$$BODY }` matches block-body arrows. They're different AST node types.
-6. **Decorators and attributes** — Decorators (`@decorator`) are separate AST nodes. To match a decorated class, use `@$DEC class $NAME { $$$BODY }`. Without it, plain `class $NAME { $$$BODY }` still matches decorated classes in some parsers.
-7. **JSX requires TSX/JSX language** — When searching for JSX patterns like `<Component $$$PROPS />`, use `lang: "tsx"` or `lang: "jsx"`. Plain `typescript` or `javascript` parsers won't recognize JSX syntax.
+Patterns are parsed as code, not text: formatting is mostly ignored, but syntax must be valid for `lang`. Include semicolons in languages that require them. Use `grep` for plain text and `ast_search` for structure.

--- a/prompts/write.md
+++ b/prompts/write.md
@@ -1,38 +1,17 @@
-Write content to a file. Creates the file if it does not exist, overwrites it if it does. Automatically creates parent directories. Returns hashlined content with `LINE:HASH` anchors for immediate use with `edit`.
+Write full file content. Creates new files and parent directories, overwrites existing files, and returns `LINE:HASH` anchors for immediate `edit` use.
 
-## When to use
-- Creating a new file
-- Replacing an entire file when a sequence of `edit` operations would be more awkward than a full rewrite
+## Use / avoid
 
-## When NOT to use
-- Small changes to an existing file — use `edit`
-- Appending to a file — `read` first, then `edit` with `insert_after`
-- Binary content workflows — `write` still writes the content, but binary-looking output gets no hashlines, so there are no anchors to feed into `edit`
+Use `write` to create a file or intentionally replace a whole file. For small changes or appends, `read` first and use `edit` (`insert_after` for appends).
 
-## Output
-Successful writes return the file contents in `LINE:HASH|content` format. Those anchors can be used directly in a follow-up `edit` call.
-Display hashlines escape control characters for safe rendering.
-
-## Truncation
-Display output is capped at 2000 lines or 50 KB. When the text view is capped, `write` says so explicitly and tells you that full anchors remain available in `ptcValue`.
-
-## Examples
-```text
-write({ path: "src/new-module.ts", content: "export function hello() {\n  return 'world';\n}\n" })
-```
-
-```text
-write({ path: "README.md", content: "# Project\n", map: true })
-```
+Existing files are overwritten without confirmation. Binary-looking content is written, but hashlines are not generated, so there are no anchors to feed into `edit`.
 
 ## Parameters
-- `path` — relative or absolute file path
-- `content` — full file contents to write
-- `map` — optional; append a structural map to the visible output
-- map append is best-effort; if structural map generation fails, the write still succeeds
 
-## Notes
-- Parent directories are created automatically.
-- Existing files are overwritten without confirmation.
-- There is no append mode; use `read` + `edit` for append-style updates.
-- Anchors returned from `write` are valid anchor sources for `edit` in the same session.
+- `path` — relative or absolute file path.
+- `content` — complete file contents.
+- `map` — optional; append a structural map when possible. Map append is best-effort and write still succeeds if map generation fails.
+
+## Output
+
+Successful text writes return `LINE:HASH|content`; display hashlines escape control characters for safe rendering. Visible output is capped at 2000 lines or 50 KB, but full anchors remain available in `ptcValue`.

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -1,7 +1,7 @@
 import { renderDiff, type ExtensionAPI, type EditToolDetails, type ToolRenderResultOptions } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import type { Static } from "@sinclair/typebox";
-import { readFileSync } from "fs";
+import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 import { readFile as fsReadFile, writeFile as fsWriteFile } from "fs/promises";
 import { detectLineEnding, generateCompactOrFullDiff, normalizeToLF, replaceText, restoreLineEndings, stripBom } from "./edit-diff";
 import { HashlineMismatchError, applyHashlineEdits, computeLineHash, ensureHashInit, parseLineRef, type HashlineEditItem, escapeControlCharsForDisplay } from "./hashline";
@@ -58,7 +58,15 @@ const hashlineEditSchema = Type.Object(
 
 type HashlineParams = Static<typeof hashlineEditSchema>;
 
-const EDIT_DESC = readFileSync(new URL("../prompts/edit.md", import.meta.url), "utf-8").trim();
+const EDIT_PROMPT_METADATA = defineToolPromptMetadata({
+	promptUrl: new URL("../prompts/edit.md", import.meta.url),
+	promptSnippet: "Edit files using hash-verified anchors from read/grep/ast_search/write",
+	promptGuidelines: [
+		"Use edit for changes to existing files; read or search first and copy fresh LINE:HASH anchors.",
+		"Prefer edit anchored set_line, replace_lines, and insert_after over shell rewrites.",
+		"Use edit replace only when anchored edits are impractical.",
+	],
+});
 
 function buildEditError(
 	path: string,
@@ -106,7 +114,9 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 	const tool = {
 		name: "edit",
 		label: "Edit",
-		description: EDIT_DESC,
+		description: EDIT_PROMPT_METADATA.description,
+		promptSnippet: EDIT_PROMPT_METADATA.promptSnippet,
+		promptGuidelines: EDIT_PROMPT_METADATA.promptGuidelines,
 		parameters: hashlineEditSchema,
 		ptc,
 		renderShell: "default" as const,

--- a/src/find.ts
+++ b/src/find.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
-import { readFileSync } from "node:fs";
+import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 import { readdir, readFile, stat } from "node:fs/promises";
 import { execFileSync, execFile } from "node:child_process";
 import { resolve, relative, join } from "node:path";
@@ -13,8 +13,15 @@ import { coerceObviousBase10Int } from "./coerce-obvious-int.js";
 
 const MAX_BYTES = 50 * 1024; // 50 KB
 const DEFAULT_LIMIT = 1000;
-const FIND_PROMPT = readFileSync(new URL("../prompts/find.md", import.meta.url), "utf-8").trim();
-const FIND_DESC = FIND_PROMPT.split(/\n\s*\n/, 1)[0]?.trim() ?? FIND_PROMPT;
+const FIND_PROMPT_METADATA = defineToolPromptMetadata({
+  promptUrl: new URL("../prompts/find.md", import.meta.url),
+  promptSnippet: "Find files recursively by name, respecting gitignore",
+  promptGuidelines: [
+    "Use find for recursive file-name discovery; use ls for one directory.",
+    "Use find path plus basename pattern rather than shell find commands.",
+    "Use find filters and sorting before limit for newest/largest file queries.",
+  ],
+});
 
 export const FIND_PTC = {
   callable: true,
@@ -289,7 +296,9 @@ export function registerFindTool(pi: ExtensionAPI) {
   const tool: Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof FIND_PTC } = {
     name: "find",
     label: "find",
-    description: FIND_DESC,
+    description: FIND_PROMPT_METADATA.description,
+    promptSnippet: FIND_PROMPT_METADATA.promptSnippet,
+    promptGuidelines: FIND_PROMPT_METADATA.promptGuidelines,
     ptc: FIND_PTC,
     parameters: Type.Object(
       {

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -3,7 +3,7 @@ import { createGrepTool } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { readFile as fsReadFile, stat as fsStat } from "fs/promises";
 import path from "path";
-import { readFileSync } from "node:fs";
+import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 import { normalizeToLF, stripBom, hasBareCarriageReturn } from "./edit-diff";
 import { looksLikeBinary } from "./binary-detect";
 import { ensureHashInit, formatHashlineDisplay, escapeControlCharsForDisplay } from "./hashline";
@@ -18,8 +18,15 @@ import { Text } from "@mariozechner/pi-tui";
 import { formatGrepCallText, formatGrepResultText } from "./grep-render-helpers.js";
 import { coerceObviousBase10Int } from "./coerce-obvious-int.js";
 
-const GREP_PROMPT = readFileSync(new URL("../prompts/grep.md", import.meta.url), "utf-8").trim();
-const GREP_DESC = GREP_PROMPT.split(/\n\s*\n/, 1)[0]?.trim() ?? GREP_PROMPT;
+const GREP_PROMPT_METADATA = defineToolPromptMetadata({
+	promptUrl: new URL("../prompts/grep.md", import.meta.url),
+	promptSnippet: "Search file contents and return edit-ready hashline anchors",
+	promptGuidelines: [
+		"Use grep for text search across files instead of bash grep or rg.",
+		"Use grep summary mode when you only need matching files or counts.",
+		"Use ast_search instead of grep when the query depends on code structure.",
+	],
+});
 
 const grepSchema = Type.Object({
 	pattern: Type.String({ description: "Search pattern (regex or literal string)" }),
@@ -294,10 +301,13 @@ export function registerGrepTool(pi: ExtensionAPI, options: GrepToolOptions = {}
 	const tool = {
 		name: "grep",
 		label: "grep",
-		description: GREP_DESC,
+		description: GREP_PROMPT_METADATA.description,
 		parameters: grepSchema,
 		ptc,
-		promptGuidelines: options.astSearchGuideline ? [options.astSearchGuideline] : undefined,
+		promptSnippet: GREP_PROMPT_METADATA.promptSnippet,
+		promptGuidelines: options.astSearchGuideline
+			? [...GREP_PROMPT_METADATA.promptGuidelines, options.astSearchGuideline]
+			: GREP_PROMPT_METADATA.promptGuidelines,
 		async execute(toolCallId, params, signal, onUpdate, ctx) {
 			await ensureHashInit();
 			const rawParams = params as GrepParams;

--- a/src/ls.ts
+++ b/src/ls.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
-import { readFileSync } from "node:fs";
+import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 import { readdir, stat } from "node:fs/promises";
 import { resolveToCwd } from "./path-utils.js";
 import { buildPtcError } from "./ptc-value.js";
@@ -10,8 +10,15 @@ import { coerceObviousBase10Int } from "./coerce-obvious-int.js";
 const MAX_BYTES = 50 * 1024; // 50 KB
 const DEFAULT_LIMIT = 500;
 
-const LS_PROMPT = readFileSync(new URL("../prompts/ls.md", import.meta.url), "utf-8").trim();
-const LS_DESC = LS_PROMPT.split(/\n\s*\n/, 1)[0]?.trim() ?? LS_PROMPT;
+const LS_PROMPT_METADATA = defineToolPromptMetadata({
+  promptUrl: new URL("../prompts/ls.md", import.meta.url),
+  promptSnippet: "List one directory with directories first and dotfiles included",
+  promptGuidelines: [
+    "Use ls to inspect one directory; use find for recursive discovery.",
+    "Use ls glob to narrow a single-directory listing.",
+    "Use read, not ls, for file contents.",
+  ],
+});
 
 export const LS_PTC = {
   callable: true,
@@ -95,7 +102,9 @@ export function registerLsTool(pi: ExtensionAPI) {
   const tool: Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof LS_PTC } = {
     name: "ls",
     label: "ls",
-    description: LS_DESC,
+    description: LS_PROMPT_METADATA.description,
+    promptSnippet: LS_PROMPT_METADATA.promptSnippet,
+    promptGuidelines: LS_PROMPT_METADATA.promptGuidelines,
     ptc: LS_PTC,
     parameters: Type.Object({
       path: Type.Optional(Type.String({ description: "Directory to list (default: cwd)" })),

--- a/src/nu.ts
+++ b/src/nu.ts
@@ -2,12 +2,13 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { execFileSync, spawn } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { existsSync, writeFileSync, unlinkSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 import { buildPtcError } from "./ptc-value.js";
 import { stripAnsi } from "./rtk/ansi.js";
+import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 
 const MAX_LINES = 2000;
 const MAX_BYTES = 50 * 1024; // 50 KB
@@ -248,9 +249,6 @@ export function augmentNuOutput(result: NuExecuteResult): string {
 // Prompt & registration
 // ---------------------------------------------------------------------------
 
-const NU_PROMPT = readFileSync(new URL("../prompts/nu.md", import.meta.url), "utf-8").trim();
-const NU_DESC = NU_PROMPT.split(/\n\s*\n/, 1)[0]?.trim() ?? NU_PROMPT;
-
 const NU_SNIPPET =
   "Structured exploration shell — file inspection, data wrangling, system queries via Nushell pipelines. Use bash for project commands.";
 
@@ -269,10 +267,16 @@ export const NU_GUIDELINES: string[] = [
 | Build Docker image | bash |
 | Explore an API response | nu |
 | Run a Makefile target | bash |`,
-  `Primer: ls | where size > 10kb | first 5 · open package.json | get scripts · http get URL | get results · where / sort-by / first / length / math sum / group-by · strings in filters must be quoted.`,
+  `nu primer: ls | where size > 10kb | first 5 · open package.json | get scripts · http get URL | get results · where / sort-by / first / length / math sum / group-by · strings in filters must be quoted.`,
 
   `Optional plugins if installed: gstat, query, formats, semver, file. Run \`plugin list\` inside nu to check availability.`,
 ];
+
+const NU_PROMPT_METADATA = defineToolPromptMetadata({
+  promptUrl: new URL("../prompts/nu.md", import.meta.url),
+  promptSnippet: NU_SNIPPET,
+  promptGuidelines: NU_GUIDELINES,
+});
 
 export const NU_PTC = {
   callable: true,
@@ -295,9 +299,9 @@ export function registerNuTool(pi: ExtensionAPI): NuToolDefinition | false {
   const tool = {
     name: "nu",
     label: "nushell",
-    description: NU_DESC,
-    promptSnippet: NU_SNIPPET,
-    promptGuidelines: NU_GUIDELINES,
+    description: NU_PROMPT_METADATA.description,
+    promptSnippet: NU_PROMPT_METADATA.promptSnippet,
+    promptGuidelines: NU_PROMPT_METADATA.promptGuidelines,
     ptc: NU_PTC,
     parameters: Type.Object({
       command: Type.String({ description: "Nushell script to run. May be multi-line." }),

--- a/src/read.ts
+++ b/src/read.ts
@@ -7,7 +7,7 @@ import {
 	DEFAULT_MAX_LINES,
 } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
-import { readFileSync } from "fs";
+import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 import { readFile as fsReadFile } from "fs/promises";
 import { normalizeToLF, stripBom, hasBareCarriageReturn } from "./edit-diff";
 import { ensureHashInit, formatHashlineDisplay } from "./hashline";
@@ -26,10 +26,15 @@ import { coerceObviousBase10Int } from "./coerce-obvious-int.js";
 import { Text } from "@mariozechner/pi-tui";
 import { formatReadCallText, formatReadResultText } from "./read-render-helpers.js";
 
-const READ_DESC = readFileSync(new URL("../prompts/read.md", import.meta.url), "utf-8")
-	.replaceAll("{{DEFAULT_MAX_LINES}}", String(DEFAULT_MAX_LINES))
-	.replaceAll("{{DEFAULT_MAX_BYTES}}", formatSize(DEFAULT_MAX_BYTES))
-	.trim();
+const READ_PROMPT_METADATA = defineToolPromptMetadata({
+	promptUrl: new URL("../prompts/read.md", import.meta.url),
+	promptSnippet: "Read files with hashline anchors and optional maps/symbol lookup",
+	promptGuidelines: [
+		"Use read instead of bash cat/head/tail/sed for file inspection.",
+		"Use read offset/limit, symbol, or map to keep large files focused.",
+		"Use read anchors as fresh inputs for edit.",
+	],
+});
 
 interface ReadParams {
 	path: string;
@@ -57,7 +62,9 @@ export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}
 	const tool = {
 		name: "read",
 		label: "Read",
-		description: READ_DESC,
+		description: READ_PROMPT_METADATA.description,
+		promptSnippet: READ_PROMPT_METADATA.promptSnippet,
+		promptGuidelines: READ_PROMPT_METADATA.promptGuidelines,
 		parameters: Type.Object({
 			path: Type.String({ description: "Path to the file to read (relative or absolute)" }),
 			offset: Type.Optional(

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -4,7 +4,7 @@ import { Type } from "@sinclair/typebox";
 import * as cp from "node:child_process";
 import path from "node:path";
 import { readFile as fsReadFile, stat as fsStat } from "node:fs/promises";
-import { readFileSync } from "node:fs";
+import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 import { normalizeToLF, stripBom } from "./edit-diff.js";
 import { ensureHashInit } from "./hashline.js";
 import { buildPtcError, buildPtcLine } from "./ptc-value.js";
@@ -85,8 +85,15 @@ export async function findEnclosingSgSymbols(absPath: string, ranges: SgRange[])
   return found;
 }
 
-const SG_PROMPT = readFileSync(new URL("../prompts/sg.md", import.meta.url), "utf-8").trim();
-const SG_DESC = SG_PROMPT.split(/\n\s*\n/, 1)[0]?.trim() ?? SG_PROMPT;
+const SG_PROMPT_METADATA = defineToolPromptMetadata({
+  promptUrl: new URL("../prompts/sg.md", import.meta.url),
+  promptSnippet: "Search code structurally with ast-grep and return edit-ready anchors",
+  promptGuidelines: [
+    "Use ast_search when text search is too broad or brittle and the query depends on code shape.",
+    "Use ast_search for calls, imports, declarations, JSX, and similar syntax patterns.",
+    "Use grep instead of ast_search for plain text search.",
+  ],
+});
 
 function execFileText(
   cmd: string,
@@ -140,7 +147,9 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
   const tool = {
     name: "ast_search",
     label: "AST Search",
-    description: SG_DESC,
+    description: SG_PROMPT_METADATA.description,
+    promptSnippet: SG_PROMPT_METADATA.promptSnippet,
+    promptGuidelines: SG_PROMPT_METADATA.promptGuidelines,
     parameters: Type.Object({
       pattern: Type.String({ description: "AST pattern to search for" }),
       lang: Type.Optional(Type.String({ description: "Language hint for ast-grep (e.g. 'typescript')" })),

--- a/src/tool-prompt-metadata.ts
+++ b/src/tool-prompt-metadata.ts
@@ -1,0 +1,32 @@
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@mariozechner/pi-coding-agent";
+import { readFileSync } from "node:fs";
+
+export interface ToolPromptMetadata {
+  description: string;
+  promptSnippet: string;
+  promptGuidelines: string[];
+}
+
+export function loadPrompt(promptUrl: URL): string {
+  return readFileSync(promptUrl, "utf-8")
+    .replaceAll("{{DEFAULT_MAX_LINES}}", String(DEFAULT_MAX_LINES))
+    .replaceAll("{{DEFAULT_MAX_BYTES}}", formatSize(DEFAULT_MAX_BYTES))
+    .trim();
+}
+
+export function firstPromptParagraph(prompt: string): string {
+  return prompt.split(/\n\s*\n/, 1)[0]?.trim() ?? prompt;
+}
+
+export function defineToolPromptMetadata(options: {
+  promptUrl: URL;
+  promptSnippet: string;
+  promptGuidelines: string[];
+}): ToolPromptMetadata {
+  const prompt = loadPrompt(options.promptUrl);
+  return {
+    description: firstPromptParagraph(prompt),
+    promptSnippet: options.promptSnippet,
+    promptGuidelines: options.promptGuidelines,
+  };
+}

--- a/src/write.ts
+++ b/src/write.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, relative } from "node:path";
 import { resolveToCwd } from "./path-utils.js";
 import { ensureHashInit, formatHashlineDisplay } from "./hashline.js";
@@ -10,11 +10,19 @@ import { looksLikeBinary } from "./binary-detect.js";
 import { getOrGenerateMap } from "./map-cache.js";
 import { formatFileMapWithBudget } from "./readmap/formatter.js";
 import { buildContextHygieneMetadata, buildFileResource, type ContextHygieneMetadata } from "./context-hygiene.js";
+import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 
 const MAX_LINES = 2000;
 const MAX_BYTES = 50 * 1024;
-const WRITE_PROMPT = readFileSync(new URL("../prompts/write.md", import.meta.url), "utf-8").trim();
-const WRITE_DESC = WRITE_PROMPT.split(/\n\s*\n/, 1)[0]?.trim() ?? WRITE_PROMPT;
+const WRITE_PROMPT_METADATA = defineToolPromptMetadata({
+  promptUrl: new URL("../prompts/write.md", import.meta.url),
+  promptSnippet: "Create or overwrite a complete file and return edit anchors",
+  promptGuidelines: [
+    "Use write to create new files or intentionally replace whole files.",
+    "Use edit instead of write for small changes or appends to existing files.",
+    "Remember write overwrites existing files without confirmation.",
+  ],
+});
 
 export interface WriteResult {
   text: string;
@@ -195,7 +203,9 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
   const tool = {
     name: "write",
     label: "write",
-    description: WRITE_DESC,
+    description: WRITE_PROMPT_METADATA.description,
+    promptSnippet: WRITE_PROMPT_METADATA.promptSnippet,
+    promptGuidelines: WRITE_PROMPT_METADATA.promptGuidelines,
     parameters: Type.Object({
       path: Type.String({ description: "Path to the file to write (relative or absolute)" }),
       content: Type.String({ description: "Content to write to the file" }),

--- a/tests/edit-prompt-coverage.test.ts
+++ b/tests/edit-prompt-coverage.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 describe("prompts/edit.md coverage", () => {
-  it("documents recovery, variants, escape-hatch replace, anchor sources, whitespace warnings, and replace nudges", () => {
+  it("documents recovery, variants, replace safety, anchor sources, and validation warnings", () => {
     const content = readFileSync(resolve("prompts/edit.md"), "utf8");
 
     expect(content).toContain("hash mismatch");
@@ -11,19 +11,21 @@ describe("prompts/edit.md coverage", () => {
     expect(content).toContain("set_line");
     expect(content).toContain("replace_lines");
     expect(content).toContain("insert_after");
+    expect(content).toContain("replace_symbol");
     expect(content).toContain("replace");
     expect(content.toLowerCase()).toContain("escape hatch");
-    expect(content).toContain("Worked examples");
+    expect(content).toContain("exact-only");
+    expect(content).toContain("fuzzy: true");
     expect(content).toContain("read");
     expect(content).toContain("grep");
     expect(content).toContain("ast_search");
     expect(content).toContain("write");
     expect(content).toContain("current session");
-    expect(content).toContain("non-whitespace-intent edit");
-    expect(content).toContain("whitespace-only changes");
-    expect(content).toContain("replace-only batch");
-    expect(content).toContain("anchored variants");
-    expect(content).toContain("file was not read");
-    expect(content.split("\n").length).toBeGreaterThanOrEqual(80);
+    expect(content).toContain("whitespace-only");
+    expect(content).toContain("`replace`-only");
+    expect(content).toContain("anchored edits");
+    expect(content).toContain("file-not-read");
+    expect(content).toContain("syntax-regression");
+    expect(content.split("\n").length).toBeGreaterThanOrEqual(70);
   });
 });

--- a/tests/find.prompt-loading.test.ts
+++ b/tests/find.prompt-loading.test.ts
@@ -23,4 +23,15 @@ describe("find prompt loading", () => {
     const tool = captureTool(registerFindTool);
     expect(tool.description).toBe(firstParagraph(resolve("prompts/find.md")));
   });
+
+  it("documents basename matching, filters, sorting, and limit order", () => {
+    const content = readFileSync(resolve("prompts/find.md"), "utf8");
+
+    expect(content).toContain("regex: true");
+    expect(content).toContain("basename");
+    expect(content).toContain("modified strictly after");
+    expect(content).toContain("Filtering and sorting happen before `limit`");
+    expect(content).toContain("minSize");
+    expect(content).toContain("maxSize");
+  });
 });

--- a/tests/grep-ast-guideline.test.ts
+++ b/tests/grep-ast-guideline.test.ts
@@ -25,15 +25,12 @@ describe("registerGrepTool with astSearchGuideline", () => {
     expect((tool as any).promptGuidelines).toContain(guideline);
   });
 
-  it("does not include ast_search guideline when option is not provided", () => {
+  it("does not include the injected astSearchGuideline when option is not provided", () => {
     const pi = createMockPi();
+    const injected = "Use `ast_search` for structural code patterns.";
     const tool = registerGrepTool(pi);
     const guidelines = (tool as any).promptGuidelines;
-    // Should either be undefined or not contain ast_search text
-    if (guidelines) {
-      for (const g of guidelines) {
-        expect(g).not.toContain("ast_search");
-      }
-    }
+    expect(guidelines).toBeDefined();
+    expect(guidelines).not.toContain(injected);
   });
 });

--- a/tests/grep-prompt.test.ts
+++ b/tests/grep-prompt.test.ts
@@ -42,7 +42,7 @@ describe("prompts/grep.md", () => {
     expect(content).toContain("scope");
     expect(content).toContain("literal");
     expect(content).toContain("Results truncated at");
-    expect(content).toContain("Output truncated:");
+    expect(content).toContain("head-truncate");
   });
 
   it("documents the grep → edit workflow", () => {

--- a/tests/ls.prompt-loading.test.ts
+++ b/tests/ls.prompt-loading.test.ts
@@ -23,4 +23,14 @@ describe("ls prompt loading", () => {
     const tool = captureTool(registerLsTool);
     expect(tool.description).toBe(firstParagraph(resolve("prompts/ls.md")));
   });
+
+  it("documents single-directory output and routing to find/read", () => {
+    const content = readFileSync(resolve("prompts/ls.md"), "utf8");
+
+    expect(content).toContain("List one directory");
+    expect(content).toContain("dotfiles are included");
+    expect(content).toContain("Output is one entry per line");
+    expect(content).toContain("find` for recursive discovery");
+    expect(content).toContain("read` for file contents");
+  });
 });

--- a/tests/nu-prompt.test.ts
+++ b/tests/nu-prompt.test.ts
@@ -13,20 +13,27 @@ describe("prompts/nu.md", () => {
     expect(content).toContain("bash");
   });
 
-  it("mentions exploration and investigation use case", () => {
+  it("mentions structured exploration and data wrangling use cases", () => {
     const content = readFileSync(resolve(__dirname, "../prompts/nu.md"), "utf-8");
-    expect(content).toContain("exploration");
+    expect(content).toContain("data wrangling");
   });
 
-  it("documents Tier 1 + Tier 2 split while keeping a short first paragraph", () => {
+  it("keeps a short first paragraph and documents failure hints", () => {
     const content = readFileSync(resolve(__dirname, "../prompts/nu.md"), "utf-8");
     // First paragraph stays short so NU_DESC (derived from it) does not grow.
     const firstParagraph = content.split(/\n\s*\n/, 1)[0]!.trim();
     expect(firstParagraph.length).toBeGreaterThan(0);
     expect(firstParagraph.length).toBeLessThanOrEqual(400);
-    // Rest of the file documents the Tier 1 / Tier 2 split.
-    expect(content).toMatch(/Tier 1/i);
-    expect(content).toMatch(/Tier 2/i);
+    expect(content).toContain("[nu-hint]");
+    expect(content).toContain("Nushell syntax is not POSIX shell syntax");
+  });
+
+  it("documents bash routing, timeout, truncation, and hint markers", () => {
+    const content = readFileSync(resolve(__dirname, "../prompts/nu.md"), "utf-8");
+
+    expect(content).toContain("tests, builds, git, package managers, and project commands");
+    expect(content).toContain("default 30");
+    expect(content).toContain("2000 lines or 50 KB");
     expect(content).toContain("[nu-hint]");
   });
 });

--- a/tests/prompts-files.test.ts
+++ b/tests/prompts-files.test.ts
@@ -18,18 +18,17 @@ describe("prompts directory (AC15)", () => {
     expect(files.some((f) => f.endsWith(".md"))).toBe(true);
   });
 
-  it("read prompt documents hashlines, truncation map, and image delegation", () => {
+  it("read prompt documents hashlines, truncation maps, image behavior, and symbol bundles", () => {
     const readPrompt = readFileSync(resolve(root, "prompts/read.md"), "utf8");
 
-    expect(readPrompt).toContain("LINE:HASH|");
-    expect(readPrompt).toContain("12:abc|content");
+    expect(readPrompt).toContain("LINE:HASH|content");
     expect(readPrompt).toContain("{{DEFAULT_MAX_LINES}}");
     expect(readPrompt).toContain("{{DEFAULT_MAX_BYTES}}");
     expect(readPrompt).toContain("structural map");
-    expect(readPrompt).toContain("read(path, { offset:");
-    expect(readPrompt).toContain("18 mapped language/file kinds");
-    expect(readPrompt).toContain("persistent caching across sessions");
-    expect(readPrompt).toContain("Images");
+    expect(readPrompt).toContain("read({ offset, limit })");
+    expect(readPrompt).toContain("Images return attachments");
+    expect(readPrompt).toContain("bundle: \"local\"");
+    expect(readPrompt).toContain("Fuzzy");
   });
 
   it("sg prompt exists and documents metavariables, workflow, and the ast_search snippet", () => {
@@ -40,8 +39,8 @@ describe("prompts directory (AC15)", () => {
     expect(content).toContain("$NAME");
     expect(content).toContain("$$$ARGS");
     expect(content).toContain("$_");
-    expect(content).toContain("Use for AST-aware code pattern search when text search is too brittle.");
-    expect(content.toLowerCase()).toContain("workflow");
+    expect(content).toContain("code shape");
+    expect(content.toLowerCase()).toContain("tips");
     expect(content.toLowerCase()).toContain("edit");
   });
 });

--- a/tests/sg.prompt-loading.test.ts
+++ b/tests/sg.prompt-loading.test.ts
@@ -19,12 +19,18 @@ describe("sg prompt loading", () => {
   it("uses the first prompt paragraph as the exact ast_search description", async () => {
     const tool = await getSgTool();
     expect(tool.description).toBe(
-      "AST-aware structural code search. Use this when grep is too brittle and you need to match code shape rather than raw text. Prefer over grep for finding function calls, imports, JSX elements, or syntax patterns. Returns anchored matches suitable for edit.",
+      "AST-aware structural code search. Use when text search is too broad or brittle and you need code shape, such as calls, imports, declarations, or JSX. Returns matches grouped by file with edit-ready hashline anchors.",
     );
   });
 
-  it("keeps the prompt snippet in prompts/sg.md", () => {
+  it("keeps structural-search contract details in prompts/sg.md", () => {
     const content = readFileSync(resolve(root, "prompts/sg.md"), "utf8");
-    expect(content).toContain("Use for AST-aware code pattern search when text search is too brittle.");
+    expect(content).toContain("code shape");
+    expect(content).toContain("grouped by file");
+    expect(content).toContain("hashline anchors");
+    expect(content).toContain("$NAME");
+    expect(content).toContain("$_");
+    expect(content).toContain("$$$ARGS");
+    expect(content).toContain("parsed as code, not text");
   });
 });

--- a/tests/tool-prompt-metadata.test.ts
+++ b/tests/tool-prompt-metadata.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@mariozechner/pi-coding-agent";
+
+type ToolDefinition = {
+  name: string;
+  description?: unknown;
+  promptSnippet?: unknown;
+  promptGuidelines?: unknown;
+};
+
+function createMockPi() {
+  return {
+    registerTool: vi.fn(),
+    events: { emit: vi.fn(), on: vi.fn() },
+    on: vi.fn(),
+  };
+}
+
+function firstParagraph(promptPath: string): string {
+  return readFileSync(resolve(promptPath), "utf8")
+    .replaceAll("{{DEFAULT_MAX_LINES}}", String(DEFAULT_MAX_LINES))
+    .replaceAll("{{DEFAULT_MAX_BYTES}}", formatSize(DEFAULT_MAX_BYTES))
+    .trim()
+    .split(/\n\s*\n/, 1)[0]
+    ?.trim() ?? "";
+}
+
+function assertPromptMetadata(tool: ToolDefinition, promptPath: string, toolName: string) {
+  expect(tool.description).toBe(firstParagraph(promptPath));
+  expect(tool.description).not.toContain("\n\n");
+
+  expect(typeof tool.promptSnippet).toBe("string");
+  expect((tool.promptSnippet as string).length).toBeGreaterThan(0);
+
+  expect(Array.isArray(tool.promptGuidelines)).toBe(true);
+  const guidelines = tool.promptGuidelines as string[];
+  expect(guidelines.length).toBeGreaterThan(0);
+  for (const guideline of guidelines) {
+    expect(typeof guideline).toBe("string");
+    expect(guideline.length).toBeGreaterThan(0);
+    expect(guideline.toLowerCase()).toContain(toolName.toLowerCase());
+    expect(guideline).not.toMatch(/\bthis tool\b/i);
+  }
+}
+
+describe("stock pi prompt metadata", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("node:child_process");
+  });
+
+  it("exposes snippets, flat guidelines, and first-paragraph descriptions for hashline tools", async () => {
+    const pi = createMockPi();
+
+    const { registerReadTool } = await import("../src/read.js");
+    const { registerEditTool } = await import("../src/edit.js");
+    const { registerGrepTool } = await import("../src/grep.js");
+    const { registerFindTool } = await import("../src/find.js");
+    const { registerLsTool } = await import("../src/ls.js");
+    const { registerWriteTool } = await import("../src/write.js");
+    const { registerSgTool } = await import("../src/sg.js");
+
+    const tools = [
+      { tool: registerReadTool(pi as any), promptPath: "prompts/read.md", toolName: "read" },
+      { tool: registerEditTool(pi as any), promptPath: "prompts/edit.md", toolName: "edit" },
+      { tool: registerGrepTool(pi as any), promptPath: "prompts/grep.md", toolName: "grep" },
+      { tool: registerFindTool(pi as any), promptPath: "prompts/find.md", toolName: "find" },
+      { tool: registerLsTool(pi as any), promptPath: "prompts/ls.md", toolName: "ls" },
+      { tool: registerWriteTool(pi as any), promptPath: "prompts/write.md", toolName: "write" },
+      { tool: registerSgTool(pi as any), promptPath: "prompts/sg.md", toolName: "ast_search" },
+    ];
+
+    for (const { tool, promptPath, toolName } of tools) {
+      assertPromptMetadata(tool, promptPath, toolName);
+    }
+  });
+
+  it("keeps nu metadata consistent with stock pi's flat prompt surface", async () => {
+    vi.doMock("node:child_process", async () => {
+      const actual = await vi.importActual<any>("node:child_process");
+      return {
+        ...actual,
+        execFileSync: vi.fn(() => Buffer.from("0.111.0\n")),
+      };
+    });
+
+    const { registerNuTool } = await import("../src/nu.js");
+    const pi = createMockPi();
+    const tool = registerNuTool(pi as any);
+
+    expect(tool).not.toBe(false);
+    assertPromptMetadata(tool as ToolDefinition, "prompts/nu.md", "nu");
+  });
+});

--- a/tests/write.prompt-loading.test.ts
+++ b/tests/write.prompt-loading.test.ts
@@ -27,11 +27,14 @@ describe("prompt loading — write", () => {
     expect(tool.description).toBe(firstParagraph(promptPath));
   });
 
-  it("documents binary no-anchor behavior, safe display escaping, and best-effort map appends", () => {
+  it("documents overwrite, binary no-anchor behavior, safe display escaping, and best-effort map appends", () => {
     const promptPath = resolve("prompts/write.md");
     const content = readFileSync(promptPath, "utf8");
+    expect(content).toContain("overwrites existing files");
+    expect(content).toContain("Existing files are overwritten without confirmation");
     expect(content).toContain("no anchors to feed into `edit`");
     expect(content).toContain("control characters");
-    expect(content).toContain("map append is best-effort");
+    expect(content).toMatch(/`map` — optional/i);
+    expect(content).toMatch(/map append is best-effort/i);
   });
 });


### PR DESCRIPTION
## Summary

Condenses the tool prompt docs for the hashline tool suite while preserving the operational contracts agents depend on. The goal is to reduce prompt footprint without losing safety-critical guidance around anchored edits, structural search, file discovery, full-file writes, and Nushell routing.

This PR now also updates the extension's stock Pi prompt metadata for every overridden/registered tool. Current Pi docs say built-in tool overrides do **not** inherit built-in `promptSnippet` or `promptGuidelines`, so override tools must define them explicitly if they should participate in Pi's default system prompt. This PR does that for `read`, `edit`, `grep`, `find`, `ls`, `write`, `ast_search`, and `nu`.

Also prepares the package for republish as `0.8.6` and fixes a dependency hygiene issue discovered during review: `find`/`ls` dynamically import `ignore` and `picomatch`, so both are now direct runtime dependencies instead of accidental transitives.

## Prompt-size impact

Across the eight prompt docs, line count drops from **539 → 224 lines**: **315 fewer lines**, about a **58% reduction**.

Diff-level prompt churn: **145 insertions / 460 deletions** under `prompts/`.

Per-prompt line counts:

| Prompt | Before | After | Reduction |
|---|---:|---:|---:|
| `edit.md` | 228 | 75 | 67% |
| `find.md` | 53 | 19 | 64% |
| `grep.md` | 85 | 26 | 69% |
| `ls.md` | 20 | 11 | 45% |
| `nu.md` | 15 | 18 | -20% |
| `read.md` | 61 | 33 | 46% |
| `sg.md` | 39 | 25 | 36% |
| `write.md` | 38 | 17 | 55% |

`nu.md` intentionally grows by three lines because the previous text mostly described internal prompt architecture; the new text is more directly useful at call time.

## Stock Pi system-prompt metadata

Pi's current extension docs define two prompt-facing fields on `pi.registerTool()` definitions:

- `promptSnippet` — one-line entry in the default `Available tools` section
- `promptGuidelines` — flat guideline bullets appended when the tool is active

The docs also warn that `promptGuidelines` are appended without a tool-name prefix, so each bullet must explicitly name the tool instead of saying “this tool”. They also state that built-in overrides do not inherit built-in prompt metadata.

This PR brings the hashline overrides in line with that model:

- Adds concise `promptSnippet` values for:
  - `read`
  - `edit`
  - `grep`
  - `find`
  - `ls`
  - `write`
  - `ast_search`
  - `nu`
- Adds explicit `promptGuidelines` for each tool.
- Ensures every flat guideline names the relevant tool.
- Keeps `grep`'s optional injected ast-grep guidance by appending it after the base grep guidelines.
- Updates the fallback ast-grep-not-installed guideline so it still names `grep` when appended into `grep.promptGuidelines`.
- Normalizes provider-facing `description` fields to the first prompt paragraph, avoiding large markdown blobs in tool schema descriptions.

## Prompt metadata helper

Adds `src/tool-prompt-metadata.ts` to centralize the repeated prompt metadata work:

- loads the markdown prompt file
- replaces shared placeholders like `{{DEFAULT_MAX_LINES}}` and `{{DEFAULT_MAX_BYTES}}`
- extracts the first paragraph for `description`
- returns `{ description, promptSnippet, promptGuidelines }`

Tool-specific snippets and guidelines remain explicit TypeScript constants at each tool registration site. This keeps behavior easy to review and avoids adding frontmatter or a custom markdown parser.

## Model robustness

The condensation was reviewed with less-than-state-of-the-art models in mind. Rather than relying on subtle inference from long examples, the new prompts and metadata keep compact, explicit decision points and danger rails:

- which tool to use (`grep` vs `ast_search`, `ls` vs `find`, `nu` vs `bash`, `write` vs `edit`)
- exact anchor requirements for safe edits
- overwrite/binary/no-anchor warnings for `write`
- basename-vs-path matching for `find`
- filter/sort-before-limit ordering for ranked discovery
- one-directory-only output for `ls`
- Nushell-not-POSIX syntax reminders and `[nu-hint]` markers
- stock Pi `Available tools` snippets for every override tool
- flat Pi guideline bullets that explicitly name their tools

This should reduce token load while making common tool-choice mistakes less likely for smaller or older models.

## Changes

### Prompt condensation

- Rewrites `prompts/read.md`, `prompts/edit.md`, `prompts/grep.md`, `prompts/find.md`, `prompts/ls.md`, `prompts/write.md`, `prompts/sg.md`, and `prompts/nu.md` to be shorter and more tool-call focused.
- Keeps the important contracts explicit:
  - fresh `LINE:HASH` anchors for `edit`
  - `read` symbol/map behavior and truncation follow-ups
  - `grep` anchors and summary mode
  - `find` basename matching, `regex: true`, strict `modifiedSince`, size filters, and filter/sort-before-limit behavior
  - `ls` single-directory behavior and one-entry-per-line output
  - `write` overwrite semantics, binary no-anchor behavior, optional best-effort `map`
  - `ast_search` metavariables, code-not-text parsing, grouped hashline anchors
  - `nu` vs `bash` routing, timeout/truncation, and `[nu-hint]` markers

### Stock Pi prompt metadata

- Adds `promptSnippet` / `promptGuidelines` to the registered tool definitions for the full stock-facing hashline tool set.
- Adds a shared prompt metadata helper to keep first-paragraph description extraction and placeholder replacement consistent.
- Updates `read` and `edit` so `description` is concise first-paragraph text, matching the other tools.
- Keeps the long-form markdown prompt files as docs/contract text rather than provider-facing schema descriptions.

### Tests and dependency hygiene

- Adds/updates prompt contract tests so condensed docs keep the key behavioral sentinels.
- Adds `tests/tool-prompt-metadata.test.ts` to assert:
  - first-paragraph descriptions
  - non-empty `promptSnippet`
  - non-empty `promptGuidelines`
  - every flat guideline explicitly names the relevant tool
  - no vague “this tool” guideline wording
- Updates `tests/grep-ast-guideline.test.ts` for the new base-plus-optional guideline behavior.
- Adds direct runtime dependencies on `ignore` and `picomatch`.
- Updates lockfile through `npm audit fix`; production audit is clean.
- Bumps package version to `0.8.6`.

## Validation

Latest validation after the stock Pi metadata update:

- `npx vitest run tests/tool-prompt-metadata.test.ts tests/grep-ast-guideline.test.ts` — passed
- `npm test` — 275 files / 1304 tests passed
- `npm run typecheck` — passed
- `npm pack --dry-run` — passed for `pi-hashline-readmap@0.8.6`

Earlier validation during the prompt-condensation/dependency update:

- `npm audit --omit=dev` — 0 vulnerabilities

## Notes

A full dev-inclusive `npm audit` still reports a dev-only issue through the local `@mariozechner/pi-coding-agent` dev dependency chain. npm says the fix requires moving to `@mariozechner/pi-coding-agent@0.73.1`, so that broader pi compatibility update is intentionally left for a separate PR.

One follow-up compliance/hardening item discovered while checking current Pi extension docs: mutating custom tools are now recommended to use `withFileMutationQueue()` so parallel tool calls cannot race on the same file. This PR does not change edit/write mutation internals; it only fixes prompt footprint and stock Pi system-prompt metadata. The queue hardening should be handled separately.