### PR TITLE
feat: emit structured diff data for edit/write (#166)

### DIFF
--- a/prompts/edit.md
+++ b/prompts/edit.md
@@ -73,3 +73,32 @@ Syntax validation runs before writing when supported:
 - `PI_HASHLINE_SYNTAX_VALIDATE` can set the default mode.
 
 Existing syntax errors are tolerated; the warning is for newly introduced parser errors.
+
+## Diff data contract
+
+Successful `edit` results include `details.diffData` and `details.ptcValue.diffData` in addition to the existing `details.diff` / `ptcValue.diff` string fields. The string fields remain the backward-compatible human-readable fallback.
+
+`diffData` is a stable versioned contract:
+
+```ts
+type DiffData = {
+  version: 1;
+  entries: Array<
+    | { kind: "context"; oldLine: number; newLine: number; text: string }
+    | { kind: "add"; newLine: number; text: string }
+    | { kind: "remove"; oldLine: number; text: string }
+    | { kind: "meta"; text: string }
+  >;
+  stats: { added: number; removed: number; context: number };
+  language?: string;
+  blockRanges?: Array<{ kind: "add" | "remove"; startLine: number; endLine: number }>;
+  inlineDiffs?: Array<{
+    removeLineIndex: number;
+    addLineIndex: number;
+    removeSpans: Array<{ kind: "equal" | "remove" | "add"; text: string }>;
+    addSpans: Array<{ kind: "equal" | "remove" | "add"; text: string }>;
+  }>;
+};
+```
+
+For compact one-line hashline diffs, `details.diff` remains compact, while `diffData.entries` uses expanded remove/add rows so renderers can show inline word changes without breaking hashline output.

--- a/prompts/write.md
+++ b/prompts/write.md
@@ -15,3 +15,32 @@ Existing files are overwritten without confirmation. Binary-looking content is w
 ## Output
 
 Successful text writes return `LINE:HASH|content`; display hashlines escape control characters for safe rendering. Visible output is capped at 2000 lines or 50 KB, but full anchors remain available in `ptcValue`.
+
+## Diff data contract
+
+Successful text `write` results include additive final `details.diff`, `details.ptcValue.diff`, `details.diffData`, and `details.ptcValue.diffData` fields. The string fields remain the backward-compatible human-readable fallback.
+
+`diffData` is a stable versioned contract:
+
+```ts
+type DiffData = {
+  version: 1;
+  entries: Array<
+    | { kind: "context"; oldLine: number; newLine: number; text: string }
+    | { kind: "add"; newLine: number; text: string }
+    | { kind: "remove"; oldLine: number; text: string }
+    | { kind: "meta"; text: string }
+  >;
+  stats: { added: number; removed: number; context: number };
+  language?: string;
+  blockRanges?: Array<{ kind: "add" | "remove"; startLine: number; endLine: number }>;
+  inlineDiffs?: Array<{
+    removeLineIndex: number;
+    addLineIndex: number;
+    removeSpans: Array<{ kind: "equal" | "remove" | "add"; text: string }>;
+    addSpans: Array<{ kind: "equal" | "remove" | "add"; text: string }>;
+  }>;
+};
+```
+
+For compact one-line hashline diffs, `details.diff` remains compact, while `diffData.entries` uses expanded remove/add rows so renderers can show inline word changes without breaking hashline output.

--- a/src/diff-data.ts
+++ b/src/diff-data.ts
@@ -1,0 +1,303 @@
+export type DiffEntry =
+  | { kind: "context"; oldLine: number; newLine: number; text: string }
+  | { kind: "add"; newLine: number; text: string }
+  | { kind: "remove"; oldLine: number; text: string }
+  | { kind: "meta"; text: string };
+
+export type DiffSpan =
+  | { kind: "equal"; text: string }
+  | { kind: "add"; text: string }
+  | { kind: "remove"; text: string };
+
+export type InlineDiff = {
+  removeLineIndex: number;
+  addLineIndex: number;
+  removeSpans: DiffSpan[];
+  addSpans: DiffSpan[];
+};
+
+export type DiffBlockRange = {
+  kind: "add" | "remove";
+  startLine: number;
+  endLine: number;
+};
+
+export type DiffData = {
+  version: 1;
+  entries: DiffEntry[];
+  stats: { added: number; removed: number; context: number };
+  language?: string;
+  blockRanges?: DiffBlockRange[];
+  inlineDiffs?: InlineDiff[];
+};
+
+export type BuildDiffDataInput = {
+  path: string;
+  oldContent: string;
+  newContent: string;
+  diff: string;
+  blockRanges?: DiffBlockRange[];
+};
+
+export const MAX_INLINE_DIFF_LINE_LENGTH = 4096;
+export const MAX_INLINE_DIFF_TOKENS = 512;
+export const MAX_INLINE_DIFF_CELLS = 200_000;
+export const MAX_INLINE_DIFF_PAIRS = 200;
+
+const INLINE_SIMILARITY_THRESHOLD = 0.35;
+const INLINE_TOKEN_PATTERN = /([A-Za-z_$][\w$]*|\d+|\s+|[^A-Za-z_$\w\s]+)/gu;
+
+const LANGUAGE_BY_EXTENSION = new Map<string, string>([
+  [".ts", "typescript"],
+  [".tsx", "typescript"],
+  [".js", "javascript"],
+  [".jsx", "javascript"],
+  [".py", "python"],
+  [".rs", "rust"],
+  [".java", "java"],
+]);
+
+function inferLanguage(path: string): string | undefined {
+  const extensionMatch = path.match(/\.[^.\/\\]+$/);
+  if (!extensionMatch) return undefined;
+  return LANGUAGE_BY_EXTENSION.get(extensionMatch[0].toLowerCase());
+}
+
+function parseFullDiffEntries(diff: string): DiffEntry[] {
+  const entries: DiffEntry[] = [];
+  let nextOldLine = 1;
+  let nextNewLine = 1;
+
+  for (const line of diff ? diff.split("\n") : []) {
+    const removeMatch = line.match(/^-\s*(\d+) (.*)$/);
+    if (removeMatch) {
+      const oldLine = Number(removeMatch[1]);
+      entries.push({ kind: "remove", oldLine, text: removeMatch[2] ?? "" });
+      nextOldLine = oldLine + 1;
+      continue;
+    }
+
+    const addMatch = line.match(/^\+\s*(\d+) (.*)$/);
+    if (addMatch) {
+      const newLine = Number(addMatch[1]);
+      entries.push({ kind: "add", newLine, text: addMatch[2] ?? "" });
+      nextNewLine = newLine + 1;
+      continue;
+    }
+
+    const contextMatch = line.match(/^ \s*(\d+) (.*)$/);
+    if (contextMatch) {
+      const oldLine = Number(contextMatch[1]);
+      const lineDelta = nextNewLine - nextOldLine;
+      const newLine = oldLine + lineDelta;
+      entries.push({ kind: "context", oldLine, newLine, text: contextMatch[2] ?? "" });
+      nextOldLine = oldLine + 1;
+      nextNewLine = newLine + 1;
+      continue;
+    }
+
+    entries.push({ kind: "meta", text: line });
+  }
+
+  void nextOldLine;
+  return entries;
+}
+
+function parseCompactDiffEntries(diff: string, oldContent: string, newContent: string): DiffEntry[] | undefined {
+  const oldLines = oldContent.split("\n");
+  const newLines = newContent.split("\n");
+
+  const compactDelete = diff.match(/^(\d+):[0-9a-f]{3}\|(.*) → \[deleted\]$/);
+  if (compactDelete) {
+    const oldLine = Number(compactDelete[1]);
+    const text = compactDelete[2] ?? "";
+    if (oldLines[oldLine - 1] === text) return [{ kind: "remove", oldLine, text }];
+  }
+
+  const compactPrefix = diff.match(/^(\d+):[0-9a-f]{3}\|/);
+  if (!compactPrefix) return undefined;
+
+  const oldLine = Number(compactPrefix[1]);
+  const oldTextStart = compactPrefix[0].length;
+  const separatorPattern = / → (\d+):[0-9a-f]{3}\|/g;
+  let separator: RegExpExecArray | null;
+  while ((separator = separatorPattern.exec(diff)) !== null) {
+    const newLine = Number(separator[1]);
+    const oldText = diff.slice(oldTextStart, separator.index);
+    const newText = diff.slice(separator.index + separator[0].length);
+    if (oldLines[oldLine - 1] === oldText && newLines[newLine - 1] === newText) {
+      return [
+        { kind: "remove", oldLine, text: oldText },
+        { kind: "add", newLine, text: newText },
+      ];
+    }
+  }
+
+  return undefined;
+}
+
+function buildStats(entries: DiffEntry[]): DiffData["stats"] {
+  return entries.reduce(
+    (stats, entry) => {
+      if (entry.kind === "add") stats.added++;
+      else if (entry.kind === "remove") stats.removed++;
+      else if (entry.kind === "context") stats.context++;
+      return stats;
+    },
+    { added: 0, removed: 0, context: 0 },
+  );
+}
+
+function tokenizeInlineDiff(text: string): string[] {
+  return text.match(INLINE_TOKEN_PATTERN) ?? (text ? [text] : []);
+}
+
+function longestCommonSubsequence(a: string[], b: string[]): Array<[number, number]> {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const table: number[][] = Array.from({ length: rows }, () => Array<number>(cols).fill(0));
+
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      table[i]![j] = a[i] === b[j] ? table[i + 1]![j + 1]! + 1 : Math.max(table[i + 1]![j]!, table[i]![j + 1]!);
+    }
+  }
+
+  const pairs: Array<[number, number]> = [];
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      pairs.push([i, j]);
+      i++;
+      j++;
+    } else if (table[i + 1]![j]! >= table[i]![j + 1]!) {
+      i++;
+    } else {
+      j++;
+    }
+  }
+
+  return pairs;
+}
+
+function pushMergedSpan(spans: DiffSpan[], span: DiffSpan): void {
+  if (!span.text) return;
+  const previous = spans[spans.length - 1];
+  if (previous?.kind === span.kind) {
+    previous.text += span.text;
+    return;
+  }
+  spans.push({ ...span });
+}
+
+function buildInlineSpans(removeText: string, addText: string): { removeSpans: DiffSpan[]; addSpans: DiffSpan[] } | undefined {
+  if (removeText.length > MAX_INLINE_DIFF_LINE_LENGTH || addText.length > MAX_INLINE_DIFF_LINE_LENGTH) return undefined;
+
+  const removeTokens = tokenizeInlineDiff(removeText);
+  const addTokens = tokenizeInlineDiff(addText);
+  if (!removeTokens.length || !addTokens.length) return undefined;
+  if (removeTokens.length > MAX_INLINE_DIFF_TOKENS || addTokens.length > MAX_INLINE_DIFF_TOKENS) return undefined;
+  if ((removeTokens.length + 1) * (addTokens.length + 1) > MAX_INLINE_DIFF_CELLS) return undefined;
+
+  const pairs = longestCommonSubsequence(removeTokens, addTokens);
+  const meaningfulRemoveTokenCount = removeTokens.filter((token) => token.trim().length > 0).length;
+  const meaningfulAddTokenCount = addTokens.filter((token) => token.trim().length > 0).length;
+  const meaningfulEqualTokenCount = pairs.filter(([removeIndex, addIndex]) => {
+    const removeToken = removeTokens[removeIndex] ?? "";
+    const addToken = addTokens[addIndex] ?? "";
+    return removeToken === addToken && removeToken.trim().length > 0 && addToken.trim().length > 0;
+  }).length;
+  const similarity = meaningfulEqualTokenCount / Math.max(meaningfulRemoveTokenCount, meaningfulAddTokenCount);
+  if (similarity < INLINE_SIMILARITY_THRESHOLD) return undefined;
+
+  const removeSpans: DiffSpan[] = [];
+  const addSpans: DiffSpan[] = [];
+  let removeCursor = 0;
+  let addCursor = 0;
+
+  for (const [removeIndex, addIndex] of pairs) {
+    if (removeCursor < removeIndex) {
+      pushMergedSpan(removeSpans, { kind: "remove", text: removeTokens.slice(removeCursor, removeIndex).join("") });
+    }
+    if (addCursor < addIndex) {
+      pushMergedSpan(addSpans, { kind: "add", text: addTokens.slice(addCursor, addIndex).join("") });
+    }
+    pushMergedSpan(removeSpans, { kind: "equal", text: removeTokens[removeIndex]! });
+    pushMergedSpan(addSpans, { kind: "equal", text: addTokens[addIndex]! });
+    removeCursor = removeIndex + 1;
+    addCursor = addIndex + 1;
+  }
+
+  if (removeCursor < removeTokens.length) {
+    pushMergedSpan(removeSpans, { kind: "remove", text: removeTokens.slice(removeCursor).join("") });
+  }
+  if (addCursor < addTokens.length) {
+    pushMergedSpan(addSpans, { kind: "add", text: addTokens.slice(addCursor).join("") });
+  }
+
+  if (!removeSpans.some((span) => span.kind === "remove") || !addSpans.some((span) => span.kind === "add")) return undefined;
+  return { removeSpans, addSpans };
+}
+
+function buildInlineDiffs(entries: DiffEntry[]): InlineDiff[] | undefined {
+  const inlineDiffs: InlineDiff[] = [];
+  let remainingPairs = MAX_INLINE_DIFF_PAIRS;
+
+  for (let index = 0; index < entries.length;) {
+    if (entries[index]?.kind !== "remove") {
+      index++;
+      continue;
+    }
+
+    const removeStart = index;
+    while (entries[index]?.kind === "remove") index++;
+    const addStart = index;
+    while (entries[index]?.kind === "add") index++;
+
+    const removeCount = addStart - removeStart;
+    const addCount = index - addStart;
+    if (removeCount === 0 || addCount === 0 || removeCount !== addCount) continue;
+
+    for (let offset = 0; offset < removeCount; offset++) {
+      if (remainingPairs <= 0) break;
+      remainingPairs--;
+
+      const removeIndex = removeStart + offset;
+      const addIndex = addStart + offset;
+      const removeEntry = entries[removeIndex];
+      const addEntry = entries[addIndex];
+      if (removeEntry?.kind !== "remove" || addEntry?.kind !== "add") continue;
+
+      const spans = buildInlineSpans(removeEntry.text, addEntry.text);
+      if (!spans) continue;
+
+      inlineDiffs.push({
+        removeLineIndex: removeIndex,
+        addLineIndex: addIndex,
+        removeSpans: spans.removeSpans,
+        addSpans: spans.addSpans,
+      });
+    }
+  }
+
+  return inlineDiffs.length ? inlineDiffs : undefined;
+}
+
+function finalizeDiffData(path: string, entries: DiffEntry[], blockRanges: DiffBlockRange[] | undefined): DiffData {
+  const language = inferLanguage(path);
+  const inlineDiffs = buildInlineDiffs(entries);
+  return {
+    version: 1,
+    entries,
+    stats: buildStats(entries),
+    ...(language ? { language } : {}),
+    ...(blockRanges?.length ? { blockRanges: [...blockRanges] } : {}),
+    ...(inlineDiffs ? { inlineDiffs } : {}),
+  };
+}
+
+export function buildDiffData(input: BuildDiffDataInput): DiffData {
+  const entries = parseCompactDiffEntries(input.diff, input.oldContent, input.newContent) ?? parseFullDiffEntries(input.diff);
+  return finalizeDiffData(input.path, entries, input.blockRanges);
+}

