### PR TITLE
feat: stream pending diff preview during edit/write (#161)

### DIFF
--- a/src/edit.ts
+++ b/src/edit.ts
@@ -16,6 +16,15 @@ import { formatEditCallText, formatEditResultText } from "./edit-render-helpers.
 import { validateSyntaxRegression } from "./edit-syntax-validate.js";
 import { resolveSyntaxValidateMode, type SyntaxValidateOptions } from "./syntax-validate-mode.js";
 import { replaceSymbol } from "./replace-symbol.js";
+import { buildEditPreviewKey, buildPendingEditPreviewData, resolvePendingDiffPreview, type PendingDiffPreviewResult } from "./pending-diff-preview.js";
+
+const EDIT_PENDING_PREVIEW_STATE_KEY = "hashline-edit-pending-preview";
+
+function formatPendingPreviewText(summary: string, preview: PendingDiffPreviewResult | undefined): string {
+	if (!preview || preview.type !== "ok") return summary;
+	const diff = preview.data.diff ? `\n${preview.data.diff}` : "";
+	return `${summary}\n${preview.data.headerLabel}${diff}`;
+}
 
 export function wrapWriteError(err: any, path: string): Error {
 	const code = err?.code;
@@ -540,19 +549,23 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			});
 		},
 		renderCall(args: any, theme: any, ...rest: any[]) {
-			const context: { argsComplete?: boolean; lastComponent?: any } = rest[0] ?? {};
+			const context: { argsComplete?: boolean; lastComponent?: any; cwd?: string; state?: Record<string, any>; invalidate?: () => void } = rest[0] ?? {};
 			const argsComplete = context.argsComplete ?? false;
 			const { path: filePath, suffix } = formatEditCallText(args, argsComplete);
 
 			let text = theme.fg("toolTitle", theme.bold("edit"));
-			if (filePath) {
-				text += ` ${theme.fg("accent", filePath)}`;
-			} else {
-				text += ` ${theme.fg("toolOutput", "...")}`;
-			}
-			if (suffix) {
-				text += ` ${theme.fg("dim", suffix)}`;
-			}
+			if (filePath) text += ` ${theme.fg("accent", filePath)}`;
+			else text += ` ${theme.fg("toolOutput", "...")}`;
+			if (suffix) text += ` ${theme.fg("dim", suffix)}`;
+
+			const previewKey = buildEditPreviewKey(args ?? {});
+			const preview = resolvePendingDiffPreview(
+				context,
+				EDIT_PENDING_PREVIEW_STATE_KEY,
+				previewKey,
+				() => buildPendingEditPreviewData(args ?? {}, context.cwd ?? process.cwd()),
+			);
+			text = formatPendingPreviewText(text, preview);
 
 			const component = context.lastComponent ?? new Text("", 0, 0);
 			component.setText(text);

--- a/src/pending-diff-preview.ts
+++ b/src/pending-diff-preview.ts
@@ -1,0 +1,275 @@
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { dirname, relative, resolve, sep } from "node:path";
+import { generateDiffString, normalizeToLF } from "./edit-diff.js";
+import { applyHashlineEdits, type HashlineEditItem } from "./hashline.js";
+import { replaceSymbol } from "./replace-symbol.js";
+
+export const PENDING_DIFF_MAX_BYTES = 1024 * 1024;
+
+export interface PendingDiffPreviewData {
+	filePath: string;
+	previousContent: string;
+	nextContent: string;
+	fileExistedBeforeWrite: boolean;
+	headerLabel: "pending edit" | "pending overwrite" | "pending create";
+	diff: string;
+}
+
+export type PendingDiffPreviewResult =
+	| { type: "ok"; data: PendingDiffPreviewData }
+	| { type: "skip"; reason: string };
+
+function skip(reason: string): PendingDiffPreviewResult {
+	return { type: "skip", reason };
+}
+
+function isInsidePath(parent: string, child: string): boolean {
+	const rel = relative(parent, child);
+	return rel === "" || (rel !== "" && !rel.startsWith("..") && !rel.startsWith(sep) && !resolve(rel).startsWith(".." + sep));
+}
+
+function resolveWorkspacePreviewPath(rawPath: unknown, cwd: string, allowMissing: boolean): { type: "ok"; path: string; existed: boolean } | { type: "skip"; reason: string } {
+	if (typeof rawPath !== "string" || rawPath.trim() === "") return { type: "skip", reason: "missing path" };
+	const workspace = realpathSync(cwd);
+	const requested = resolve(workspace, rawPath.replace(/^@/, ""));
+	if (existsSync(requested)) {
+		const realTarget = realpathSync(requested);
+		if (!isInsidePath(workspace, realTarget)) return { type: "skip", reason: "path outside workspace" };
+		return { type: "ok", path: realTarget, existed: true };
+	}
+
+	if (!isInsidePath(workspace, requested)) return { type: "skip", reason: "path outside workspace" };
+
+	if (!allowMissing) return { type: "skip", reason: "file not found" };
+	const parent = dirname(requested);
+	if (!existsSync(parent)) return { type: "skip", reason: "parent directory not found" };
+	return { type: "ok", path: requested, existed: false };
+}
+
+function readUtf8File(filePath: string): { type: "ok"; content: string } | { type: "skip"; reason: string } {
+	const stat = statSync(filePath);
+	if (!stat.isFile()) return { type: "skip", reason: "not a file" };
+	if (stat.size > PENDING_DIFF_MAX_BYTES) return { type: "skip", reason: "file too large" };
+	const content = readFileSync(filePath, "utf-8");
+	if (content.includes("\0")) return { type: "skip", reason: "binary file" };
+	return { type: "ok", content };
+}
+
+function buildData(
+	filePath: string,
+	previousContent: string,
+	nextContent: string,
+	existed: boolean,
+	headerLabel: PendingDiffPreviewData["headerLabel"],
+): PendingDiffPreviewResult {
+	const diff = generateDiffString(normalizeToLF(previousContent), normalizeToLF(nextContent)).diff;
+	return {
+		type: "ok",
+		data: {
+			filePath,
+			previousContent,
+			nextContent,
+			fileExistedBeforeWrite: existed,
+			headerLabel,
+			diff,
+		},
+	};
+}
+
+type ReplaceEdit = { replace: { old_text: string; new_text: string } };
+type PendingEditInput = { path?: unknown; edits?: unknown[]; oldText?: unknown; newText?: unknown; old_text?: unknown; new_text?: unknown };
+
+function normalizeReplaceOnlyEdits(input: PendingEditInput): unknown[] {
+	if (Array.isArray(input.edits)) return input.edits;
+	const oldText = typeof input.oldText === "string" ? input.oldText : typeof input.old_text === "string" ? input.old_text : undefined;
+	const newText = typeof input.newText === "string" ? input.newText : typeof input.new_text === "string" ? input.new_text : undefined;
+	if (oldText === undefined || newText === undefined) return [];
+	return [{ replace: { old_text: oldText, new_text: newText } }];
+}
+
+function isReplaceEdit(edit: unknown): edit is ReplaceEdit {
+	return !!edit && typeof edit === "object" && "replace" in edit && typeof (edit as any).replace?.old_text === "string" && typeof (edit as any).replace?.new_text === "string";
+}
+
+type AnchorEdit =
+	| { set_line: { anchor: string; new_text: string } }
+	| { replace_lines: { start_anchor: string; end_anchor: string; new_text: string } }
+	| { insert_after: { anchor: string; new_text: string; text?: string } };
+
+function isAnchorEdit(edit: unknown): edit is AnchorEdit {
+	return !!edit && typeof edit === "object" && ("set_line" in edit || "replace_lines" in edit || "insert_after" in edit);
+}
+
+function applyAnchoredPreview(content: string, edits: AnchorEdit[]): { type: "ok"; content: string } | { type: "skip"; reason: string } {
+	try {
+		return { type: "ok", content: applyHashlineEdits(content, edits as HashlineEditItem[]).content };
+	} catch (err: any) {
+		return { type: "skip", reason: `anchor projection failed: ${err?.message ?? String(err)}` };
+	}
+}
+
+type ReplaceSymbolEdit = { replace_symbol: { symbol: string; new_body: string } };
+
+function isReplaceSymbolEdit(edit: unknown): edit is ReplaceSymbolEdit {
+	return !!edit && typeof edit === "object" && "replace_symbol" in edit && typeof (edit as any).replace_symbol?.symbol === "string" && typeof (edit as any).replace_symbol?.new_body === "string";
+}
+
+async function applyReplaceSymbolPreview(filePath: string, content: string, edit: ReplaceSymbolEdit): Promise<{ type: "ok"; content: string } | { type: "skip"; reason: string }> {
+	try {
+		if (!edit.replace_symbol.new_body.trim()) return { type: "skip", reason: "replace_symbol new_body is empty" };
+		const probe = await replaceSymbol({
+			filePath,
+			content,
+			symbol: edit.replace_symbol.symbol,
+			newBody: edit.replace_symbol.new_body,
+		});
+		if (probe.type !== "ok") return { type: "skip", reason: `symbol projection failed: ${probe.message}` };
+		return { type: "ok", content: probe.content };
+	} catch (err: any) {
+		return { type: "skip", reason: `symbol projection failed: ${err?.message ?? String(err)}` };
+	}
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+	if (!needle.length) return 0;
+	let count = 0;
+	let offset = 0;
+	while (true) {
+		const idx = haystack.indexOf(needle, offset);
+		if (idx === -1) return count;
+		count++;
+		offset = idx + needle.length;
+	}
+}
+
+function applyReplacePreview(content: string, edit: ReplaceEdit): { type: "ok"; content: string } | { type: "skip"; reason: string } {
+	const { old_text, new_text } = edit.replace;
+	if (!old_text.length) return { type: "skip", reason: "replace old_text is empty" };
+	const matches = countOccurrences(content, old_text);
+	if (matches !== 1) return { type: "skip", reason: `replace old_text is not unique (${matches} matches)` };
+	return { type: "ok", content: content.replace(old_text, normalizeToLF(new_text)) };
+}
+
+export function buildPendingWritePreviewData(input: { path?: unknown; content?: unknown }, cwd: string): PendingDiffPreviewResult {
+	if (typeof input.content !== "string") return skip("missing content");
+	if (Buffer.byteLength(input.content, "utf8") > PENDING_DIFF_MAX_BYTES) return skip("content too large");
+	const resolved = resolveWorkspacePreviewPath(input.path, cwd, true);
+	if (resolved.type === "skip") return resolved;
+	const previous = resolved.existed ? readUtf8File(resolved.path) : { type: "ok" as const, content: "" };
+	if (previous.type === "skip") return previous;
+	return buildData(resolved.path, previous.content, input.content, resolved.existed, resolved.existed ? "pending overwrite" : "pending create");
+}
+
+export async function buildPendingEditPreviewData(input: PendingEditInput, cwd: string): Promise<PendingDiffPreviewResult> {
+	const edits = normalizeReplaceOnlyEdits(input);
+	if (edits.length === 0) return skip("missing edits");
+	const resolved = resolveWorkspacePreviewPath(input.path, cwd, false);
+	if (resolved.type === "skip") return resolved;
+	const previous = readUtf8File(resolved.path);
+	if (previous.type === "skip") return previous;
+	let next = normalizeToLF(previous.content);
+	const anchorBatch: AnchorEdit[] = [];
+
+	for (const edit of edits) {
+		if (isReplaceEdit(edit)) {
+			if (anchorBatch.length > 0) {
+				const anchored = applyAnchoredPreview(next, anchorBatch);
+				if (anchored.type === "skip") return anchored;
+				next = anchored.content;
+				anchorBatch.length = 0;
+			}
+			const projected = applyReplacePreview(next, edit);
+			if (projected.type === "skip") return projected;
+			next = projected.content;
+			continue;
+		}
+		if (isAnchorEdit(edit)) {
+			anchorBatch.push(edit);
+			continue;
+		}
+		if (isReplaceSymbolEdit(edit)) {
+			if (anchorBatch.length > 0) {
+				const anchored = applyAnchoredPreview(next, anchorBatch);
+				if (anchored.type === "skip") return anchored;
+				next = anchored.content;
+				anchorBatch.length = 0;
+			}
+			const projected = await applyReplaceSymbolPreview(resolved.path, next, edit);
+			if (projected.type === "skip") return projected;
+			next = projected.content;
+			continue;
+		}
+		return skip("unsupported edit variant");
+	}
+
+	if (anchorBatch.length > 0) {
+		const anchored = applyAnchoredPreview(next, anchorBatch);
+		if (anchored.type === "skip") return anchored;
+		next = anchored.content;
+	}
+	return buildData(resolved.path, previous.content, next, true, "pending edit");
+}
+
+export interface PendingDiffPreviewCacheSlot<T = PendingDiffPreviewResult> {
+	key?: string;
+	data?: T;
+	pending?: boolean;
+}
+
+export function buildEditPreviewKey(input: PendingEditInput): string | undefined {
+	if (typeof input.path !== "string") return undefined;
+	const edits = normalizeReplaceOnlyEdits(input);
+	if (edits.length === 0) return undefined;
+	return JSON.stringify({ path: input.path, edits });
+}
+
+export function buildWritePreviewKey(input: { path?: unknown; content?: unknown }): string | undefined {
+	if (typeof input.path !== "string" || typeof input.content !== "string") return undefined;
+	return JSON.stringify({ path: input.path, content: input.content });
+}
+
+export function resolvePendingDiffPreview<T extends PendingDiffPreviewResult>(
+	context: { state?: Record<string, PendingDiffPreviewCacheSlot<T>>; invalidate?: () => void } | undefined,
+	stateKey: string,
+	previewKey: string | undefined,
+	compute: () => T | Promise<T>,
+): T | undefined {
+	if (!previewKey) return undefined;
+	const root = context?.state;
+	if (!root) return undefined;
+	const slot = (root[stateKey] ??= {} as PendingDiffPreviewCacheSlot<T>);
+	if (slot.key !== previewKey) {
+		slot.key = previewKey;
+		slot.data = undefined;
+		slot.pending = false;
+	}
+	if (slot.data !== undefined) return slot.data;
+	if (slot.pending) return undefined;
+
+	let value: T | Promise<T>;
+	try {
+		value = compute();
+	} catch (err: any) {
+		const skipped = { type: "skip", reason: `projection failed: ${err?.message ?? String(err)}` } as T;
+		slot.data = skipped;
+		return skipped;
+	}
+	if (value && typeof (value as any).then === "function") {
+		slot.pending = true;
+		void (value as Promise<T>).then((resolved) => {
+			if (slot.key !== previewKey) return;
+			slot.data = resolved;
+			slot.pending = false;
+			context?.invalidate?.();
+		}).catch((err: any) => {
+			if (slot.key !== previewKey) return;
+			slot.data = { type: "skip", reason: `projection failed: ${err?.message ?? String(err)}` } as T;
+			slot.pending = false;
+			context?.invalidate?.();
+		});
+		return undefined;
+	}
+
+	slot.data = value as T;
+	return slot.data;
+}

--- a/src/write.ts
+++ b/src/write.ts
@@ -11,6 +11,15 @@ import { getOrGenerateMap } from "./map-cache.js";
 import { formatFileMapWithBudget } from "./readmap/formatter.js";
 import { buildContextHygieneMetadata, buildFileResource, type ContextHygieneMetadata } from "./context-hygiene.js";
 import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
+import { buildPendingWritePreviewData, buildWritePreviewKey, resolvePendingDiffPreview, type PendingDiffPreviewResult } from "./pending-diff-preview.js";
+
+const WRITE_PENDING_PREVIEW_STATE_KEY = "hashline-write-pending-preview";
+
+function formatPendingWritePreviewText(summary: string, preview: PendingDiffPreviewResult | undefined): string {
+	if (!preview || preview.type !== "ok") return summary;
+	const diff = preview.data.diff ? `\n${preview.data.diff}` : "";
+	return `${summary}\n${preview.data.headerLabel}${diff}`;
+}
 
 const MAX_LINES = 2000;
 const MAX_BYTES = 50 * 1024;
@@ -282,10 +291,21 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
       };
       });
     },
