### PR TITLE
fix: harden write/edit edge-case input handling (#177)

### DIFF
--- a/src/edit-output.ts
+++ b/src/edit-output.ts
@@ -26,9 +26,19 @@ function getVisibleDiffStats(diff: string): { added: number; removed: number } {
   return { added: 1, removed: 1 };
 }
 function buildVisibleSummary(displayPath: string, diff: string, edits: unknown[] | undefined): string {
-  const stats = getVisibleDiffStats(diff);
+  let stats = getVisibleDiffStats(diff);
   const counts = countEditTypes(edits);
   const editCount = counts.total || 1;
+
+  if (
+    counts.total > 0 &&
+    counts.insert_after === counts.total &&
+    stats.removed > 0 &&
+    stats.added === stats.removed + counts.insert_after
+  ) {
+    stats = { added: counts.insert_after, removed: 0 };
+  }
+
   const changeWord = editCount === 1 ? "change" : "changes";
   const changedLineCount = Math.max(stats.added, stats.removed);
   const lineWord = changedLineCount === 1 ? "line" : "lines";

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -56,6 +56,10 @@ const hashlineEditItemSchema = Type.Union([
 		{ replace_symbol: Type.Object({ symbol: Type.String(), new_body: Type.String() }) },
 		{ additionalProperties: true },
 	),
+	Type.Object(
+		{ old_text: Type.String(), new_text: Type.String() },
+		{ additionalProperties: true },
+	),
 ]);
 
 const hashlineEditSchema = Type.Object(

--- a/src/hashline.ts
+++ b/src/hashline.ts
@@ -693,6 +693,11 @@ export function applyHashlineEdits(
 				noopEdits.push({ editIndex: idx, loc: `${spec.after.line}:${spec.after.hash}`, currentContent: anchor });
 				continue;
 			}
+			if (content === "" && spec.after.line === 1 && anchor === "") {
+				fileLines.splice(0, 1, ...inserted);
+				track(1);
+				continue;
+			}
 			fileLines.splice(spec.after.line, 0, ...inserted);
 			track(spec.after.line + 1);
 		}

--- a/src/write.ts
+++ b/src/write.ts
@@ -12,7 +12,7 @@ import { formatFileMapWithBudget } from "./readmap/formatter.js";
 import { buildContextHygieneMetadata, buildFileResource, type ContextHygieneMetadata } from "./context-hygiene.js";
 import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 import { buildPendingWritePreviewData, buildWritePreviewKey, resolvePendingDiffPreview, type PendingDiffPreviewResult } from "./pending-diff-preview.js";
-import { generateCompactOrFullDiff, normalizeToLF } from "./edit-diff.js";
+import { generateCompactOrFullDiff, normalizeToLF, hasBareCarriageReturn } from "./edit-diff.js";
 import { buildDiffData, type DiffData } from "./diff-data.js";
 
 const WRITE_PENDING_PREVIEW_STATE_KEY = "hashline-write-pending-preview";
@@ -144,6 +144,30 @@ export async function executeWrite(opts: {
   await ensureHashInit();
 
   const { path: filePath, content, map: requestMap, cwd } = opts;
+  const warnings: string[] = [];
+  const ptcWarnings: PtcWarning[] = [];
+  const contextHygiene = buildContextHygieneMetadata({
+    tool: "write",
+    classification: "mutation",
+    resources: [buildFileResource(filePath)],
+  });
+
+  if (hasBareCarriageReturn(content)) {
+    const message = "File content contains bare CR (\\r) line endings; write refuses to emit anchors that read/edit would normalize differently.";
+    warnings.push(message);
+    ptcWarnings.push(buildPtcWarning("bare-cr", message));
+    return {
+      text: `Cannot write ${filePath}\n⚠️ ${message}`,
+      warnings,
+      ptcValue: {
+        tool: "write",
+        path: filePath,
+        lines: [],
+        warnings: ptcWarnings,
+      },
+      contextHygiene,
+    };
+  }
   const previousContent = readPreviousTextForDiff(filePath);
 
   // Create parent directories
@@ -161,13 +185,6 @@ export async function executeWrite(opts: {
     throw err;
   }
 
-  const warnings: string[] = [];
-  const ptcWarnings: PtcWarning[] = [];
-  const contextHygiene = buildContextHygieneMetadata({
-    tool: "write",
-    classification: "mutation",
-    resources: [buildFileResource(filePath)],
-  });
 
   // Binary detection
   if (looksLikeBinary(Buffer.from(content, "utf-8"))) {
@@ -321,6 +338,23 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
               ...result.ptcValue,
               ok: false,
               error: buildPtcError("binary-content", binaryWarning.message),
+            },
+            warnings: result.warnings,
+            contextHygiene: result.contextHygiene,
+          },
+        };
+      }
+
+      const bareCrWarning = result.ptcValue.warnings.find((w) => w.code === "bare-cr");
+      if (bareCrWarning) {
+        return {
+          content: [{ type: "text" as const, text: result.text }],
+          isError: true,
+          details: {
+            ptcValue: {
+              ...result.ptcValue,
+              ok: false,
+              error: buildPtcError("bare-cr", bareCrWarning.message),
             },
             warnings: result.warnings,
             contextHygiene: result.contextHygiene,

--- a/tests/repro-177-core-edit-input-correctness-edge-cases.test.ts
+++ b/tests/repro-177-core-edit-input-correctness-edge-cases.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { Value } from "@sinclair/typebox/value";
+import { ensureHashInit } from "../src/hashline.js";
+import { registerEditTool } from "../src/edit.js";
+import { registerWriteTool } from "../src/write.js";
+import { buildPendingEditPreviewData } from "../src/pending-diff-preview.js";
+
+function captureTool(register: (pi: any, options?: any) => any, options?: any) {
+  let tool: any;
+  register({
+    registerTool(def: any) {
+      tool = def;
+    },
+  }, options);
+  if (!tool) throw new Error("tool was not registered");
+  return tool;
+}
+
+function textOf(result: any): string {
+  return result.content?.find((part: any) => part.type === "text")?.text ?? "";
+}
+
+describe("repro 177 — core edit input correctness edge cases", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("insert_after on the synthetic empty-file anchor inserts the first line without a leading blank", async () => {
+    const root = resolve(process.cwd(), "tmp");
+    mkdirSync(root, { recursive: true });
+    const dir = mkdtempSync(resolve(root, "pi-repro-177-empty-"));
+    const filePath = resolve(dir, "empty.txt");
+    const writeTool = captureTool(registerWriteTool);
+    const editTool = captureTool(registerEditTool, { wasReadInSession: () => true });
+
+    const writeResult = await writeTool.execute("write", { path: filePath, content: "" }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+    expect(textOf(writeResult)).toBe("1:d05|");
+
+    const preview = await buildPendingEditPreviewData({
+      path: filePath,
+      edits: [{ insert_after: { anchor: "1:d05", new_text: "first" } }],
+    }, process.cwd());
+    expect(preview.type).toBe("ok");
+    if (preview.type === "ok") expect(preview.data.nextContent).toBe("first");
+
+    await editTool.execute("edit", {
+      path: filePath,
+      edits: [{ insert_after: { anchor: "1:d05", new_text: "first" } }],
+    }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+
+    expect(readFileSync(filePath, "utf8")).toBe("first");
+  });
+
+  it("bare-CR write content is rejected before unusable anchors are emitted", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-repro-177-cr-"));
+    const filePath = resolve(dir, "bare-cr.txt");
+    const writeTool = captureTool(registerWriteTool);
+
+    const writeResult = await writeTool.execute("write", { path: filePath, content: "a\rb\r" }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+
+    expect(writeResult.isError).toBe(true);
+    expect(textOf(writeResult)).toContain("bare CR");
+    expect(writeResult.details?.ptcValue?.error?.code).toBe("bare-cr");
+    expect(writeResult.details?.ptcValue?.lines).toEqual([]);
+  });
+
+  it("schema permits common edits[] old_text/new_text mistake so custom guidance can run", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-repro-177-shape-"));
+    const filePath = resolve(dir, "shape.txt");
+    const writeTool = captureTool(registerWriteTool);
+    const editTool = captureTool(registerEditTool, { wasReadInSession: () => true });
+    const commonMistake = {
+      path: filePath,
+      edits: [{ old_text: "a", new_text: "b" }],
+    };
+
+    await writeTool.execute("write", { path: filePath, content: "const a = 1;\n" }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+
+    expect(Value.Check(editTool.parameters, commonMistake)).toBe(true);
+    const result = await editTool.execute("edit", commonMistake, new AbortController().signal, () => {}, { cwd: process.cwd() });
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("edits[0] has top-level 'old_text'/'new_text'");
+    expect(textOf(result)).toContain("Use {replace: {old_text, new_text}}");
+    expect(result.details?.ptcValue?.error?.code).toBe("invalid-edit-variant");
+  });
+
+  it("insert_after at EOF without a final newline reports an insertion-only summary", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-repro-177-nofinal-"));
+    const filePath = resolve(dir, "nofinal.txt");
+    const writeTool = captureTool(registerWriteTool);
+    const editTool = captureTool(registerEditTool, { wasReadInSession: () => true });
+
+    await writeTool.execute("write", { path: filePath, content: "alpha\nbeta" }, new AbortController().signal, () => {}, {
+      cwd: process.cwd(),
+    });
+    const editResult = await editTool.execute("edit", {
+      path: filePath,
+      edits: [{ insert_after: { anchor: "2:589", new_text: "gamma" } }],
+    }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+
+    expect(textOf(editResult)).toContain("+1 -0 line");
+    expect(readFileSync(filePath, "utf8")).toBe("alpha\nbeta\ngamma");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes four core write/edit input-correctness edge cases that made hashline anchors or edit output misleading in boundary cases.

`insert_after` on the synthetic empty-file `1:d05|` anchor now writes the first inserted line at byte 0 instead of preserving a leading blank line, and pending edit preview follows the same behavior. `write` now rejects bare carriage-return content before emitting anchors that `read`/`edit` would normalize differently. The edit schema now admits the common `edits: [{ old_text, new_text }]` mistake far enough for the existing custom `Use {replace: {old_text, new_text}}` guidance to run. Pure `insert_after` edits at EOF in no-final-newline files now report insertion-oriented summary counts while preserving the underlying diff.

Resolves #177.
Refs #170. Refs #171. Refs #172. Refs #174.

## Acceptance Criteria

- [x] Empty-file `write` + `insert_after` no longer silently produces a leading blank line.
- [x] Bare-CR input no longer yields unusable write anchors; `write` refuses it before presenting anchors as usable.
- [x] `edit({ edits: [{ old_text, new_text }] })` reaches concise custom guidance containing `Use {replace: {old_text, new_text}}` instead of the generic TypeBox union failure.
- [x] `insert_after` at EOF in a no-final-newline file still produces correct content and reports an insertion-oriented visible summary, not `+2 -1 lines`.
- [x] Pending edit preview behavior remains consistent with real edit behavior for anchored edits, especially empty-file handling.
- [x] Existing CRLF insertion regression coverage remains green; no reintroduction of doubled `\r` or extra blank lines from inserted text ending in LF/CRLF.

## Verification

- `npm test`
- `npm test -- tests/repro-177-core-edit-input-correctness-edge-cases.test.ts`
- `npm test -- tests/repro-019-crlf-corruption.test.ts`
- `npm run typecheck`