--- a/src/edit-output.ts
+++ b/src/edit-output.ts
@@ -1,10 +1,12 @@
 import { countEditTypes, parseDiffStats } from "./edit-render-helpers.js";
 import { buildPtcEditResult, type SemanticSummary } from "./ptc-value.js";
 import { buildContextHygieneMetadata, buildFileResource, type ContextHygieneMetadata } from "./context-hygiene.js";
+import type { DiffData } from "./diff-data.js";
 export interface BuildEditOutputInput {
   path: string;
   displayPath: string;
   diff: string;
+  diffData?: DiffData;
   firstChangedLine: number | undefined;
   warnings: string[];
   noopEdits: unknown[];
@@ -77,6 +79,7 @@ export function buildEditOutput(input: BuildEditOutputInput): EditOutputResult {
       path: input.path,
       summary,
       diff: input.diff,
+      ...(input.diffData ? { diffData: input.diffData } : {}),
       firstChangedLine: input.firstChangedLine,
       warnings: input.warnings,
       noopEdits: input.noopEdits,

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -17,6 +17,7 @@ import { validateSyntaxRegression } from "./edit-syntax-validate.js";
 import { resolveSyntaxValidateMode, type SyntaxValidateOptions } from "./syntax-validate-mode.js";
 import { replaceSymbol } from "./replace-symbol.js";
 import { buildEditPreviewKey, buildPendingEditPreviewData, resolvePendingDiffPreview, type PendingDiffPreviewResult } from "./pending-diff-preview.js";
+import { buildDiffData, type DiffBlockRange } from "./diff-data.js";
 
 const EDIT_PENDING_PREVIEW_STATE_KEY = "hashline-edit-pending-preview";
 
@@ -489,6 +490,18 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			}
 
 			const diffResult = generateCompactOrFullDiff(originalNormalized, result);
+			const blockRanges: DiffBlockRange[] = rsProbeResults.map((probe) => ({
+				kind: "remove" as const,
+				startLine: probe.range.start,
+				endLine: probe.range.end,
+			}));
+			const diffData = buildDiffData({
+				path: absolutePath,
+				oldContent: originalNormalized,
+				newContent: result,
+				diff: diffResult.diff,
+				...(blockRanges.length ? { blockRanges } : {}),
+			});
 			const warnings: string[] = [];
 			if (anchorResult.warnings?.length) warnings.push(...anchorResult.warnings);
 			if (legacyNormalizationWarning) warnings.push(legacyNormalizationWarning);
@@ -518,6 +531,7 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				path: absolutePath,
 				displayPath: path,
 				diff: diffResult.diff,
+				diffData,
 				firstChangedLine: anchorResult.firstChangedLine ?? diffResult.firstChangedLine,
 				warnings,
 				noopEdits: anchorResult.noopEdits ?? [],
@@ -530,16 +544,19 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				content: [{ type: "text", text: builtOutput.text }],
 				details: {
 					diff: diffResult.diff,
+					diffData,
 					firstChangedLine: anchorResult.firstChangedLine ?? diffResult.firstChangedLine,
 					ptcValue: builtOutput.ptcValue,
 					contextHygiene: builtOutput.contextHygiene,
 				} as EditToolDetails & {
+					diffData: typeof diffData;
 					ptcValue: {
 						tool: string;
 						ok: boolean;
 						path: string;
 						summary: string;
 						diff: string;
+						diffData: typeof diffData;
 						firstChangedLine: number | undefined;
 						warnings: string[];
 						noopEdits: unknown[];

--- a/src/ptc-value.ts
+++ b/src/ptc-value.ts
@@ -1,4 +1,5 @@
 import { computeLineHash, escapeControlCharsForDisplay } from "./hashline.js";
+import type { DiffData } from "./diff-data.js";
 
 export interface PtcLine {
   line: number;
@@ -53,6 +54,7 @@ export interface PtcEditResult {
   path: string;
   summary: string;
   diff: string;
+  diffData?: DiffData;
   firstChangedLine: number | undefined;
   warnings: string[];
   noopEdits: unknown[];
@@ -121,6 +123,7 @@ export function buildPtcEditResult(input: {
   path: string;
   summary: string;
   diff: string;
+  diffData?: DiffData;
   firstChangedLine: number | undefined;
   warnings: string[];
   noopEdits: unknown[];
@@ -132,6 +135,7 @@ export function buildPtcEditResult(input: {
     path: input.path,
     summary: input.summary,
     diff: input.diff,
+    ...(input.diffData ? { diffData: input.diffData } : {}),
     firstChangedLine: input.firstChangedLine,
     warnings: [...input.warnings],
     noopEdits: [...input.noopEdits],

--- a/src/write.ts
+++ b/src/write.ts
@@ -1,7 +1,7 @@
 import { withFileMutationQueue, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, relative } from "node:path";
 import { resolveToCwd } from "./path-utils.js";
 import { ensureHashInit, formatHashlineDisplay } from "./hashline.js";
@@ -12,6 +12,8 @@ import { formatFileMapWithBudget } from "./readmap/formatter.js";
 import { buildContextHygieneMetadata, buildFileResource, type ContextHygieneMetadata } from "./context-hygiene.js";
 import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 import { buildPendingWritePreviewData, buildWritePreviewKey, resolvePendingDiffPreview, type PendingDiffPreviewResult } from "./pending-diff-preview.js";
+import { generateCompactOrFullDiff, normalizeToLF } from "./edit-diff.js";
+import { buildDiffData, type DiffData } from "./diff-data.js";
 
 const WRITE_PENDING_PREVIEW_STATE_KEY = "hashline-write-pending-preview";
 
@@ -33,7 +35,12 @@ const WRITE_PROMPT_METADATA = defineToolPromptMetadata({
   ],
 });
 
-export interface WriteResult {
+type WriteDiffFields = {
+  diff?: string;
+  diffData?: DiffData;
+};
+
+export interface WriteResult extends WriteDiffFields {
   text: string;
   warnings: string[];
   ptcValue: {
@@ -41,9 +48,35 @@ export interface WriteResult {
     path: string;
     lines: PtcLine[];
     warnings: PtcWarning[];
+    diff?: string;
+    diffData?: DiffData;
     map?: { appended: boolean };
   };
   contextHygiene: ContextHygieneMetadata;
+}
+
+function readPreviousTextForDiff(filePath: string): string {
+  try {
+    if (!existsSync(filePath)) return "";
+    const previous = readFileSync(filePath);
+    if (looksLikeBinary(previous)) return "";
+    return previous.toString("utf-8");
+  } catch {
+    return "";
+  }
+}
+
+function generateWriteDiff(previousContent: string, nextContent: string): { diff: string; firstChangedLine: number | undefined } {
+  if (previousContent !== "") return generateCompactOrFullDiff(previousContent, nextContent);
+  const normalizedNext = normalizeToLF(nextContent);
+  if (normalizedNext === "") return { diff: "", firstChangedLine: undefined };
+  const lines = normalizedNext.split("\n");
+  if (lines[lines.length - 1] === "") lines.pop();
+  const width = String(lines.length).length;
+  return {
+    diff: lines.map((line, index) => `+${String(index + 1).padStart(width, " ")} ${line}`).join("\n"),
+    firstChangedLine: 1,
+  };
 }
 
 export interface WriteToolOptions {
@@ -111,6 +144,7 @@ export async function executeWrite(opts: {
   await ensureHashInit();
 
   const { path: filePath, content, map: requestMap, cwd } = opts;
+  const previousContent = readPreviousTextForDiff(filePath);
 
   // Create parent directories
   try {
@@ -193,15 +227,28 @@ export async function executeWrite(opts: {
   }
 
   const displayPath = cwd ? relative(cwd, filePath) || filePath : filePath;
+  const normalizedPrevious = normalizeToLF(previousContent);
+  const normalizedNext = normalizeToLF(content);
+  const diffResult = generateWriteDiff(normalizedPrevious, normalizedNext);
+  const diffData = buildDiffData({
+    path: filePath,
+    oldContent: normalizedPrevious,
+    newContent: normalizedNext,
+    diff: diffResult.diff,
+  });
 
   return {
     text,
     warnings,
+    diff: diffResult.diff,
+    diffData,
     ptcValue: {
       tool: "write",
       path: displayPath,
       lines: ptcLines,
       warnings: ptcWarnings,
+      diff: diffResult.diff,
+      diffData,
       ...(requestMap !== undefined ? { map: { appended: mapAppended } } : {}),
     },
     contextHygiene,
@@ -284,6 +331,8 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
       return {
         content: [{ type: "text" as const, text: result.text }],
         details: {
+          ...(result.diff !== undefined ? { diff: result.diff } : {}),
+          ...(result.diffData !== undefined ? { diffData: result.diffData } : {}),
           ptcValue: result.ptcValue,
           warnings: result.warnings,
           contextHygiene: result.contextHygiene,

--- a/tests/diff-data-compact.test.ts
+++ b/tests/diff-data-compact.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { generateCompactOrFullDiff } from "../src/edit-diff.js";
+import { ensureHashInit } from "../src/hashline.js";
+import { buildDiffData } from "../src/diff-data.js";
+
+describe("DiffData compact hashline diffs", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("keeps compact replacement diff strings while expanding structured rows", () => {
+    const oldContent = "line one\nline two\nline three";
+    const newContent = "line one\nline TWO\nline three";
+    const { diff } = generateCompactOrFullDiff(oldContent, newContent);
+
+    const diffData = buildDiffData({ path: "sample.ts", oldContent, newContent, diff });
+
+    expect(diff).toMatch(/^2:[0-9a-f]{3}\|line two → 2:[0-9a-f]{3}\|line TWO$/);
+    expect(diffData.entries).toEqual([
+      { kind: "remove", oldLine: 2, text: "line two" },
+      { kind: "add", newLine: 2, text: "line TWO" },
+    ]);
+    expect(diffData.stats).toEqual({ added: 1, removed: 1, context: 0 });
+  });
+
+  it("uses source contents when compact replacement text contains delimiter-shaped text", () => {
+    const oldContent = "line one\nconst text = 'old';\nline three";
+    const newContent = "line one\nconst text = 'new → 2:def|not a separator';\nline three";
+    const { diff } = generateCompactOrFullDiff(oldContent, newContent);
+
+    const diffData = buildDiffData({ path: "sample.ts", oldContent, newContent, diff });
+
+    expect(diffData.entries).toEqual([
+      { kind: "remove", oldLine: 2, text: "const text = 'old';" },
+      { kind: "add", newLine: 2, text: "const text = 'new → 2:def|not a separator';" },
+    ]);
+  });
+
+  it("keeps compact deletion diff strings while expanding structured rows", () => {
+    const oldContent = "line one\nline two\nline three";
+    const newContent = "line one\nline three";
+    const { diff } = generateCompactOrFullDiff(oldContent, newContent);
+
+    const diffData = buildDiffData({ path: "sample.ts", oldContent, newContent, diff });
+
+    expect(diff).toMatch(/^2:[0-9a-f]{3}\|line two → \[deleted\]$/);
+    expect(diffData.entries).toEqual([{ kind: "remove", oldLine: 2, text: "line two" }]);
+    expect(diffData.stats).toEqual({ added: 0, removed: 1, context: 0 });
+  });
+});

--- a/tests/diff-data-inline.test.ts
+++ b/tests/diff-data-inline.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { generateCompactOrFullDiff, generateDiffString } from "../src/edit-diff.js";
+import { ensureHashInit } from "../src/hashline.js";
+import { buildDiffData, MAX_INLINE_DIFF_LINE_LENGTH, MAX_INLINE_DIFF_PAIRS, MAX_INLINE_DIFF_TOKENS } from "../src/diff-data.js";
+
+function joinSpans(spans: Array<{ text: string }>): string {
+  return spans.map((span) => span.text).join("");
+}
+
+describe("DiffData inline diffs", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("adds inline spans for similar compact rename rows", () => {
+    const oldContent = "function greet(firstName: string) { return firstName; }";
+    const newContent = "function greet(displayName: string) { return displayName; }";
+    const { diff } = generateCompactOrFullDiff(oldContent, newContent);
+
+    const diffData = buildDiffData({ path: "sample.ts", oldContent, newContent, diff });
+
+    expect(diffData.inlineDiffs).toHaveLength(1);
+    const inline = diffData.inlineDiffs![0];
+    expect(inline.removeLineIndex).toBe(0);
+    expect(inline.addLineIndex).toBe(1);
+    expect(joinSpans(inline.removeSpans)).toBe("function greet(firstName: string) { return firstName; }");
+    expect(joinSpans(inline.addSpans)).toBe("function greet(displayName: string) { return displayName; }");
+    expect(inline.removeSpans.some((span) => span.kind === "remove" && span.text.includes("firstName"))).toBe(true);
+    expect(inline.addSpans.some((span) => span.kind === "add" && span.text.includes("displayName"))).toBe(true);
+  });
+
+  it("adds inline spans for a multi-token single-line edit", () => {
+    const oldContent = "const total = price + tax;";
+    const newContent = "const subtotal = price - discount + tax;";
+    const { diff } = generateCompactOrFullDiff(oldContent, newContent);
+
+    const diffData = buildDiffData({ path: "sample.ts", oldContent, newContent, diff });
+
+    expect(diffData.inlineDiffs).toHaveLength(1);
+    const inline = diffData.inlineDiffs![0];
+    expect(joinSpans(inline.removeSpans)).toBe(oldContent);
+    expect(joinSpans(inline.addSpans)).toBe(newContent);
+    expect(inline.removeSpans.some((span) => span.kind === "remove" && span.text.includes("total"))).toBe(true);
+    expect(inline.addSpans.some((span) => span.kind === "add" && span.text.includes("subtotal"))).toBe(true);
+    expect(inline.addSpans.some((span) => span.kind === "add" && span.text.includes("discount"))).toBe(true);
+  });
+
+  it("pairs multi-line replacement rows by hunk-relative position", () => {
+    const oldContent = [
+      "function one(firstName: string) { return firstName; }",
+      "function two(lastName: string) { return lastName; }",
+    ].join("\n");
+    const newContent = [
+      "function one(displayName: string) { return displayName; }",
+      "function two(familyName: string) { return familyName; }",
+    ].join("\n");
+    const { diff } = generateDiffString(oldContent, newContent);
+
+    const diffData = buildDiffData({ path: "sample.ts", oldContent, newContent, diff });
+
+    expect(diffData.inlineDiffs).toHaveLength(2);
+    expect(diffData.inlineDiffs![0]!.removeLineIndex).toBe(0);
+    expect(diffData.inlineDiffs![0]!.addLineIndex).toBe(2);
+    expect(joinSpans(diffData.inlineDiffs![0]!.removeSpans)).toBe("function one(firstName: string) { return firstName; }");
+    expect(joinSpans(diffData.inlineDiffs![0]!.addSpans)).toBe("function one(displayName: string) { return displayName; }");
+    expect(diffData.inlineDiffs![1]!.removeLineIndex).toBe(1);
+    expect(diffData.inlineDiffs![1]!.addLineIndex).toBe(3);
+    expect(joinSpans(diffData.inlineDiffs![1]!.removeSpans)).toBe("function two(lastName: string) { return lastName; }");
+    expect(joinSpans(diffData.inlineDiffs![1]!.addSpans)).toBe("function two(familyName: string) { return familyName; }");
+  });
+
+  it("skips ambiguous unequal remove/add hunks", () => {
+    const oldContent = "const firstName = user.firstName;";
+    const newContent = [
+      "const displayName = user.displayName;",
+      "const fallbackName = user.name;",
+    ].join("\n");
+    const { diff } = generateDiffString(oldContent, newContent);
+
+    const diffData = buildDiffData({ path: "sample.ts", oldContent, newContent, diff });
+
+    expect(diffData.inlineDiffs ?? []).toHaveLength(0);
+  });
+
+  it("skips unrelated remove/add pairs", () => {
+    const oldContent = "alpha beta gamma";
+    const newContent = "completely unrelated text";
+    const { diff } = generateCompactOrFullDiff(oldContent, newContent);
+
+    const diffData = buildDiffData({ path: "sample.ts", oldContent, newContent, diff });
+
+    expect(diffData.inlineDiffs ?? []).toHaveLength(0);
+  });
+
+  it("skips lines longer than the inline diff cap", () => {
+    const oldContent = `prefix ${"a".repeat(MAX_INLINE_DIFF_LINE_LENGTH + 1)}`;
+    const newContent = `prefix ${"b".repeat(MAX_INLINE_DIFF_LINE_LENGTH + 1)}`;
+    const { diff } = generateDiffString(oldContent, newContent);
+
+    const diffData = buildDiffData({ path: "sample.ts", oldContent, newContent, diff });
+
+    expect(diffData.inlineDiffs ?? []).toHaveLength(0);
+  });
+
+  it("skips token-heavy lines before allocating inline diff tables", () => {
+    const oldContent = Array.from({ length: MAX_INLINE_DIFF_TOKENS + 1 }, (_, index) => `a${index}`).join(" ");
+    const newContent = Array.from({ length: MAX_INLINE_DIFF_TOKENS + 1 }, (_, index) => `b${index}`).join(" ");
+    const { diff } = generateDiffString(oldContent, newContent);
+
+    const diffData = buildDiffData({ path: "sample.ts", oldContent, newContent, diff });
+
+    expect(diffData.inlineDiffs ?? []).toHaveLength(0);
+  });
+
+  it("does not create inline diffs for added-only or removed-only changes", () => {
+    const addedOnly = buildDiffData({
+      path: "sample.ts",
+      oldContent: "alpha",
+      newContent: "alpha\nbeta",
+      diff: generateDiffString("alpha", "alpha\nbeta").diff,
+    });
+    expect(addedOnly.inlineDiffs ?? []).toHaveLength(0);
+
+    const removedOnly = buildDiffData({
+      path: "sample.ts",
+      oldContent: "alpha\nbeta",
+      newContent: "alpha",
+      diff: generateDiffString("alpha\nbeta", "alpha").diff,
+    });
+    expect(removedOnly.inlineDiffs ?? []).toHaveLength(0);
+  });
+
+
+  it("caps total inline diff pair work", () => {
+    const oldContent = Array.from({ length: 260 }, (_, index) => `const value${index} = oldName + ${index};`).join("\n");
+    const newContent = Array.from({ length: 260 }, (_, index) => `const value${index} = newName + ${index};`).join("\n");
+    const { diff } = generateDiffString(oldContent, newContent, 0);
+
+    const diffData = buildDiffData({ path: "sample.ts", oldContent, newContent, diff });
+
+    expect((diffData.inlineDiffs ?? []).length).toBeLessThanOrEqual(MAX_INLINE_DIFF_PAIRS);
+  });
+});

--- a/tests/diff-data-rows.test.ts
+++ b/tests/diff-data-rows.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { generateDiffString } from "../src/edit-diff.js";
+import { buildDiffData } from "../src/diff-data.js";
+
+function countByKind(entries: Array<{ kind: string }>, kind: string): number {
+  return entries.filter((entry) => entry.kind === kind).length;
+}
+
+describe("DiffData full diff rows", () => {
+  it("builds versioned entries, stats, and language for full multi-line diffs", () => {
+    const oldContent = ["const one = 1;", "const two = 2;", "const three = 3;", "const four = 4;"].join("\n");
+    const newContent = ["const one = 1;", "const two = 22;", "const three = 33;", "const four = 4;"].join("\n");
+    const diff = generateDiffString(oldContent, newContent).diff;
+
+    const diffData = buildDiffData({ path: "sample.ts", oldContent, newContent, diff });
+
+    expect(diffData.version).toBe(1);
+    expect(diffData.language).toBe("typescript");
+    expect(diffData.entries).toHaveLength(diff.split("\n").length);
+    expect(diffData.entries.some((entry) => entry.kind === "context" && entry.oldLine === 1 && entry.newLine === 1 && entry.text === "const one = 1;")).toBe(true);
+    expect(diffData.entries.some((entry) => entry.kind === "remove" && entry.oldLine === 2 && entry.text === "const two = 2;")).toBe(true);
+    expect(diffData.entries.some((entry) => entry.kind === "add" && entry.newLine === 2 && entry.text === "const two = 22;")).toBe(true);
+    expect(diffData.stats).toEqual({
+      added: countByKind(diffData.entries, "add"),
+      removed: countByKind(diffData.entries, "remove"),
+      context: countByKind(diffData.entries, "context"),
+    });
+  });
+
+  it("keeps context newLine aligned after omitted leading context", () => {
+    const oldLines = Array.from({ length: 120 }, (_, index) => `line ${index + 1}`);
+    const newLines = [...oldLines];
+    newLines[99] = "line one hundred changed";
+    const oldContent = oldLines.join("\n");
+    const newContent = newLines.join("\n");
+    const diff = generateDiffString(oldContent, newContent).diff;
+
+    const diffData = buildDiffData({ path: "sample.ts", oldContent, newContent, diff });
+
+    expect(diffData.entries).toContainEqual({ kind: "meta", text: "     ..." });
+    expect(diffData.entries).toContainEqual({ kind: "context", oldLine: 96, newLine: 96, text: "line 96" });
+    expect(diffData.entries).toContainEqual({ kind: "remove", oldLine: 100, text: "line 100" });
+    expect(diffData.entries).toContainEqual({ kind: "add", newLine: 100, text: "line one hundred changed" });
+  });
+
+  it("omits language for unknown extensions", () => {
+    const oldContent = "alpha\nbeta";
+    const newContent = "alpha\nBETA";
+    const diff = generateDiffString(oldContent, newContent).diff;
+
+    const diffData = buildDiffData({ path: "sample.unknownext", oldContent, newContent, diff });
+
+    expect(diffData.language).toBeUndefined();
+  });
+});

--- a/tests/edit-output-diff-data.test.ts
+++ b/tests/edit-output-diff-data.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildEditOutput } from "../src/edit-output.js";
+import type { DiffData } from "../src/diff-data.js";
+
+describe("buildEditOutput diffData", () => {
+  it("projects diffData into edit ptcValue without changing existing diff fields", () => {
+    const diffData: DiffData = {
+      version: 1,
+      entries: [
+        { kind: "remove", oldLine: 1, text: "const value = 1;" },
+        { kind: "add", newLine: 1, text: "const value = 2;" },
+      ],
+      stats: { added: 1, removed: 1, context: 0 },
+      language: "typescript",
+    };
+
+    const result = buildEditOutput({
+      path: "/tmp/sample.ts",
+      displayPath: "sample.ts",
+      diff: "1:abc|const value = 1; → 1:def|const value = 2;",
+      diffData,
+      firstChangedLine: 1,
+      warnings: [],
+      noopEdits: [],
+      edits: [{ set_line: { anchor: "1:abc", new_text: "const value = 2;" } }],
+    });
+
+    expect(result.ptcValue.diff).toBe("1:abc|const value = 1; → 1:def|const value = 2;");
+    expect(result.ptcValue.firstChangedLine).toBe(1);
+    expect(result.ptcValue.diffData).toEqual(diffData);
+  });
+});

--- a/tests/edit-tool-diff-data.test.ts
+++ b/tests/edit-tool-diff-data.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { computeLineHash, ensureHashInit } from "../src/hashline.js";
+import { registerEditTool } from "../src/edit.js";
+
+async function callEditTool(params: Record<string, unknown>) {
+  let capturedTool: any;
+  registerEditTool({ registerTool(tool: any) { capturedTool = tool; } } as any);
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+describe("edit tool diffData", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("returns diffData in details and ptcValue for compact anchor edits without changing legacy fields", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-diff-data-"));
+    const filePath = resolve(dir, "sample.ts");
+    writeFileSync(filePath, "const value = 1;\nconst other = 2;", "utf-8");
+    const oldLine = readFileSync(filePath, "utf-8").split("\n")[0];
+    const anchor = `1:${computeLineHash(1, oldLine)}`;
+
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ set_line: { anchor, new_text: "const value = 11;" } }],
+    });
+
+    expect(result.details.diff).toMatch(/^1:[0-9a-f]{3}\|const value = 1; → 1:[0-9a-f]{3}\|const value = 11;$/);
+    expect(result.details.firstChangedLine).toBe(1);
+    expect(result.details.ptcValue.diff).toBe(result.details.diff);
+    expect(result.content[0].text).toContain("Edited");
+    expect(result.details.diffData).toEqual(result.details.ptcValue.diffData);
+    expect(result.details.diffData.version).toBe(1);
+    expect(result.details.diffData.entries).toEqual([
+      { kind: "remove", oldLine: 1, text: "const value = 1;" },
+      { kind: "add", newLine: 1, text: "const value = 11;" },
+    ]);
+    expect(result.details.diffData.inlineDiffs?.length).toBeGreaterThan(0);
+  });
+
+
+  it("returns expanded diffData entries for compact deletion edits", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-delete-diff-data-"));
+    const filePath = resolve(dir, "sample.ts");
+    writeFileSync(filePath, "line one\nline two\nline three", "utf-8");
+    const anchor = `2:${computeLineHash(2, "line two")}`;
+
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ replace_lines: { start_anchor: anchor, end_anchor: anchor, new_text: "" } }],
+    });
+
+    expect(result.details.diff).toMatch(/^2:[0-9a-f]{3}\|line two → \[deleted\]$/);
+    expect(result.details.diffData.entries).toEqual([{ kind: "remove", oldLine: 2, text: "line two" }]);
+  });
+
+  it("returns 1:1 diffData entries for full multi-line edit diffs", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-full-diff-data-"));
+    const filePath = resolve(dir, "sample.ts");
+    writeFileSync(filePath, "const one = 1;\nconst two = 2;\nconst three = 3;\nconst four = 4;", "utf-8");
+    const startAnchor = `2:${computeLineHash(2, "const two = 2;")}`;
+    const endAnchor = `3:${computeLineHash(3, "const three = 3;")}`;
+
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ replace_lines: { start_anchor: startAnchor, end_anchor: endAnchor, new_text: "const two = 22;\nconst three = 33;" } }],
+    });
+
+    expect(result.details.diff).toContain("-2 const two = 2;");
+    expect(result.details.diff).toContain("+2 const two = 22;");
+    expect(result.details.diffData.entries).toHaveLength(result.details.diff.split("\n").length);
+    expect(result.details.diffData.entries.some((entry: any) => entry.kind === "context")).toBe(true);
+  });
+
+  it("returns replace_symbol blockRanges from resolved symbol ranges", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-symbol-diff-data-"));
+    const filePath = resolve(dir, "sample.ts");
+    writeFileSync(filePath, [
+      "export function greet(firstName: string) {",
+      "  return firstName;",
+      "}",
+    ].join("\n"), "utf-8");
+
+    const result = await callEditTool({
+      path: filePath,
+      edits: [{ replace_symbol: { symbol: "greet", new_body: ["export function greet(displayName: string) {", "  return displayName;", "}"].join("\n") } }],
+    });
+
+    expect(result.details.diffData.blockRanges).toEqual([{ kind: "remove", startLine: 1, endLine: 3 }]);
+  });
+});