-    renderCall(args: any, theme: any) {
+    renderCall(args: any, theme: any, context: any = {}) {
       const { path } = args as { path: string };
       const label = theme.fg("toolTitle", "✏️ write");
-      return new Text(`${label} ${theme.fg("muted", path)}`, 0, 0);
+      let text = `${label} ${theme.fg("muted", path)}`;
+      const previewKey = buildWritePreviewKey(args ?? {});
+      const preview = resolvePendingDiffPreview(
+        context,
+        WRITE_PENDING_PREVIEW_STATE_KEY,
+        previewKey,
+        () => buildPendingWritePreviewData(args ?? {}, context.cwd ?? process.cwd()),
+      );
+      text = formatPendingWritePreviewText(text, preview);
+      const component = context.lastComponent ?? new Text("", 0, 0);
+      component.setText(text);
+      return component;
     },
     renderResult(result: any, _options: any, theme: any) {
       const output = result.content[0]?.type === "text"

--- a/tests/edit-pending-diff-render-fallback.test.ts
+++ b/tests/edit-pending-diff-render-fallback.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { registerEditTool } from "../src/edit.js";
+
+function getEditTool(): any {
+	let tool: any;
+	registerEditTool({ registerTool(def: any) { tool = def; } } as any);
+	if (!tool) throw new Error("edit tool was not registered");
+	return tool;
+}
+
+function textOf(component: any): string {
+	return component?.text ?? component?.render?.(120)?.join("\n") ?? "";
+}
+
+const theme = {
+	fg: (_style: string, text: string) => text,
+	bold: (text: string) => text,
+};
+
+describe("edit renderCall preview fallback", () => {
+	it("keeps the summary after a skipped preview", async () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-edit-pending-fallback-"));
+		const filePath = resolve(cwd, "sample.ts");
+		writeFileSync(filePath, "const value = 1;\nconst value = 1;\n", "utf-8");
+		const tool = getEditTool();
+		const context: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined };
+		const args = { path: filePath, edits: [{ replace: { old_text: "const value = 1;", new_text: "const value = 2;" } }] };
+
+		expect(() => tool.renderCall(args, theme, context)).not.toThrow();
+		await Promise.resolve();
+		const rendered = textOf(tool.renderCall(args, theme, context));
+		expect(rendered).toContain("edit");
+		expect(rendered).not.toContain("pending edit");
+
+		const result = await tool.execute("edit-call", args, new AbortController().signal, undefined, { cwd });
+		expect(result.isError).not.toBe(true);
+		expect(readFileSync(filePath, "utf-8")).toBe("const value = 2;\nconst value = 1;\n");
+	});
+});

