### PR TITLE
fix: harden Pi integration — edit/write join file mutation queue + prompt-metadata integration test, v0.8.7 (#160)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -1,4 +1,4 @@
-import { renderDiff, type ExtensionAPI, type EditToolDetails, type ToolRenderResultOptions } from "@mariozechner/pi-coding-agent";
+import { renderDiff, withFileMutationQueue, type ExtensionAPI, type EditToolDetails, type ToolRenderResultOptions } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import type { Static } from "@sinclair/typebox";
 import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
@@ -128,6 +128,8 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			const path = rawPath.replace(/^@/, "");
 			const absolutePath = resolveToCwd(path, ctx.cwd);
 			throwIfAborted(signal);
+			return withFileMutationQueue(absolutePath, async () => {
+				throwIfAborted(signal);
 			if (options.wasReadInSession && !options.wasReadInSession(absolutePath)) {
 				const message = [
 					`You must get fresh anchors for ${absolutePath} before editing it.`,
@@ -535,6 +537,7 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 					};
 				},
 			};
+			});
 		},
 		renderCall(args: any, theme: any, ...rest: any[]) {
 			const context: { argsComplete?: boolean; lastComponent?: any } = rest[0] ?? {};

--- a/src/write.ts
+++ b/src/write.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { withFileMutationQueue, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { mkdirSync, writeFileSync } from "node:fs";
@@ -214,6 +214,7 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
     async execute(_toolCallId: string, params: { path: string; content: string; map?: boolean }, _signal: AbortSignal | undefined, _onUpdate: any, ctx: any): Promise<any> {
       const cwd = ctx?.cwd ?? process.cwd();
       const absolutePath = resolveToCwd(params.path, cwd);
+      return withFileMutationQueue(absolutePath, async () => {
       let result: WriteResult;
       try {
         result = await executeWrite({
@@ -279,6 +280,7 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
           contextHygiene: result.contextHygiene,
         },
       };
+      });
     },
     renderCall(args: any, theme: any) {
       const { path } = args as { path: string };

--- a/tests/helpers/pi-prompt-metadata-harness.ts
+++ b/tests/helpers/pi-prompt-metadata-harness.ts
@@ -1,0 +1,91 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createAgentSession,
+  DefaultResourceLoader,
+  SessionManager,
+  type ToolDefinition,
+} from "@mariozechner/pi-coding-agent";
+import { registerFauxProvider } from "@mariozechner/pi-ai";
+
+type PromptMetadataResult = {
+  systemPrompt: string;
+  snippets: Record<string, string>;
+  guidelinesByTool: Record<string, string[]>;
+  activeToolNames: string[];
+};
+
+function normalizePromptSnippet(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function normalizePromptGuidelines(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+export async function collectHashlineSystemPromptMetadata(activeTools: string[]): Promise<PromptMetadataResult> {
+  const cwd = process.cwd();
+  const agentDir = mkdtempSync(join(tmpdir(), "pi-hashline-prompt-metadata-"));
+  const faux = registerFauxProvider({ models: [{ id: "prompt-metadata-test" }] });
+  let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
+
+  try {
+    const { default: extensionFactory } = await import("../../index.js");
+    const resourceLoader = new DefaultResourceLoader({
+      cwd,
+      agentDir,
+      extensionFactories: [extensionFactory],
+      noSkills: true,
+      noPromptTemplates: true,
+      noThemes: true,
+      noContextFiles: true,
+    });
+    await resourceLoader.reload();
+
+    const created = await createAgentSession({
+      cwd,
+      agentDir,
+      model: faux.getModel(),
+      resourceLoader,
+      sessionManager: SessionManager.inMemory(cwd),
+      tools: activeTools,
+    });
+    session = created.session;
+    session.setActiveToolsByName(activeTools);
+
+    const snippets: Record<string, string> = {};
+    const guidelinesByTool: Record<string, string[]> = {};
+
+    for (const toolName of activeTools) {
+      const definition = session.getToolDefinition(toolName) as (ToolDefinition & {
+        promptSnippet?: unknown;
+        promptGuidelines?: unknown;
+      }) | undefined;
+      if (!definition) throw new Error(`Expected active Pi session to expose tool ${toolName}`);
+
+      const snippet = normalizePromptSnippet(definition.promptSnippet);
+      if (!snippet) throw new Error(`Expected ${toolName} to expose a non-empty promptSnippet`);
+      snippets[toolName] = snippet;
+
+      const guidelines = normalizePromptGuidelines(definition.promptGuidelines);
+      if (guidelines.length === 0) throw new Error(`Expected ${toolName} to expose non-empty promptGuidelines`);
+      guidelinesByTool[toolName] = guidelines;
+    }
+
+    return {
+      systemPrompt: session.systemPrompt,
+      snippets,
+      guidelinesByTool,
+      activeToolNames: session.getActiveToolNames(),
+    };
+  } finally {
+    session?.dispose();
+    faux.unregister();
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+}

--- a/tests/pi-prompt-metadata-integration.test.ts
+++ b/tests/pi-prompt-metadata-integration.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { collectHashlineSystemPromptMetadata } from "./helpers/pi-prompt-metadata-harness.js";
+
+const EXPECTED_TOOLS = ["read", "edit", "grep", "find", "ls", "write", "ast_search", "nu"] as const;
+
+describe("Pi system prompt metadata integration", () => {
+  afterEach(() => {
+    vi.doUnmock("node:child_process");
+    vi.resetModules();
+  });
+
+  it("renders hashline override snippets and flat tool-named guidelines through Pi registration", async () => {
+    vi.doMock("node:child_process", async () => {
+      const actual = await vi.importActual<any>("node:child_process");
+      return {
+        ...actual,
+        execFileSync: vi.fn(() => Buffer.from("0.111.0\n")),
+      };
+    });
+
+    const { systemPrompt, snippets, guidelinesByTool, activeToolNames } = await collectHashlineSystemPromptMetadata([...EXPECTED_TOOLS]);
+    expect(activeToolNames).toEqual([...EXPECTED_TOOLS]);
+
+    for (const toolName of EXPECTED_TOOLS) {
+      const snippet = snippets[toolName];
+      expect(snippet, `${toolName} promptSnippet`).toBeTruthy();
+      expect(snippet).not.toContain("\n");
+      expect(snippet.length, `${toolName} promptSnippet should stay concise`).toBeLessThanOrEqual(140);
+      expect(systemPrompt).toContain(`- ${toolName}: ${snippet}`);
+
+      const guidelines = guidelinesByTool[toolName];
+      expect(guidelines.length, `${toolName} promptGuidelines`).toBeGreaterThan(0);
+      for (const guideline of guidelines) {
+        expect(guideline.toLowerCase(), `${toolName} guideline should name its tool`).toContain(toolName.toLowerCase());
+        expect(guideline, `${toolName} guideline should avoid ambiguous phrasing`).not.toMatch(/\bthis tool\b/i);
+        expect(systemPrompt).toContain(`- ${guideline}`);
+      }
+    }
+  });
+});

--- a/tests/repro-160-mutation-queue.test.ts
+++ b/tests/repro-160-mutation-queue.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("repro 160 — Pi file mutation queue integration", () => {
+  afterEach(() => {
+    vi.doUnmock("fs/promises");
+    vi.resetModules();
+  });
+
+  it("serializes edit's full read-modify-write window for same-file parallel calls", async () => {
+    vi.resetModules();
+
+    const filePath = "/virtual/race.txt";
+    let fileContent = "alpha\nbeta\n";
+
+    vi.doMock("fs/promises", () => ({
+      readFile: vi.fn(async () => {
+        await tick();
+        return Buffer.from(fileContent, "utf-8");
+      }),
+      writeFile: vi.fn(async (_path: string, content: string | Buffer) => {
+        await tick();
+        fileContent = content.toString();
+      }),
+    }));
+
+    const { registerEditTool } = await import("../src/edit.js");
+    let tool: any;
+    registerEditTool(
+      { registerTool(def: any) { tool = def; } } as any,
+      { wasReadInSession: () => true, syntaxValidate: "off" },
+    );
+
+    const resultPromiseA = tool.execute(
+      "edit-alpha",
+      { path: filePath, edits: [{ replace: { old_text: "alpha", new_text: "ALPHA" } }] },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/" },
+    );
+    const resultPromiseB = tool.execute(
+      "edit-beta",
+      { path: filePath, edits: [{ replace: { old_text: "beta", new_text: "BETA" } }] },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/" },
+    );
+
+    const results = await Promise.all([resultPromiseA, resultPromiseB]);
+
+    expect(results.map((result: any) => result.isError ?? false)).toEqual([false, false]);
+    expect(fileContent).toBe("ALPHA\nBETA\n");
+  });
+});

--- a/tests/write-mutation-queue.test.ts
+++ b/tests/write-mutation-queue.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("write Pi file mutation queue integration", () => {
+  afterEach(() => {
+    vi.doUnmock("@mariozechner/pi-coding-agent");
+    vi.doUnmock("node:fs");
+    vi.resetModules();
+  });
+
+  it("wraps write's full mutation window in Pi's file mutation queue", async () => {
+    vi.resetModules();
+    const events: string[] = [];
+    const filePath = "/virtual/write-queue.txt";
+
+    vi.doMock("@mariozechner/pi-coding-agent", async () => {
+      const actual = await vi.importActual<any>("@mariozechner/pi-coding-agent");
+      return {
+        ...actual,
+        withFileMutationQueue: vi.fn(async (queuedPath: string, fn: () => Promise<unknown>) => {
+          events.push(`queue-enter:${queuedPath}`);
+          const result = await fn();
+          events.push(`queue-exit:${queuedPath}`);
+          return result;
+        }),
+      };
+    });
+
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<any>("node:fs");
+      return {
+        ...actual,
+        mkdirSync: vi.fn((dirPath: string) => {
+          events.push(`mkdir:${dirPath}`);
+        }),
+        writeFileSync: vi.fn((targetPath: string, content: string) => {
+          events.push(`write:${targetPath}:${content}`);
+        }),
+      };
+    });
+
+    const { registerWriteTool } = await import("../src/write.js");
+    let tool: any;
+    registerWriteTool({ registerTool(def: any) { tool = def; } } as any);
+
+    const result = await tool.execute(
+      "write-queue",
+      { path: filePath, content: "queued content" },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/" },
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(events[0]).toBe(`queue-enter:${filePath}`);
+    expect(events).toEqual([
+      `queue-enter:${filePath}`,
+      "mkdir:/virtual",
+      `write:${filePath}:queued content`,
+      `queue-exit:${filePath}`,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

The extension's overriding `edit` and `write` tools did not participate in Pi's per-file mutation queue. Two parallel same-file `edit` calls could both read the same pre-mutation content and clobber each other on write — a classic lost-update race. `write` was similarly unqueued and didn't coordinate with same-file `edit` or other built-in tools.

This PR wraps both tools' full mutation windows in `withFileMutationQueue(absolutePath, …)`, adds two focused regression tests for the queue behavior, and adds an end-to-end Pi prompt-metadata integration test that proves override `promptSnippet` / `promptGuidelines` survive the real Pi system-prompt rebuild path.

**Version bump:** `0.8.6` → `0.8.7`

Resolves #160.

---

## Diagnosis

Pi exposes `withFileMutationQueue<T>(filePath: string, fn: () => Promise<T>): Promise<T>` so any mutating tool can serialize its read-modify-write window against other tools on the same file. Pi's built-in `edit` and `write` use it. The hashline extension's overrides did not.

**Lost-update trace for `edit`:**

1. `edit-alpha` enters `src/edit.ts:123` and resolves `absolutePath` at `:129`.
2. `edit-beta` enters before `edit-alpha` writes.
3. Both reach `fsReadFile(absolutePath)` at `src/edit.ts:225` and read the same content `alpha\nbeta\n`.
4. `edit-alpha` computes `ALPHA\nbeta\n`; `edit-beta` computes `alpha\nBETA\n`.
5. Both write at `src/edit.ts:464`. Last write wins → `alpha\nBETA\n` instead of `ALPHA\nBETA\n`.

`write` was structurally similar: `resolveToCwd` → `executeWrite` (`mkdirSync` + `writeFileSync`) with no queue wrap, so it didn't coordinate with same-file `edit` or any other queued mutating tool.

**Secondary gap:** existing prompt-metadata tests only inspected `tool.promptSnippet` / `tool.promptGuidelines` directly. They never crossed Pi's `ExtensionAPI.registerTool` → `_refreshToolRegistry` → `_rebuildSystemPrompt` → `buildSystemPrompt` boundary, so silent Pi drift could drop our override snippets without any test going red.

---

## Changes

### F1 — `edit` participates in Pi's mutation queue

`src/edit.ts` (+4/−1)

- New import: `withFileMutationQueue` from `@mariozechner/pi-coding-agent`.
- After `resolveToCwd(...)` produces `absolutePath` (still outside the queue, matching Pi docs), the entire remaining `execute` body is wrapped in `return withFileMutationQueue(absolutePath, async () => { … });`.
- The closure covers: read-before-edit guard, legacy input normalization, edit-variant validation, `fsReadFile`, BOM / line-ending detection, `replaceSymbol` probe + apply, hashline anchor application, `replace` variants, no-op diagnostic, syntax-regression validation, `fsWriteFile`, diff / semantic-summary generation, and output shaping. Nothing that depends on the read or determines the write sits outside the queue.

### F2 — `write` participates in Pi's mutation queue

`src/write.ts` (+3/−1)

- New import: `withFileMutationQueue` from `@mariozechner/pi-coding-agent`.
- After `resolveToCwd(params.path, cwd)` produces `absolutePath`, the `execute` body is wrapped in `return withFileMutationQueue(absolutePath, async () => { … });`.
- The closure covers `executeWrite()` (parent `mkdirSync` + `writeFileSync`), error mapping, `onFileAnchored?.(absolutePath)`, binary-content envelope handling, and the success-path result builder.
- `executeWrite()`'s public signature is intentionally unchanged. Queueing happens at the Pi tool boundary so direct test callers stay deterministic.

### F3 — End-to-end Pi prompt-metadata integration coverage

New harness `tests/helpers/pi-prompt-metadata-harness.ts` builds a real Pi session via:

| Public API | From |
|------------|------|
| `DefaultResourceLoader` | `@mariozechner/pi-coding-agent` |
| `createAgentSession` | `@mariozechner/pi-coding-agent` |
| `SessionManager.inMemory` | `@mariozechner/pi-coding-agent` |
| `registerFauxProvider` | `@mariozechner/pi-ai` |

It loads the extension exactly how Pi loads it in production, activates the eight overridden tools, and returns the rendered `session.systemPrompt` plus per-tool `promptSnippet` / `promptGuidelines`.

### F4 — Package version

`package.json` / `package-lock.json`: `0.8.6` → `0.8.7`

---

## New Tests

| File | Coverage |
|------|----------|
| `tests/repro-160-mutation-queue.test.ts` | Parallel `edit.execute()` on the same virtual file with mocked `fs/promises`; asserts final content is `ALPHA\nBETA\n`. Goes red without F1. |
| `tests/write-mutation-queue.test.ts` | Mocks `withFileMutationQueue` + `node:fs.mkdirSync` / `writeFileSync` to record `queue-enter → mkdir → write → queue-exit` event sequence. Deterministic; no timing flake. Goes red without F2. |
| `tests/pi-prompt-metadata-integration.test.ts` | Loads the extension through the real Pi registration path, activates `read`, `edit`, `grep`, `find`, `ls`, `write`, `ast_search`, `nu`, asserts each contributes a concise `- toolName: snippet` line and tool-named `promptGuidelines` that never contain `"this tool"`. |
| `tests/helpers/pi-prompt-metadata-harness.ts` | Reusable harness exporting `collectHashlineSystemPromptMetadata(activeTools)`. |

---

## Acceptance Criteria

- [x] **AC 1** — `edit` imports and uses `withFileMutationQueue(absolutePath, …)`; closure covers the full read-modify-write decision window (`src/edit.ts:1`, `:131`, includes `fsReadFile` at `:225` through `fsWriteFile` at `:464`).
- [x] **AC 2** — `write` imports and uses `withFileMutationQueue(absolutePath, …)`; closure covers parent-directory creation, file write, output generation, and `onFileAnchored` (`src/write.ts:1`, `:217`).
- [x] **AC 3** — `tests/repro-160-mutation-queue.test.ts` passes and proves parallel edits preserve both updates. Red-green verified: pre-fix `expected 'alpha\nBETA\n' to be 'ALPHA\nBETA\n'`; post-fix green.
- [x] **AC 4** — `tests/write-mutation-queue.test.ts` proves `write` participates in the queue via deterministic event-order instrumentation (no timing flake).
- [x] **AC 5** — Existing focused edit/write tests continue to pass: `tests/edit/**` (23 files, 111 tests) and `tests/write/**` (5 files, 17 tests).
- [x] **AC 6** — `tests/pi-prompt-metadata-integration.test.ts` exercises Pi's real `ExtensionAPI.registerTool → _refreshToolRegistry → _rebuildSystemPrompt → buildSystemPrompt` path and asserts `- toolName: snippet` lines for `read`, `edit`, `grep`, `find`, `ls`, `write`, `ast_search`, `nu`.
- [x] **AC 7** — Same test asserts flat tool-named `promptGuidelines` appear as `- guideline` in the system prompt and never match `/\bthis tool\b/i`.
- [x] **AC 8** — `npm run typecheck` passes (exit 0).

---

## Verification

```bash
# Reproduce the lost-update race (red without fix):
git stash -- src/edit.ts src/write.ts
npx vitest run tests/repro-160-mutation-queue.test.ts tests/write-mutation-queue.test.ts
#  FAIL  expected 'alpha\nBETA\n' to be 'ALPHA\nBETA\n'
#  FAIL  expected 'mkdir:/virtual' to be 'queue-enter:/virtual/write-queue.txt'
git stash pop

# Green with fix:
npx vitest run tests/repro-160-mutation-queue.test.ts tests/write-mutation-queue.test.ts
#  Test Files  2 passed (2)   Tests  2 passed (2)
```

---

## Test Results

```
Test Files  278 passed (278)
     Tests  1307 passed (1307)
```

`npm run typecheck`: exit 0

---

## Notes for reviewers

- The queue wrappers open **after** `resolveToCwd(...)` so per-path queueing matches Pi's docs and same-file symlink / relative-path aliases coordinate correctly.
- `executeWrite()` stays unqueued so direct test callers keep deterministic behavior; only the registered `write` tool boundary is queued. If a future non-test caller wants queued semantics outside `registerWriteTool.execute`, it should wrap at its own call site.
- The prompt-metadata harness is reusable for any future built-in override — call `collectHashlineSystemPromptMetadata([…tools])` and assert against the rendered `session.systemPrompt`.

---

## Follow-ups (out of scope)

- Audit any other extension-registered mutating tools (current repo: none beyond `edit` / `write`) for the same queue-omission pattern.
- Consider exporting a thin `queuedMutate(absolutePath, fn)` wrapper from this package so future overrides can't forget the wrap.