--- a/tests/write-diff-data.test.ts
+++ b/tests/write-diff-data.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit } from "../src/hashline.js";
+import { executeWrite, registerWriteTool } from "../src/write.js";
+
+async function callWriteTool(params: Record<string, unknown>) {
+  let capturedTool: any;
+  registerWriteTool({ registerTool(tool: any) { capturedTool = tool; } } as any);
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+describe("write diff data", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("executeWrite returns final diff string parity and diffData", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-write-diff-data-"));
+    const filePath = join(dir, "sample.ts");
+    writeFileSync(filePath, "const value = 1;\n", "utf-8");
+
+    const result = await executeWrite({ path: filePath, content: "const value = 2;\n" });
+
+    expect(result.diff).toMatch(/^1:[0-9a-f]{3}\|const value = 1; → 1:[0-9a-f]{3}\|const value = 2;$/);
+    expect(result.ptcValue.diff).toBe(result.diff);
+    expect(result.diffData).toEqual(result.ptcValue.diffData);
+    expect(result.diffData!.entries).toEqual([
+      { kind: "remove", oldLine: 1, text: "const value = 1;" },
+      { kind: "add", newLine: 1, text: "const value = 2;" },
+    ]);
+  });
+
+  it("represents creating a text file as add-only diff data", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-write-create-diff-data-"));
+    const filePath = join(dir, "sample.ts");
+
+    const result = await executeWrite({ path: filePath, content: "const value = 1;\n" });
+
+    expect(result.diff).toBe("+1 const value = 1;");
+    expect(result.diffData!.entries).toEqual([{ kind: "add", newLine: 1, text: "const value = 1;" }]);
+  });
+
+  it("represents overwriting a zero-byte file as add-only diff data", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-write-empty-diff-data-"));
+    const filePath = join(dir, "sample.ts");
+    writeFileSync(filePath, "", "utf-8");
+
+    const result = await executeWrite({ path: filePath, content: "const value = 1;\n" });
+
+    expect(result.diff).toBe("+1 const value = 1;");
+    expect(result.diffData!.entries).toEqual([{ kind: "add", newLine: 1, text: "const value = 1;" }]);
+  });
+
+  it("registered write tool exposes diff fields in details", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-write-tool-diff-data-"));
+    const filePath = join(dir, "sample.ts");
+    writeFileSync(filePath, "const value = 1;\n", "utf-8");
+
+    const result = await callWriteTool({ path: filePath, content: "const value = 2;\n" });
+
+    expect(result.details.diff).toBe(result.details.ptcValue.diff);
+    expect(result.details.diffData).toEqual(result.details.ptcValue.diffData);
+    expect(result.details.diffData.version).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a stable, additive `DiffData` contract to successful `edit` and text `write` results so renderers can consume parsed diff rows, stats, language hints, `replace_symbol` block ranges, and bounded inline word-diff spans without reparsing the existing diff string.

Existing `details.diff` / `ptcValue.diff` strings remain the backward-compatible fallback, including compact single-line hashline diffs. Compact structured rows are validated against source contents, full diff context lines preserve old/new numbering across omitted `...` ranges, and inline span generation is capped for CPU/memory safety.

Documents the contract in `prompts/edit.md` and `prompts/write.md`, and adds focused integration/regression coverage for edit/write payloads, compact deletion/replacement, new-file writes, `replace_symbol` block ranges, multi-line replacement pairing, delimiter-shaped source text, and long/token-heavy inline-diff skips.

Resolves #166.
Refs #162. Refs #163.

## Verification

- `npm test -- tests/diff-data-compact.test.ts tests/diff-data-inline.test.ts tests/diff-data-rows.test.ts tests/write-diff-data.test.ts tests/edit-tool-diff-data.test.ts tests/edit-output-diff-data.test.ts`
- `npm run typecheck`
- `npm test`