--- a/tests/edit-pending-diff-render-success.test.ts
+++ b/tests/edit-pending-diff-render-success.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { registerEditTool } from "../src/edit.js";
+
+function getEditTool(): any {
+	let tool: any;
+	registerEditTool({ registerTool(def: any) { tool = def; } } as any);
+	if (!tool) throw new Error("edit tool was not registered");
+	return tool;
+}
+
+function textOf(component: any): string {
+	return component?.text ?? component?.render?.(120)?.join("\n") ?? "";
+}
+
+const theme = {
+	fg: (_style: string, text: string) => text,
+	bold: (text: string) => text,
+};
+
+describe("edit renderCall pending diff preview", () => {
+	it("renders a pending edit preview", async () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-edit-pending-success-"));
+		const filePath = resolve(cwd, "sample.ts");
+		writeFileSync(filePath, "const unique = 1;\n", "utf-8");
+		const tool = getEditTool();
+		const context: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined };
+		const args = { path: filePath, edits: [{ replace: { old_text: "const unique = 1;", new_text: "const unique = 2;" } }] };
+
+		const first = tool.renderCall(args, theme, context);
+		await Promise.resolve();
+		const second = tool.renderCall(args, theme, { ...context, lastComponent: first });
+		const rendered = textOf(second);
+
+		expect(rendered).toContain("pending edit");
+		expect(rendered).toContain("-1 const unique = 1;");
+		expect(rendered).toContain("+1 const unique = 2;");
+	});
+});

