### PR TITLE
fix: readmap + ast_search correctness — TS literal consts (#169), TSX auto-promotion (#173)

### DIFF
--- a/src/readmap/mappers/typescript.ts
+++ b/src/readmap/mappers/typescript.ts
@@ -8,7 +8,7 @@ import { readFile, stat } from "node:fs/promises";
 import type { FileMap, FileSymbol } from "../types.js";
 
 import { DetailLevel, SymbolKind } from "../enums.js";
-export const MAPPER_VERSION = 1;
+export const MAPPER_VERSION = 2;
 
 // Lazy load ts-morph to avoid startup cost when not needed
 let tsMorphModule: typeof import("ts-morph") | null = null;
@@ -143,19 +143,12 @@ function getVariableSignature(
     return cleanupSignature(typeNode.getText());
   }
 
-  let typeText = "";
-  try {
-    typeText = varDecl.getType().getText();
-  } catch {
-    typeText = "";
-  }
-  if (typeText.length > 100) {
-    return undefined;
-  }
-  if (!typeText) {
-    return undefined;
-  }
-  return cleanupSignature(typeText);
+  // No explicit type annotation and no callable initializer: do not emit a
+  // signature. ts-morph's inferred type text (e.g. literal types like `3`,
+  // `true`, `"hello"`) is not safe to concatenate onto the symbol name in the
+  // shared formatter, which assumes non-name-containing signatures are
+  // call-shaped. See issue #169 in this repo.
+  return undefined;
 }
 
 function getTypeSignature(
@@ -481,7 +474,7 @@ function extractSymbols(
   for (const varStatement of sourceFile.getVariableStatements()) {
     const statementDocstring = getDocstring(varStatement);
     for (const varDecl of varStatement.getDeclarations()) {
-      const signature = getVariableSignature(ts, varDecl) ?? varDecl.getName();
+      const signature = getVariableSignature(ts, varDecl);
       symbols.push({
         name: varDecl.getName(),
         kind: "variable",

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -165,10 +165,8 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
         path: p.path,
       });
       const args = ["run", "--json", "-p", p.pattern];
-      if (p.lang) args.push("-l", p.lang);
 
       const searchPath = resolveToCwd(p.path ?? ".", ctx.cwd);
-      args.push(searchPath);
 
       try {
         await fsStat(searchPath);
@@ -217,6 +215,25 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
           },
         };
       }
+
+      // Auto-promote `lang: "typescript"` → "tsx" when the user pointed at a
+      // single `.tsx` file. ast-grep's TS grammar cannot parse JSX, so this
+      // closes the silent-miss reported in issue #173. Per-file scope only:
+      // directory paths and other extensions are left untouched so existing
+      // behavior is preserved for mixed-extension trees.
+      let effectiveLang = p.lang;
+      if (p.lang === "typescript") {
+        try {
+          const st = await fsStat(searchPath);
+          if (st.isFile() && path.extname(searchPath).toLowerCase() === ".tsx") {
+            effectiveLang = "tsx";
+          }
+        } catch {
+          // Already handled by the prior fsStat block; fall through.
+        }
+      }
+      if (effectiveLang) args.push("-l", effectiveLang);
+      args.push(searchPath);
 
       try {
         const { stdout } = await execFileText("sg", args, {

--- a/tests/readmap-typescript-const-literal-format.test.ts
+++ b/tests/readmap-typescript-const-literal-format.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { typescriptMapperFromContent } from "../src/readmap/mappers/typescript.js";
+import { formatFileMap } from "../src/readmap/formatter.js";
+import { DetailLevel } from "../src/readmap/enums.js";
+describe("readmap formats exported const literal initializers cleanly (#169)", () => {
+  it("does not glue numeric / boolean / string / null literals onto the symbol name", async () => {
+    const content = [
+      "export const value = 3;",
+      "export const flag = true;",
+      "export const name = \"hello\";",
+      "export const ptr = null;",
+      "export function add(a: number, b: number): number { return a + b; }",
+      "",
+    ].join("\n");
+
+    const fm = await typescriptMapperFromContent("virtual.ts", content);
+    expect(fm).not.toBeNull();
+
+    const out = formatFileMap(fm!, DetailLevel.Full);
+
+    // Negative: no glued literal next to the identifier
+    expect(out).not.toMatch(/\bvalue3\b/);
+    expect(out).not.toMatch(/\bflagtrue\b/);
+    expect(out).not.toMatch(/name"hello"/);
+    expect(out).not.toMatch(/\bptrnull\b/);
+
+    // Positive: identifier renders intact, with `export` modifier, in the
+    // variable form "<name> = ... [<lineRange>]" produced by the formatter.
+    expect(out).toMatch(/export value = \.\.\. \[1\]/);
+    expect(out).toMatch(/export flag = \.\.\. \[2\]/);
+    expect(out).toMatch(/export name = \.\.\. \[3\]/);
+    expect(out).toMatch(/export ptr = \.\.\. \[4\]/);
+
+    // Functions stay untouched (regression guard).
+    expect(out).toMatch(/add\(a: number, b: number\): number: \[5\]/);
+  });
+});

--- a/tests/sg.args.test.ts
+++ b/tests/sg.args.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import * as cp from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 vi.mock("node:child_process", () => ({
   execFile: vi.fn(),
@@ -33,5 +36,131 @@ describe("sg cli args", () => {
     expect(calls[0]).toContain("-l");
     expect(calls[0]).toContain("python");
     expect(calls[1]).not.toContain("-l");
+  });
+
+  function makeTmpDir(): string {
+    return mkdtempSync(path.join(tmpdir(), "pi-sg-tsx-"));
+  }
+
+  it("rewrites lang:typescript → tsx when the path is a .tsx file (#173)", async () => {
+    const tool = await getSgTool();
+    const dir = makeTmpDir();
+    const tsxPath = path.join(dir, "foo.tsx");
+    writeFileSync(tsxPath, "export const App = () => <div>x</div>;\n", "utf8");
+
+    const calls: string[][] = [];
+    vi.mocked(cp.execFile).mockImplementation((_cmd: any, args: any, _opts: any, cb: any) => {
+      calls.push(args);
+      cb(null, "[]", "");
+      return {} as any;
+    });
+
+    try {
+      await tool.execute(
+        "tc",
+        { pattern: "<div>$$$</div>", lang: "typescript", path: tsxPath },
+        new AbortController().signal,
+        () => {},
+        { cwd: dir },
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    expect(calls).toHaveLength(1);
+    const langIdx = calls[0].indexOf("-l");
+    expect(langIdx).toBeGreaterThan(-1);
+    expect(calls[0][langIdx + 1]).toBe("tsx");
+    expect(calls[0]).not.toContain("typescript");
+  });
+
+  it("leaves lang:typescript alone when the path is a .ts file", async () => {
+    const tool = await getSgTool();
+    const dir = makeTmpDir();
+    const tsPath = path.join(dir, "foo.ts");
+    writeFileSync(tsPath, "export const x: number = 3;\n", "utf8");
+
+    const calls: string[][] = [];
+    vi.mocked(cp.execFile).mockImplementation((_cmd: any, args: any, _opts: any, cb: any) => {
+      calls.push(args);
+      cb(null, "[]", "");
+      return {} as any;
+    });
+
+    try {
+      await tool.execute(
+        "tc",
+        { pattern: "const $X = $Y", lang: "typescript", path: tsPath },
+        new AbortController().signal,
+        () => {},
+        { cwd: dir },
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    const langIdx = calls[0].indexOf("-l");
+    expect(langIdx).toBeGreaterThan(-1);
+    expect(calls[0][langIdx + 1]).toBe("typescript");
+  });
+
+  it("leaves lang:tsx alone when the path is a .tsx file (no regression)", async () => {
+    const tool = await getSgTool();
+    const dir = makeTmpDir();
+    const tsxPath = path.join(dir, "foo.tsx");
+    writeFileSync(tsxPath, "export const App = () => <div>x</div>;\n", "utf8");
+
+    const calls: string[][] = [];
+    vi.mocked(cp.execFile).mockImplementation((_cmd: any, args: any, _opts: any, cb: any) => {
+      calls.push(args);
+      cb(null, "[]", "");
+      return {} as any;
+    });
+
+    try {
+      await tool.execute(
+        "tc",
+        { pattern: "<div>$$$</div>", lang: "tsx", path: tsxPath },
+        new AbortController().signal,
+        () => {},
+        { cwd: dir },
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    const langIdx = calls[0].indexOf("-l");
+    expect(langIdx).toBeGreaterThan(-1);
+    expect(calls[0][langIdx + 1]).toBe("tsx");
+  });
+
+  it("leaves lang:typescript alone when the path is a directory (per-call scope preserved)", async () => {
+    const tool = await getSgTool();
+    const dir = makeTmpDir();
+    writeFileSync(path.join(dir, "a.ts"), "export const x = 1;\n", "utf8");
+    writeFileSync(path.join(dir, "b.tsx"), "export const App = () => <div/>;\n", "utf8");
+
+    const calls: string[][] = [];
+    vi.mocked(cp.execFile).mockImplementation((_cmd: any, args: any, _opts: any, cb: any) => {
+      calls.push(args);
+      cb(null, "[]", "");
+      return {} as any;
+    });
+
+    try {
+      await tool.execute(
+        "tc",
+        { pattern: "p", lang: "typescript", path: dir },
+        new AbortController().signal,
+        () => {},
+        { cwd: dir },
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    const langIdx = calls[0].indexOf("-l");
+    expect(langIdx).toBeGreaterThan(-1);
+    expect(calls[0][langIdx + 1]).toBe("typescript");
   });
 });


### PR DESCRIPTION
Resolves #179. Batches two independent correctness defects surfaced during live tool break-testing.

## #169 — TypeScript readmap glues literal initializers onto const names

**Symptom:** `export const value = 3;` rendered as `export value3 = ... [1]`; same for `flagtrue`, `name"hello"`, `ptrany`.

**Root cause:** `getVariableSignature` (`src/readmap/mappers/typescript.ts`) fell through to `varDecl.getType().getText()` for literal-initialized consts with no explicit annotation, returning the narrowed literal-type text (`"3"`). The shared formatter (`src/readmap/formatter.ts`) then concatenated that non-name-containing, non-call-shaped signature directly onto the identifier with no separator. A `?? varDecl.getName()` collapse at the call site would have re-broken rendering (dropping the `export` modifier via the formatter's `signature.includes(name)` shortcut) even after fixing the obvious miss.

**Fix:** Narrow the **mapper** contract instead of loosening the formatter (which still correctly serves Python `(x, y) -> None`, Clojure `(name params)`, Rust `pub fn …`):
- `getVariableSignature` returns `undefined` when the initializer isn't arrow/function-shaped and there's no `typeNode`.
- Drop the `?? varDecl.getName()` fallback at the call site so `undefined` propagates honestly.
- Bump `MAPPER_VERSION` 1 → 2 to invalidate the persistent map cache (per `AGENTS.md`).

### Fixed When (#169)
- [x] `export const value = 3;` renders as `export value = ... [N]` (no glued literal)
- [x] `flag = true`, `name = "hello"`, `ptr = null` render with identifier intact
- [x] Arrow-function const `export const fn = (a: number) => a;` still renders the call-shaped signature
- [x] Typed const `export const x: number = 3;` renders without glued type text
- [x] Function rendering unchanged (`add(a: number, b: number): number: [N]`)
- [x] Python/Clojure mapper formatter tests still pass
- [x] `MAPPER_VERSION` bumped (cache invalidation)
- [x] New regression test pins the four literal-initializer cases

## #173 — `ast_search` misses JSX with `lang:"typescript"` on a `.tsx` file

**Symptom:** `ast_search({ lang: "typescript", path: "x.tsx", pattern: "<div>$$$</div>" })` returned 0 matches with ast-grep warning `Pattern contains an ERROR node`. Same pattern with `lang: "tsx"` matched.

**Root cause:** `registerSgTool.execute` forwarded `p.lang` to ast-grep verbatim. ast-grep's TypeScript grammar cannot parse JSX, so explicit `-l typescript` overrode extension-based auto-detection and JSX silently failed.

**Fix:** Per-file normalization (minimal blast radius): when `p.lang === "typescript"` and the resolved `searchPath` is a regular file with extension `.tsx`, push `-l tsx` instead. Directory paths, `.ts` files, and explicit `lang: "tsx"` are untouched.

### Fixed When (#173)
- [x] `ast_search({ lang:"typescript", path:"<file>.tsx", pattern:"<div>$$$</div>" })` returns ≥1 match
- [x] `lang:"typescript"` + `.ts` file is not regressed
- [x] Explicit `lang:"tsx"` + `.tsx` file still matches
- [x] Args forwarded to `sg` include `-l tsx` (not `-l typescript`) for the auto-promotion case
- [x] Directory-scope behavior explicitly addressed and pinned (left as-is)

## Files changed
```
src/readmap/mappers/typescript.ts                     |  23 +++----
src/sg.ts                                             |  21 ++++++-
tests/sg.args.test.ts                                 | 129 ++++++++++++++++++
tests/readmap-typescript-const-literal-format.test.ts |  38 +++++++++ (new)
```

## Verification
- `npm test` — 304 files / 1362 tests passing
- `npm run typecheck` — clean
- Live reproduction of both original symptoms shows them resolved (see `.megapowers/plans/179-readmap-and-structural-search-correctnes/verify.md`)

## Related PRs
Continues the recent correctness pass:
- #99 — Ship 178 pending-preview correctness pass
- #98 — Ship 177 core edit input correctness edge cases
- #96 — Ship 166 structured diff data / inline word diff
