### PR TITLE
fix: pending diff preview correctness for absolute paths and replace variants (#167, #168)

### DIFF
--- a/src/pending-diff-preview.ts
+++ b/src/pending-diff-preview.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
-import { dirname, relative, resolve, sep } from "node:path";
-import { generateDiffString, normalizeToLF } from "./edit-diff.js";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { generateDiffString, normalizeToLF, replaceText } from "./edit-diff.js";
 import { applyHashlineEdits, type HashlineEditItem } from "./hashline.js";
 import { replaceSymbol } from "./replace-symbol.js";
 
@@ -31,14 +31,16 @@ function isInsidePath(parent: string, child: string): boolean {
 function resolveWorkspacePreviewPath(rawPath: unknown, cwd: string, allowMissing: boolean): { type: "ok"; path: string; existed: boolean } | { type: "skip"; reason: string } {
 	if (typeof rawPath !== "string" || rawPath.trim() === "") return { type: "skip", reason: "missing path" };
 	const workspace = realpathSync(cwd);
-	const requested = resolve(workspace, rawPath.replace(/^@/, ""));
+	const normalizedPath = rawPath.replace(/^@/, "");
+	const explicitAbsolute = isAbsolute(normalizedPath);
+	const requested = resolve(workspace, normalizedPath);
 	if (existsSync(requested)) {
 		const realTarget = realpathSync(requested);
-		if (!isInsidePath(workspace, realTarget)) return { type: "skip", reason: "path outside workspace" };
+		if (!explicitAbsolute && !isInsidePath(workspace, realTarget)) return { type: "skip", reason: "path outside workspace" };
 		return { type: "ok", path: realTarget, existed: true };
 	}
 
-	if (!isInsidePath(workspace, requested)) return { type: "skip", reason: "path outside workspace" };
+	if (!explicitAbsolute && !isInsidePath(workspace, requested)) return { type: "skip", reason: "path outside workspace" };
 
 	if (!allowMissing) return { type: "skip", reason: "file not found" };
 	const parent = dirname(requested);
@@ -76,7 +78,7 @@ function buildData(
 	};
 }
 
-type ReplaceEdit = { replace: { old_text: string; new_text: string } };
+type ReplaceEdit = { replace: { old_text: string; new_text: string; all?: boolean; fuzzy?: boolean } };
 type PendingEditInput = { path?: unknown; edits?: unknown[]; oldText?: unknown; newText?: unknown; old_text?: unknown; new_text?: unknown };
 
 function normalizeReplaceOnlyEdits(input: PendingEditInput): unknown[] {
@@ -130,24 +132,16 @@ async function applyReplaceSymbolPreview(filePath: string, content: string, edit
 	}
 }
 
-function countOccurrences(haystack: string, needle: string): number {
-	if (!needle.length) return 0;
-	let count = 0;
-	let offset = 0;
-	while (true) {
-		const idx = haystack.indexOf(needle, offset);
-		if (idx === -1) return count;
-		count++;
-		offset = idx + needle.length;
-	}
-}
 
 function applyReplacePreview(content: string, edit: ReplaceEdit): { type: "ok"; content: string } | { type: "skip"; reason: string } {
 	const { old_text, new_text } = edit.replace;
 	if (!old_text.length) return { type: "skip", reason: "replace old_text is empty" };
-	const matches = countOccurrences(content, old_text);
-	if (matches !== 1) return { type: "skip", reason: `replace old_text is not unique (${matches} matches)` };
-	return { type: "ok", content: content.replace(old_text, normalizeToLF(new_text)) };
+	const replacement = replaceText(content, old_text, new_text, {
+		all: edit.replace.all ?? false,
+		fuzzy: edit.replace.fuzzy ?? false,
+	});
+	if (!replacement.count) return { type: "skip", reason: "replace old_text was not found" };
+	return { type: "ok", content: replacement.content };
 }
 
 export function buildPendingWritePreviewData(input: { path?: unknown; content?: unknown }, cwd: string): PendingDiffPreviewResult {

--- a/tests/edit-pending-diff-render-fallback.test.ts
+++ b/tests/edit-pending-diff-render-fallback.test.ts
@@ -21,7 +21,7 @@ const theme = {
 };
 
 describe("edit renderCall preview fallback", () => {
-	it("keeps the summary after a skipped preview", async () => {
+	it("projects first-occurrence replace preview and executes the same change", async () => {
 		const cwd = mkdtempSync(resolve(tmpdir(), "pi-edit-pending-fallback-"));
 		const filePath = resolve(cwd, "sample.ts");
 		writeFileSync(filePath, "const value = 1;\nconst value = 1;\n", "utf-8");
@@ -33,7 +33,7 @@ describe("edit renderCall preview fallback", () => {
 		await Promise.resolve();
 		const rendered = textOf(tool.renderCall(args, theme, context));
 		expect(rendered).toContain("edit");
-		expect(rendered).not.toContain("pending edit");
+		expect(rendered).toContain("pending edit");
 
 		const result = await tool.execute("edit-call", args, new AbortController().signal, undefined, { cwd });
 		expect(result.isError).not.toBe(true);

--- a/tests/pending-diff-preview-correctness-repro.test.ts
+++ b/tests/pending-diff-preview-correctness-repro.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, realpathSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { buildPendingEditPreviewData, buildPendingWritePreviewData } from "../src/pending-diff-preview.js";
+
+function expectOk<T extends { type: string; reason?: string }>(preview: T): asserts preview is T & { type: "ok" } {
+	if (preview.type !== "ok") throw new Error(`preview skipped: ${preview.reason ?? "unknown reason"}`);
+}
+
+describe("pending diff preview correctness regression", () => {
+	it("previews an explicit absolute write path outside cwd", () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-abs-write-repro-cwd-"));
+		const outsideDir = mkdtempSync(resolve(tmpdir(), "pi-pending-abs-write-repro-outside-"));
+		const outsideFile = resolve(outsideDir, "outside.txt");
+		writeFileSync(outsideFile, "before\n", "utf-8");
+		const realOutsideFile = realpathSync(outsideFile);
+
+		const preview = buildPendingWritePreviewData({ path: outsideFile, content: "after\n" }, cwd);
+
+		expectOk(preview);
+		expect(preview.data.headerLabel).toBe("pending overwrite");
+		expect(preview.data.filePath).toBe(realOutsideFile);
+		expect(preview.data.nextContent).toBe("after\n");
+	});
+
+	it("previews an explicit absolute create path outside cwd", () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-abs-create-repro-cwd-"));
+		const outsideDir = mkdtempSync(resolve(tmpdir(), "pi-pending-abs-create-repro-outside-"));
+		const outsideFile = resolve(outsideDir, "created.txt");
+
+		const preview = buildPendingWritePreviewData({ path: outsideFile, content: "created\n" }, cwd);
+
+		expectOk(preview);
+		expect(preview.data.headerLabel).toBe("pending create");
+		expect(preview.data.fileExistedBeforeWrite).toBe(false);
+		expect(preview.data.filePath).toBe(outsideFile);
+		expect(preview.data.previousContent).toBe("");
+		expect(preview.data.nextContent).toBe("created\n");
+	});
+
+	it("previews plain replace the same way final edit applies it: first occurrence only", async () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-replace-first-repro-"));
+		const filePath = resolve(cwd, "sample.ts");
+		writeFileSync(filePath, "const one = 1;\nconst two = 2;\n", "utf-8");
+
+		const preview = await buildPendingEditPreviewData({
+			path: filePath,
+			edits: [{ replace: { old_text: "const", new_text: "let" } }],
+		}, cwd);
+
+		expectOk(preview);
+		expect(preview.data.nextContent).toBe("let one = 1;\nconst two = 2;\n");
+	});
+
+	it("previews replace with all:true across repeated matches", async () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-replace-all-repro-"));
+		const filePath = resolve(cwd, "sample.ts");
+		writeFileSync(filePath, "const one = 1;\nconst two = 2;\n", "utf-8");
+
+		const preview = await buildPendingEditPreviewData({
+			path: filePath,
+			edits: [{ replace: { old_text: "const", new_text: "let", all: true } }],
+		}, cwd);
+
+		expectOk(preview);
+		expect(preview.data.nextContent).toBe("let one = 1;\nlet two = 2;\n");
+	});
+
+	it("previews replace with fuzzy:true when exact text is absent", async () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-replace-fuzzy-repro-"));
+		const filePath = resolve(cwd, "sample.ts");
+		writeFileSync(filePath, "alpha   \n beta\n gamma\n", "utf-8");
+
+		const preview = await buildPendingEditPreviewData({
+			path: filePath,
+			edits: [{ replace: { old_text: "alpha\n beta\n gamma\n", new_text: "alpha\n", fuzzy: true } }],
+		}, cwd);
+
+		expectOk(preview);
+		expect(preview.data.nextContent).toBe("alpha\n");
+	});
+});

--- a/tests/pending-diff-preview-outside-path.test.ts
+++ b/tests/pending-diff-preview-outside-path.test.ts
@@ -1,20 +1,24 @@
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, realpathSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { buildPendingWritePreviewData } from "../src/pending-diff-preview.js";
 
-describe("pending preview outside path guard", () => {
-	it("skips an absolute path outside cwd", () => {
-		const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-guard-cwd-"));
-		const outsideDir = mkdtempSync(resolve(tmpdir(), "pi-pending-guard-outside-"));
+describe("pending preview explicit absolute path", () => {
+	it("projects an absolute existing-file write preview outside cwd", () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-abs-write-cwd-"));
+		const outsideDir = mkdtempSync(resolve(tmpdir(), "pi-pending-abs-write-outside-"));
 		const outsideFile = resolve(outsideDir, "outside.txt");
-		writeFileSync(outsideFile, "outside\n", "utf-8");
+		writeFileSync(outsideFile, "before\n", "utf-8");
+		const realOutsideFile = realpathSync(outsideFile);
 
-		const outside = buildPendingWritePreviewData({ path: outsideFile, content: "changed\n" }, cwd);
+		const preview = buildPendingWritePreviewData({ path: outsideFile, content: "after\n" }, cwd);
 
-		expect(outside.type).toBe("skip");
-		if (outside.type !== "skip") throw new Error("outside path unexpectedly projected");
-		expect(outside.reason).toContain("workspace");
+		expect(preview.type).toBe("ok");
+		if (preview.type !== "ok") throw new Error(`preview skipped: ${preview.reason}`);
+		expect(preview.data.headerLabel).toBe("pending overwrite");
+		expect(preview.data.filePath).toBe(realOutsideFile);
+		expect(preview.data.previousContent).toBe("before\n");
+		expect(preview.data.nextContent).toBe("after\n");
 	});
 });

--- a/tests/pending-diff-preview-replace-fallback.test.ts
+++ b/tests/pending-diff-preview-replace-fallback.test.ts
@@ -5,23 +5,24 @@ import { tmpdir } from "node:os";
 import { buildPendingEditPreviewData } from "../src/pending-diff-preview.js";
 
 function makeFixture(content: string): { cwd: string; filePath: string } {
-	const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-replace-fallback-"));
+	const cwd = mkdtempSync(resolve(tmpdir(), "pi-pending-replace-first-"));
 	const filePath = resolve(cwd, "sample.ts");
 	writeFileSync(filePath, content, "utf-8");
 	return { cwd, filePath };
 }
 
-describe("pending edit replace fallback", () => {
-	it("skips ambiguous replace text", async () => {
-		const { cwd, filePath } = makeFixture("const value = 1;\nconst other = 2;\n");
+describe("pending edit replace preview", () => {
+	it("projects plain repeated replace as the first occurrence", async () => {
+		const { cwd, filePath } = makeFixture("const one = 1;\nconst two = 2;\n");
 
-		const ambiguous = await buildPendingEditPreviewData({
+		const preview = await buildPendingEditPreviewData({
 			path: filePath,
 			edits: [{ replace: { old_text: "const", new_text: "let" } }],
 		}, cwd);
 
-		expect(ambiguous.type).toBe("skip");
-		if (ambiguous.type !== "skip") throw new Error("ambiguous replace unexpectedly projected");
-		expect(ambiguous.reason).toContain("not unique");
+		expect(preview.type).toBe("ok");
+		if (preview.type !== "ok") throw new Error(`preview skipped: ${preview.reason}`);
+		expect(preview.data.headerLabel).toBe("pending edit");
+		expect(preview.data.nextContent).toBe("let one = 1;\nconst two = 2;\n");
 	});
 });


### PR DESCRIPTION
## Summary

Aligns pending diff preview projection with the actual `write`/`edit` execution paths so the TUI shows a preview whenever the final mutation will run. Two correctness gaps in `src/pending-diff-preview.ts` are fixed:

1. **Absolute paths outside cwd** — `resolveWorkspacePreviewPath` realpath-ed `cwd` and rejected any target outside it, including explicit absolute paths the user supplied. Final `write`/`edit` resolve with `resolveToCwd` which preserves absolute paths, so the runtime would write `/tmp/foo.txt` but the preview silently skipped (`path outside workspace`) and the TUI showed only the post-execute summary. Fixed by gating the workspace containment check on `!isAbsolute(normalizedPath)` for both the existing-file and missing-file branches. Relative `../` escapes and symlink escapes from inside cwd still skip.
2. **Replace variants** — `applyReplacePreview` required exactly one exact match, ignored `all`, and ignored `fuzzy`. Final `edit` delegates to `replaceText(content, old_text, new_text, { all, fuzzy })`, which supports first-occurrence, replace-all, and fuzzy matching. Fixed by widening `ReplaceEdit` to `{ old_text, new_text, all?, fuzzy? }`, deleting the in-module `countOccurrences` helper, and delegating to `replaceText` so the preview and the executor share one algorithm. Empty `old_text` and true no-match still skip.

User-visible result: `pending overwrite` / `pending create` / `pending edit` diffs render for every mutation that will actually execute, instead of falling back to summary-only.

Resolves #167. Resolves #168.

## Acceptance Criteria

- [x] **AC 1** — Pending write preview returns `ok` for an explicit absolute existing path outside cwd and renders a `pending overwrite` diff.
- [x] **AC 2** — Pending write preview returns `ok` for an explicit absolute missing path outside cwd when the parent exists and renders a `pending create` diff.
- [x] **AC 3** — Relative-path workspace guards still skip `../` escapes and symlink escapes.
- [x] **AC 4** — Pending edit preview for plain repeated-text `replace` projects the same first-occurrence change final edit applies.
- [x] **AC 5** — Pending edit preview for `replace` with `all:true` projects all exact matches.
- [x] **AC 6** — Pending edit preview for `replace` with `fuzzy:true` projects a fuzzy match when `replaceText` would succeed.
- [x] **AC 7** — Pending edit preview still skips empty `old_text` and true no-match replace edits.
- [x] **AC 8** — Existing pending-preview tests plus the focused regression tests pass.

## Files Changed

```
 src/pending-diff-preview.ts                              | 34 +++++++++-------------
 tests/edit-pending-diff-render-fallback.test.ts          |  4 +--
 tests/pending-diff-preview-outside-path.test.ts          | 24 ++++++++-------
 tests/pending-diff-preview-replace-fallback.test.ts      | 17 ++++++-----
 tests/pending-diff-preview-correctness-repro.test.ts     | new (5 tests)
```

## Verification

```
$ npm test
Test Files  303 passed (303)
     Tests  1357 passed (1357)

$ npm run typecheck      # exit 0

$ npx vitest run tests/pending-diff-preview-*.test.ts tests/edit-pending-diff-render-fallback.test.ts
Test Files 7 passed (7)
     Tests 11 passed (11)
```

The new `tests/pending-diff-preview-correctness-repro.test.ts` is a single-file repro that covers all five fixed cases (absolute existing, absolute create, first-occurrence replace, `all:true`, `fuzzy:true`). Three pre-existing tests were updated to assert the new positive-projection behavior rather than the obsolete `skip` outcomes:

- `tests/pending-diff-preview-outside-path.test.ts` — now asserts `pending overwrite` projection for an explicit absolute path.
- `tests/pending-diff-preview-replace-fallback.test.ts` — now asserts first-occurrence projection for repeated text.
- `tests/edit-pending-diff-render-fallback.test.ts` — now asserts `pending edit` is rendered for repeated replace and the final `execute` produces the same first-occurrence result.

Symlink-escape and replace-success tests remain unchanged and green.

## Notes for reviewers

- `resolveWorkspacePreviewPath` keeps the `realpathSync(target)` resolution for existing files, so the preview's `filePath` reflects the real on-disk location (matches final-edit behavior on macOS where `/tmp` → `/private/tmp`).
- `applyReplacePreview` now defers entirely to `replaceText` for replacement, so any future tweak to fuzzy or all-replace semantics in `edit-diff.ts` automatically applies to preview without re-coding.
- No changes to `execute`, `renderResult`, or structured `ptcValue` contracts.