--- a/tests/pending-diff-preview-cache-exception.test.ts
+++ b/tests/pending-diff-preview-cache-exception.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolvePendingDiffPreview } from "../src/pending-diff-preview.js";
+
+describe("pending diff preview cache exceptions", () => {
+	it("turns synchronous projection exceptions into cached skips", () => {
+		const context: any = { state: {}, invalidate: vi.fn() };
+
+		const thrown = resolvePendingDiffPreview(context, "throwing-preview", "throw-key", () => {
+			throw new Error("projection exploded");
+		});
+		const cached = resolvePendingDiffPreview(context, "throwing-preview", "throw-key", () => {
+			throw new Error("projection exploded again");
+		});
+
+		expect(thrown).toEqual({ type: "skip", reason: expect.stringContaining("projection") });
+		expect(cached).toEqual(thrown);
+	});
+});

--- a/tests/pending-diff-preview-cache.test.ts
+++ b/tests/pending-diff-preview-cache.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolvePendingDiffPreview } from "../src/pending-diff-preview.js";
+
+describe("pending diff preview cache", () => {
+	it("reuses cached data for identical keys", async () => {
+		const context: any = { state: {}, invalidate: vi.fn() };
+		let calls = 0;
+
+		const first = resolvePendingDiffPreview(context, "preview", "key-1", () => {
+			calls++;
+			return { type: "skip" as const, reason: "first" };
+		});
+		const second = resolvePendingDiffPreview(context, "preview", "key-1", () => {
+			calls++;
+			return { type: "skip" as const, reason: "second" };
+		});
+
+		expect(first).toEqual({ type: "skip", reason: "first" });
+		expect(second).toEqual({ type: "skip", reason: "first" });
+		expect(calls).toBe(1);
+
+		const third = resolvePendingDiffPreview(context, "preview", "key-2", () => {
+			calls++;
+			return Promise.resolve({ type: "skip" as const, reason: "third" });
+		});
+		expect(third).toBeUndefined();
+		expect(calls).toBe(2);
+
+		await Promise.resolve();
+		const fourth = resolvePendingDiffPreview(context, "preview", "key-2", () => {
+			calls++;
+			return { type: "skip" as const, reason: "fourth" };
+		});
+
+		expect(fourth).toEqual({ type: "skip", reason: "third" });
+		expect(calls).toBe(2);
+		expect(context.invalidate).toHaveBeenCalledTimes(1);
+	});
+});

--- a/tests/pending-diff-preview-hashline-fallback.test.ts
+++ b/tests/pending-diff-preview-hashline-fallback.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit } from "../src/hashline.js";
+import { buildPendingEditPreviewData } from "../src/pending-diff-preview.js";
+
+describe("pending hashline edit fallback", () => {
+	beforeAll(async () => {
+		await ensureHashInit();
+	});
+
+	it("skips an out-of-range anchor", async () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-anchor-fallback-"));
+		const filePath = resolve(cwd, "sample.ts");
+		writeFileSync(filePath, "const value = 1;\nconst other = 2;\n", "utf-8");
+
+		const stale = await buildPendingEditPreviewData({
+			path: filePath,
+			edits: [{ set_line: { anchor: "99:bad", new_text: "const value = 99;" } }],
+		}, cwd);
+
+		expect(stale.type).toBe("skip");
+		if (stale.type !== "skip") throw new Error("stale anchor unexpectedly projected");
+		expect(stale.reason).toContain("anchor projection failed");
+	});
+});

--- a/tests/pending-diff-preview-hashline-success.test.ts
+++ b/tests/pending-diff-preview-hashline-success.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+import { buildPendingEditPreviewData } from "../src/pending-diff-preview.js";
+
+describe("pending hashline edit preview", () => {
+	beforeAll(async () => {
+		await ensureHashInit();
+	});
+
+	it("projects an anchored set_line edit", async () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-anchor-success-"));
+		const filePath = resolve(cwd, "sample.ts");
+		writeFileSync(filePath, "const value = 1;\nconst other = 2;\n", "utf-8");
+		const anchor = `1:${computeLineHash(1, "const value = 1;")}`;
+
+		const projected = await buildPendingEditPreviewData({
+			path: filePath,
+			edits: [{ set_line: { anchor, new_text: "const value = 10;" } }],
+		}, cwd);
+
+		expect(projected.type).toBe("ok");
+		if (projected.type !== "ok") throw new Error(projected.reason);
+		expect(projected.data.nextContent).toContain("const value = 10;");
+		expect(projected.data.diff).toContain("-1 const value = 1;");
+		expect(projected.data.diff).toContain("+1 const value = 10;");
+	});
+});

--- a/tests/pending-diff-preview-outside-path.test.ts
+++ b/tests/pending-diff-preview-outside-path.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { buildPendingWritePreviewData } from "../src/pending-diff-preview.js";
+
+describe("pending preview outside path guard", () => {
+	it("skips an absolute path outside cwd", () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-guard-cwd-"));
+		const outsideDir = mkdtempSync(resolve(tmpdir(), "pi-pending-guard-outside-"));
+		const outsideFile = resolve(outsideDir, "outside.txt");
+		writeFileSync(outsideFile, "outside\n", "utf-8");
+
+		const outside = buildPendingWritePreviewData({ path: outsideFile, content: "changed\n" }, cwd);
+
+		expect(outside.type).toBe("skip");
+		if (outside.type !== "skip") throw new Error("outside path unexpectedly projected");
+		expect(outside.reason).toContain("workspace");
+	});
+});

--- a/tests/pending-diff-preview-replace-fallback.test.ts
+++ b/tests/pending-diff-preview-replace-fallback.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { buildPendingEditPreviewData } from "../src/pending-diff-preview.js";
+
+function makeFixture(content: string): { cwd: string; filePath: string } {
+	const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-replace-fallback-"));
+	const filePath = resolve(cwd, "sample.ts");
+	writeFileSync(filePath, content, "utf-8");
+	return { cwd, filePath };
+}
+
+describe("pending edit replace fallback", () => {
+	it("skips ambiguous replace text", async () => {
+		const { cwd, filePath } = makeFixture("const value = 1;\nconst other = 2;\n");
+
+		const ambiguous = await buildPendingEditPreviewData({
+			path: filePath,
+			edits: [{ replace: { old_text: "const", new_text: "let" } }],
+		}, cwd);
+
+		expect(ambiguous.type).toBe("skip");
+		if (ambiguous.type !== "skip") throw new Error("ambiguous replace unexpectedly projected");
+		expect(ambiguous.reason).toContain("not unique");
+	});
+});

--- a/tests/pending-diff-preview-replace-success.test.ts
+++ b/tests/pending-diff-preview-replace-success.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { buildPendingEditPreviewData } from "../src/pending-diff-preview.js";
+
+function makeFixture(content: string): { cwd: string; filePath: string } {
+	const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-replace-success-"));
+	const filePath = resolve(cwd, "sample.ts");
+	writeFileSync(filePath, content, "utf-8");
+	return { cwd, filePath };
+}
+
+describe("pending edit replace preview", () => {
+	it("projects an exact replace edit", async () => {
+		const { cwd, filePath } = makeFixture("const value = 1;\nconst other = 2;\n");
+
+		const projected = await buildPendingEditPreviewData({
+			path: filePath,
+			edits: [{ replace: { old_text: "const value = 1;", new_text: "const value = 10;" } }],
+		}, cwd);
+
+		expect(projected.type).toBe("ok");
+		if (projected.type !== "ok") throw new Error(projected.reason);
+		expect(projected.data.headerLabel).toBe("pending edit");
+		expect(projected.data.previousContent).toContain("const value = 1;");
+		expect(projected.data.nextContent).toContain("const value = 10;");
+		expect(projected.data.diff).toContain("-1 const value = 1;");
+		expect(projected.data.diff).toContain("+1 const value = 10;");
+	});
+});

--- a/tests/pending-diff-preview-replace-symbol-fallback.test.ts
+++ b/tests/pending-diff-preview-replace-symbol-fallback.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { buildPendingEditPreviewData } from "../src/pending-diff-preview.js";
+
+describe("pending replace_symbol fallback", () => {
+	it("skips an unresolved symbol", async () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-symbol-fallback-"));
+		const filePath = resolve(cwd, "sample.ts");
+		writeFileSync(filePath, "export function add(a: number, b: number) {\n  return a + b;\n}\n", "utf-8");
+
+		const missing = await buildPendingEditPreviewData({
+			path: filePath,
+			edits: [{ replace_symbol: { symbol: "missing", new_body: "export function missing() {\n  return 1;\n}" } }],
+		}, cwd);
+
+		expect(missing.type).toBe("skip");
+		if (missing.type !== "skip") throw new Error("missing symbol unexpectedly projected");
+		expect(missing.reason).toContain("symbol projection failed");
+	});
+});

--- a/tests/pending-diff-preview-replace-symbol-success.test.ts
+++ b/tests/pending-diff-preview-replace-symbol-success.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { buildPendingEditPreviewData } from "../src/pending-diff-preview.js";
+
+describe("pending replace_symbol edit preview", () => {
+	it("projects a resolved symbol replacement", async () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-symbol-success-"));
+		const filePath = resolve(cwd, "sample.ts");
+		writeFileSync(filePath, "export function add(a: number, b: number) {\n  return a + b;\n}\n", "utf-8");
+
+		const projected = await buildPendingEditPreviewData({
+			path: filePath,
+			edits: [{ replace_symbol: { symbol: "add", new_body: "export function add(a: number, b: number) {\n  return a + b + 1;\n}" } }],
+		}, cwd);
+
+		expect(projected.type).toBe("ok");
+		if (projected.type !== "ok") throw new Error(projected.reason);
+		expect(projected.data.headerLabel).toBe("pending edit");
+		expect(projected.data.nextContent).toContain("return a + b + 1;");
+		expect(projected.data.diff).toContain("-2   return a + b;");
+		expect(projected.data.diff).toContain("+2   return a + b + 1;");
+	});
+});

--- a/tests/pending-diff-preview-size-limit.test.ts
+++ b/tests/pending-diff-preview-size-limit.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { buildPendingWritePreviewData } from "../src/pending-diff-preview.js";
+
+describe("pending preview size limit", () => {
+	it("skips proposed write content above the preview limit", () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-size-limit-"));
+
+		const huge = buildPendingWritePreviewData({ path: "huge.txt", content: "x".repeat(1024 * 1024 + 1) }, cwd);
+
+		expect(huge.type).toBe("skip");
+		if (huge.type !== "skip") throw new Error("oversized content unexpectedly projected");
+		expect(huge.reason).toContain("large");
+	});
+});

--- a/tests/pending-diff-preview-symlink-escape.test.ts
+++ b/tests/pending-diff-preview-symlink-escape.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { buildPendingWritePreviewData } from "../src/pending-diff-preview.js";
+
+describe("pending preview symlink guard", () => {
+	it("skips a symlink whose real path escapes cwd", () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-symlink-cwd-"));
+		const outsideDir = mkdtempSync(resolve(tmpdir(), "pi-pending-symlink-outside-"));
+		const outsideFile = resolve(outsideDir, "outside.txt");
+		writeFileSync(outsideFile, "outside\n", "utf-8");
+		symlinkSync(outsideFile, resolve(cwd, "escape.txt"));
+
+		const symlink = buildPendingWritePreviewData({ path: "escape.txt", content: "changed\n" }, cwd);
+
+		expect(symlink.type).toBe("skip");
+		if (symlink.type !== "skip") throw new Error("symlink escape unexpectedly projected");
+		expect(symlink.reason).toContain("workspace");
+	});
+});

--- a/tests/pending-diff-preview-write-create.test.ts
+++ b/tests/pending-diff-preview-write-create.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { buildPendingWritePreviewData } from "../src/pending-diff-preview.js";
+
+function makeDir(): string {
+	return mkdtempSync(resolve(tmpdir(), "pi-pending-write-create-"));
+}
+
+describe("pending write create preview", () => {
+	it("projects a missing-file create preview", () => {
+		const cwd = makeDir();
+
+		const created = buildPendingWritePreviewData({ path: "created.txt", content: "created value\n" }, cwd);
+
+		expect(created.type).toBe("ok");
+		if (created.type !== "ok") throw new Error(created.reason);
+		expect(created.data.headerLabel).toBe("pending create");
+		expect(created.data.fileExistedBeforeWrite).toBe(false);
+		expect(created.data.previousContent).toBe("");
+		expect(created.data.nextContent).toBe("created value\n");
+		expect(created.data.diff).toContain("+1 created value");
+	});
+});

--- a/tests/pending-diff-preview-write-overwrite.test.ts
+++ b/tests/pending-diff-preview-write-overwrite.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { buildPendingWritePreviewData } from "../src/pending-diff-preview.js";
+
+function makeDir(): string {
+	return mkdtempSync(resolve(tmpdir(), "pi-pending-write-overwrite-"));
+}
+
+describe("pending write overwrite preview", () => {
+	it("projects an existing-file overwrite preview", () => {
+		const cwd = makeDir();
+		const existingPath = resolve(cwd, "sample.txt");
+		writeFileSync(existingPath, "old value\n", "utf-8");
+
+		const overwrite = buildPendingWritePreviewData({ path: "sample.txt", content: "new value\n" }, cwd);
+
+		expect(overwrite.type).toBe("ok");
+		if (overwrite.type !== "ok") throw new Error(overwrite.reason);
+		expect(overwrite.data.headerLabel).toBe("pending overwrite");
+		expect(overwrite.data.fileExistedBeforeWrite).toBe(true);
+		expect(overwrite.data.previousContent).toBe("old value\n");
+		expect(overwrite.data.nextContent).toBe("new value\n");
+		expect(overwrite.data.diff).toContain("-1 old value");
+		expect(overwrite.data.diff).toContain("+1 new value");
+	});
+});

--- a/tests/write-pending-diff-render-fallback.test.ts
+++ b/tests/write-pending-diff-render-fallback.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { registerWriteTool } from "../src/write.js";
+
+function getWriteTool(): any {
+	let tool: any;
+	registerWriteTool({ registerTool(def: any) { tool = def; } } as any);
+	if (!tool) throw new Error("write tool was not registered");
+	return tool;
+}
+
+function textOf(component: any): string {
+	return component?.text ?? component?.render?.(120)?.join("\n") ?? "";
+}
+
+const theme = {
+	fg: (_style: string, text: string) => text,
+	bold: (text: string) => text,
+};
+
+describe("write renderCall preview fallback", () => {
+	it("keeps the summary after a skipped preview", async () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-write-pending-fallback-"));
+		const tool = getWriteTool();
+		const context: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined };
+		const args = { path: "large.txt", content: "x".repeat(1024 * 1024 + 1) };
+
+		expect(() => tool.renderCall(args, theme, context)).not.toThrow();
+		const rendered = textOf(tool.renderCall(args, theme, context));
+		expect(rendered).toContain("write");
+		expect(rendered).not.toContain("pending");
+
+		const result = await tool.execute("write-large", args, new AbortController().signal, undefined, { cwd });
+		expect(result.isError).not.toBe(true);
+		expect(readFileSync(resolve(cwd, "large.txt"), "utf-8")).toBe(args.content);
+	});
+});

--- a/tests/write-pending-diff-render-success.test.ts
+++ b/tests/write-pending-diff-render-success.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { registerWriteTool } from "../src/write.js";
+
+function getWriteTool(): any {
+	let tool: any;
+	registerWriteTool({ registerTool(def: any) { tool = def; } } as any);
+	if (!tool) throw new Error("write tool was not registered");
+	return tool;
+}
+
+function textOf(component: any): string {
+	return component?.text ?? component?.render?.(120)?.join("\n") ?? "";
+}
+
+const theme = {
+	fg: (_style: string, text: string) => text,
+	bold: (text: string) => text,
+};
+
+describe("write renderCall pending diff preview", () => {
+	it("renders a pending overwrite preview", () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-write-pending-success-"));
+		writeFileSync(resolve(cwd, "sample.txt"), "old value\n", "utf-8");
+		const tool = getWriteTool();
+		const context: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined };
+
+		const rendered = tool.renderCall({ path: "sample.txt", content: "new value\n" }, theme, context);
+		const text = textOf(rendered);
+
+		expect(text).toContain("pending overwrite");
+		expect(text).toContain("-1 old value");
+		expect(text).toContain("+1 new value");
+	});
+});


### PR DESCRIPTION
## Summary

Adds a read-only **pending diff preview** for streamed `edit` and `write` tool calls. While args are still streaming, `renderCall` now projects the proposed mutation against the current workspace file content and renders a unified-line diff under the existing one-line summary — so users can see *what is about to happen* without waiting for `execute` to finish.

Mutation-safety, the per-file mutation queue, `execute` semantics, `renderResult`, and structured `ptcValue` contracts are **untouched**. The preview is purely additive on the `renderCall` path.

Resolves #161.

---

## What the user sees

```
edit /…/sample.ts
pending edit
-1 const value = 1;
+1 const value = 2;
```

```
✏️ write /…/sample.txt
pending overwrite
-1 old value
+1 new value
```

For new files, the header reads `pending create` and the previous content is treated as empty. When projection cannot run deterministically (missing args, ambiguous `replace`, stale anchors, oversize, etc.) the tool falls back to the original one-line summary — no diff body, no crash.

---

## Changes

### F1 — New `src/pending-diff-preview.ts` module

Pure-read projection primitives + a render-context cache. Imports only `existsSync` / `readFileSync` / `realpathSync` / `statSync` from `node:fs` — no fs-mutating APIs (`writeFileSync`, `mkdir*`, etc.), so AC 19 is provable by `grep`, not just by tests.

Public surface:

```ts
export const PENDING_DIFF_MAX_BYTES = 1024 * 1024;

export interface PendingDiffPreviewData {
  filePath: string;
  previousContent: string;
  nextContent: string;
  fileExistedBeforeWrite: boolean;
  headerLabel: "pending edit" | "pending overwrite" | "pending create";
  diff: string;
}

export type PendingDiffPreviewResult =
  | { type: "ok"; data: PendingDiffPreviewData }
  | { type: "skip"; reason: string };

export function buildPendingWritePreviewData(
  input: { path?: unknown; content?: unknown },
  cwd: string,
): PendingDiffPreviewResult;

export async function buildPendingEditPreviewData(
  input: PendingEditInput,
  cwd: string,
): Promise<PendingDiffPreviewResult>;

export function buildEditPreviewKey(input: PendingEditInput): string | undefined;
export function buildWritePreviewKey(
  input: { path?: unknown; content?: unknown },
): string | undefined;

export function resolvePendingDiffPreview<T extends PendingDiffPreviewResult>(
  context: { state?: Record<string, PendingDiffPreviewCacheSlot<T>>;
             invalidate?: () => void } | undefined,
  stateKey: string,
  previewKey: string | undefined,
  compute: () => T | Promise<T>,
): T | undefined;
```

Projection model:

| Variant | Projection |
|---|---|
| `replace { old_text, new_text }` | Reads workspace file, applies exact text replacement. **Succeeds only when `old_text` occurs exactly once**; otherwise `skip`. |
| `set_line` / `replace_lines` / `insert_after` | Batched and applied through `applyHashlineEdits`. Any anchor / hash failure → `skip`. |
| `replace_symbol { symbol, new_body }` | Runs through `replaceSymbol(...)`. Unresolved / ambiguous / unsupported → `skip`. |
| unknown | `skip("unsupported edit variant")` |

Workspace / size / failure guards:

- `resolveWorkspacePreviewPath` `realpathSync`-resolves both `cwd` and the target. Existing entries that resolve outside `cwd` are rejected (`skip("path outside workspace")`), so absolute paths and escaping symlinks can never reach `readFileSync`.
- `PENDING_DIFF_MAX_BYTES = 1 MB`, applied to file size in `readUtf8File` *and* to proposed write content in `buildPendingWritePreviewData`.
- Every projection path is wrapped to return `{type:"ok"}` or `{type:"skip"}` — never throws. `resolvePendingDiffPreview` adds final try/catch + `.catch` around sync and async `compute`, guaranteeing `renderCall` itself never throws.

Render-context cache:

- `resolvePendingDiffPreview` caches results under `context.state[stateKey]` keyed by `previewKey`. Repeated `renderCall` invocations with the same args reuse the cached `data` without re-reading the file or rerunning the projection.
- For async projections it marks the slot `pending`, fires off the compute, and invokes `context.invalidate?.()` when the result is ready so the UI re-renders.

### F2 — `src/edit.ts` wires preview into `renderCall`

`renderCall` gains a third `context` arg (`{ cwd, state, invalidate, lastComponent, … }`). It calls `resolvePendingDiffPreview` → `buildPendingEditPreviewData` and appends the preview to the existing summary via `formatPendingPreviewText`. `execute`, `renderResult`, and the schema are unchanged.

### F3 — `src/write.ts` wires preview into `renderCall`

Same shape as F2: new `context` arg, `resolvePendingDiffPreview` → `buildPendingWritePreviewData`, append via `formatPendingWritePreviewText`. `execute` and `renderResult` are unchanged.

---

## Acceptance Criteria

- [x] **AC 1** — `edit.renderCall` renders a pending diff preview during partial/incomplete streamed args when the edit args contain a path, ≥1 complete edit op, and projection succeeds.
- [x] **AC 2** — `write.renderCall` renders a pending diff preview during partial/incomplete streamed args when the write args contain a path, content, and projection succeeds.
- [x] **AC 3** — `edit.renderCall` continues to render the existing one-line summary when no edit preview is available.
- [x] **AC 4** — `write.renderCall` continues to render the existing one-line summary when no write preview is available.
- [x] **AC 5** — `replace` edit preview projection reads the current workspace file and applies each `replace.old_text` to `replace.new_text` by exact text matching.
- [x] **AC 6** — `replace` edit preview projection succeeds only when each `old_text` occurs exactly once in the projected content at the time it is applied.
- [x] **AC 7** — `replace` edit preview projection falls back to summary-only behavior without throwing when `old_text` is empty, missing, unmatched, or ambiguous.
- [x] **AC 8** — Hashline edit preview projection for `set_line`, `replace_lines`, and `insert_after` uses `applyHashlineEdits` against the current workspace file content.
- [x] **AC 9** — Hashline edit preview projection falls back to summary-only behavior without throwing when anchors are invalid, stale, missing, out of range, or fail hash validation.
- [x] **AC 10** — `replace_symbol` edit preview projection uses `replaceSymbol` against current workspace file content.
- [x] **AC 11** — `replace_symbol` edit preview output includes the projected replacement for the resolved symbol range when projection succeeds.
- [x] **AC 12** — `replace_symbol` edit preview projection falls back to summary-only behavior without throwing when the symbol is unsupported, not found, ambiguous, invalid, or otherwise unresolved.
- [x] **AC 13** — Existing-file `write` preview projection compares proposed `content` against current on-disk file content.
- [x] **AC 14** — Missing-file `write` preview projection treats proposed `content` as a new-file preview.
- [x] **AC 15** — Existing-file `write` preview labels the preview as `pending overwrite`.
- [x] **AC 16** — Missing-file `write` preview labels the preview as `pending create`.
- [x] **AC 17** — Projection failures in `renderCall` never throw to the caller.
- [x] **AC 18** — A failed or skipped preview does not alter later `edit.execute` or `write.execute` behavior for the same args.
- [x] **AC 19** — Preview generation does not write files or mutate project state.
- [x] **AC 20** — Preview file reads are allowed only for paths that resolve inside the render context `cwd`.
- [x] **AC 21** — Preview file reads reject absolute paths outside `cwd`.
- [x] **AC 22** — Preview file reads reject symlinks whose real path escapes `cwd`.
- [x] **AC 23** — Preview generation is skipped for files or proposed content above a conservative size limit (`PENDING_DIFF_MAX_BYTES = 1 MB`).
- [x] **AC 24** — Repeated `renderCall` calls with the same projection key reuse cached preview data instead of repeating file reads or projection work.
- [x] **AC 25** — The projection cache key changes when relevant streamed args change, including path, edit operations, replacement text, symbol name, and write content.
- [x] **AC 26** — Final `renderResult` behavior for `edit` remains compatible with existing tests and visible output expectations (untouched at source level).
- [x] **AC 27** — Final `renderResult` behavior for `write` remains compatible with existing tests and visible output expectations (untouched at source level).
- [x] **AC 28** — Structured `ptcValue` contracts for `edit.execute` and `write.execute` remain unchanged (both `execute` bodies untouched).
- [x] **AC 29** — Tests cover successful preview projection for `replace`, hashline anchored edits, `replace_symbol`, existing-file write, and new-file write.
- [x] **AC 30** — Tests cover fallback behavior for `replace`, hashline anchored edits, `replace_symbol`, write projection, and workspace-boundary failures.
- [x] **AC 31** — `npm run typecheck` passes.

---

## New Tests (17)

| File | Coverage |
|---|---|
| `tests/pending-diff-preview-replace-success.test.ts` | exact-1-match `replace` projection produces correct diff |
| `tests/pending-diff-preview-replace-fallback.test.ts` | ambiguous `old_text` → `skip` (no throw) |
| `tests/pending-diff-preview-hashline-success.test.ts` | `set_line` anchored projection via `applyHashlineEdits` |
| `tests/pending-diff-preview-hashline-fallback.test.ts` | out-of-range anchor → `skip` |
| `tests/pending-diff-preview-replace-symbol-success.test.ts` | `replace_symbol` projection includes resolved replacement |
| `tests/pending-diff-preview-replace-symbol-fallback.test.ts` | unresolved symbol → `skip` |
| `tests/pending-diff-preview-write-overwrite.test.ts` | existing file → `pending overwrite` + diff |
| `tests/pending-diff-preview-write-create.test.ts` | missing file → `pending create` + diff |
| `tests/pending-diff-preview-outside-path.test.ts` | absolute path outside `cwd` → `skip` |
| `tests/pending-diff-preview-symlink-escape.test.ts` | symlink whose `realpath` escapes `cwd` → `skip` |
| `tests/pending-diff-preview-size-limit.test.ts` | >1 MB content → `skip` |
| `tests/pending-diff-preview-cache.test.ts` | sync + async cache reuse + invalidate-on-resolve |
| `tests/pending-diff-preview-cache-exception.test.ts` | sync `compute` throw → cached `skip` |
| `tests/edit-pending-diff-render-success.test.ts` | render-level: `pending edit` + diff lines visible |
| `tests/edit-pending-diff-render-fallback.test.ts` | render-level: skip preserves summary; later `execute` still mutates correctly |
| `tests/write-pending-diff-render-success.test.ts` | render-level: `pending overwrite` + diff lines visible |
| `tests/write-pending-diff-render-fallback.test.ts` | render-level: skip preserves summary; later `execute` still writes correctly |

---

## Verification

```
$ npm test
 Test Files  295 passed (295)
      Tests  1324 passed (1324)
   Duration  19.72s

$ npm run typecheck
> tsc --noEmit
[exit 0, no diagnostics]
```

`impact registerEditTool registerWriteTool` (behavior_change) surfaced only the four new render tests, all of which ran in the same fresh suite. Pre-existing `edit` / `write` `execute` / `renderResult` / ptcValue tests (`tests/ptc-error-edit-*`, `tests/ptc-error-hash-mismatch.test.ts`, `tests/edit-replace-symbol.test.ts`, `tests/write-mutation-queue.test.ts`, `tests/repro-052-edit-diagnostic-control-chars.test.ts`, …) continue to pass unchanged.

---

## Files Changed

```
$ git diff --stat main
 src/edit.ts  | 31 ++++++++++++++++++++++---------
 src/write.ts | 24 ++++++++++++++++++++++--
 2 files changed, 44 insertions(+), 11 deletions(-)
```

Plus the new module + 17 tests checked in on this branch.

---

## Review (Codex + adversarial)

Both `/codex-review` and `/codex-adversarial-review` were run against `main` with focus text covering boundary guards, ordering, cache, async race, and edge cases. Findings adopted/categorized in `.megapowers/plans/161-stream-pending-diff-preview-during-edit-/code-review.md`. Summary:

- **Critical:** None
- **Important (tracked for follow-up, not blocking):**
  1. Preview projects edits in **input order**, while `execute` stages them as `replace_symbol → anchored → replace`. Mixed-variant edits can show a diff that differs from the post-execute file. Spec-compliant (`skip` is allowed; AC 1 doesn't mandate post-execute fidelity) but a real fidelity gap worth a shared-projection refactor.
  2. Cache key `JSON.stringify`s full content on every stream tick before the size guard runs. Cheap fix: short-circuit oversized inputs before key construction, or replace with a bounded digest.
- **Minor:** `replace.all` / `replace.fuzzy` are ignored by preview (spec-compliant skip — AC 5–7 mandate exact-1-match); missing-file `write` doesn't `realpath` a symlinked parent (preview never writes, so AC 19 / 22 still hold, but the label is misleading); one dead branch in `isInsidePath`.

---

## Notes for reviewers

- Read order: `src/pending-diff-preview.ts` (the new module), then `src/edit.ts` `renderCall`, then `src/write.ts` `renderCall`. `execute` and `renderResult` bodies are untouched — confirm with `git diff src/edit.ts src/write.ts`.
- The `replace_symbol` projection reuses Pi's `replaceSymbol(...)` async API on the rolling content buffer; the cache primitive handles the async return without blocking the render thread.
- Workspace-boundary tests use `mkdtempSync` for hermeticity and call into `realpathSync`, so they exercise the real symlink-resolution code path rather than mocked filesystem layers.

---

## Follow-ups (out of scope)

Filing as a focused next issue (`pending-diff-preview-execution-parity-and-cache-cost`):

- Extract a shared `projectEdits(content, edits)` pure helper from `src/edit.ts` and have the preview call it, so preview and execute share staging (`replace_symbol → anchored → replace`) by construction.
- Short-circuit the cache key when payload size exceeds `PENDING_DIFF_MAX_BYTES`, and consider a bounded digest key (path + sha1) longer-term.
- `realpathSync` the parent of a missing target in `resolveWorkspacePreviewPath` so `pending create` labels can't lie about workspace containment.
- Drop the dead `resolve(rel).startsWith("..")` branch in `isInsidePath`.
