### PR TITLE
feat(tui): pi-inspired tool-display renderer (#180)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,7 @@ import { registerNuTool } from "./src/nu.js";
 import { registerWriteTool } from "./src/write.js";
 import { registerLsTool } from "./src/ls.js";
 import { registerFindTool } from "./src/find.js";
+import { registerBashRendererTool } from "./src/bash-renderer.js";
 import { filterBashOutput } from "./src/rtk/bash-filter.js";
 import { ensureBashOriginalOutputSnapshot, selectBashOriginalOutput } from "./src/rtk/bash-original-output.js";
 import { applyBashContextGuard, resolveBashContextGuardConfig, type BashContextGuardConfig } from "./src/rtk/bash-context-guard.js";
@@ -205,6 +206,7 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
   const writeTool = registerWriteTool(pi, { onFileAnchored: noteRead });
   const lsTool = registerLsTool(pi);
   const findTool = registerFindTool(pi);
+  registerBashRendererTool(pi, { cwd: process.cwd() });
   const contextHygieneDebugTool = registerContextHygieneDebugTool(pi);
   const toolExecutors = {
     read: readTool,

--- a/src/bash-renderer.ts
+++ b/src/bash-renderer.ts
@@ -1,0 +1,52 @@
+import { createBashTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine } from "./tui-render-utils.js";
+
+type BuiltInFactory = (cwd: string) => any;
+
+export function registerBashRendererTool(pi: Pick<ExtensionAPI, "registerTool">, options: { cwd?: string; createBuiltInBashTool?: BuiltInFactory } = {}): any {
+  const cache = new Map<string, any>();
+  const createBuiltInBashTool = options.createBuiltInBashTool ?? ((cwd: string) => createBashTool(cwd));
+  const getBuiltIn = (cwd: string) => {
+    let tool = cache.get(cwd);
+    if (!tool) {
+      tool = createBuiltInBashTool(cwd);
+      cache.set(cwd, tool);
+    }
+    return tool;
+  };
+  const initialCwd = options.cwd ?? process.cwd();
+  const initialBuiltIn = getBuiltIn(initialCwd);
+  const tool = {
+    name: "bash",
+    label: "bash",
+    description: initialBuiltIn?.description ?? "Run bash commands with compact TUI rendering while delegating execution to Pi's built-in bash tool.",
+    parameters: initialBuiltIn?.parameters ?? {},
+    async execute(toolCallId: string, params: any, signal?: AbortSignal, onUpdate?: any, ctx: any = {}) {
+      const cwd = ctx?.cwd ?? options.cwd ?? process.cwd();
+      return getBuiltIn(cwd).execute(toolCallId, params, signal, onUpdate);
+    },
+    renderCall(args: any, theme: any, context: any = {}) {
+      const raw = String(args?.command ?? "");
+      const command = raw.split("\n")[0] + (raw.includes("\n") ? " …" : "");
+      return new Text(clampLineToWidth(`${renderToolLabel(theme, "bash")} ${theme.fg("muted", command)}`, context.width), 0, 0);
+    },
+    renderResult(result: any, optionsArg: any, _theme: any, context: any = {}) {
+      const expanded = isRendererExpanded(optionsArg, context);
+      const width = context.width ?? optionsArg?.width;
+      const text = result.content?.find((item: any) => item.type === "text")?.text ?? "";
+      if (result.isError || context.isError) {
+        const first = text.split("\n")[0] || "command failed";
+        const body = expanded && text ? text : first;
+        return new Text(clampLinesToWidth([summaryLine(body)], width).join("\n"), 0, 0);
+      }
+      if (!text.trim()) return new Text(summaryLine("command completed (no output)"), 0, 0);
+      const lineCount = text.split("\n").filter(Boolean).length;
+      let rendered = summaryLine(`${lineCount} ${lineCount === 1 ? "line" : "lines"} returned`, { hidden: !expanded });
+      if (expanded) rendered += `\n${text}`;
+      return new Text(clampLinesToWidth(rendered.split("\n"), width).join("\n"), 0, 0);
+    },
+  };
+  pi.registerTool(tool as any);
+  return tool;
+}

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -1,4 +1,4 @@
-import { renderDiff, withFileMutationQueue, type ExtensionAPI, type EditToolDetails, type ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
+import { withFileMutationQueue, type ExtensionAPI, type EditToolDetails, type ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import type { Static } from "@sinclair/typebox";
 import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
@@ -12,19 +12,22 @@ import { classifyEdit, isDifftAvailable, runDifftastic } from "./edit-classify.j
 import type { SemanticSummary } from "./ptc-value.js";
 import { buildPtcError } from "./ptc-value.js";
 import { Text } from "@earendil-works/pi-tui";
-import { formatEditCallText, formatEditResultText } from "./edit-render-helpers.js";
+import { countEditTypes, formatEditCallText, formatEditResultText } from "./edit-render-helpers.js";
 import { validateSyntaxRegression } from "./edit-syntax-validate.js";
 import { resolveSyntaxValidateMode, type SyntaxValidateOptions } from "./syntax-validate-mode.js";
 import { replaceSymbol } from "./replace-symbol.js";
 import { buildEditPreviewKey, buildPendingEditPreviewData, resolvePendingDiffPreview, type PendingDiffPreviewResult } from "./pending-diff-preview.js";
 import { buildDiffData, type DiffBlockRange } from "./diff-data.js";
+import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, summaryLine } from "./tui-render-utils.js";
+import { renderTuiDiff } from "./tui-diff-renderer.js";
 
 const EDIT_PENDING_PREVIEW_STATE_KEY = "hashline-edit-pending-preview";
 
-function formatPendingPreviewText(summary: string, preview: PendingDiffPreviewResult | undefined): string {
-	if (!preview || preview.type !== "ok") return summary;
-	const diff = preview.data.diff ? `\n${preview.data.diff}` : "";
-	return `${summary}\n${preview.data.headerLabel}${diff}`;
+function formatPendingPreviewText(summary: string, preview: PendingDiffPreviewResult | undefined, theme: any, width = 80): string {
+	if (!preview || preview.type !== "ok") return clampLinesToWidth(summary.split("\n"), width).join("\n");
+	const diffData = buildDiffData({ path: preview.data.filePath, oldContent: preview.data.previousContent, newContent: preview.data.nextContent, diff: preview.data.diff });
+	const text = `${summary}\n${summaryLine(preview.data.headerLabel)}\n${renderTuiDiff({ diffData, width, theme, expanded: true }).lines.join("\n")}`;
+	return clampLinesToWidth(text.split("\n"), width).join("\n");
 }
 
 export function wrapWriteError(err: any, path: string): Error {
@@ -570,15 +573,20 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			});
 		},
 		renderCall(args: any, theme: any, ...rest: any[]) {
-			const context: { argsComplete?: boolean; lastComponent?: any; cwd?: string; state?: Record<string, any>; invalidate?: () => void } = rest[0] ?? {};
+			const context: { argsComplete?: boolean; lastComponent?: any; cwd?: string; state?: Record<string, any>; invalidate?: () => void; width?: number } = rest[0] ?? {};
 			const argsComplete = context.argsComplete ?? false;
 			const { path: filePath, suffix } = formatEditCallText(args, argsComplete);
 
 			let text = theme.fg("toolTitle", theme.bold("edit"));
 			if (filePath) text += ` ${theme.fg("accent", filePath)}`;
 			else text += ` ${theme.fg("toolOutput", "...")}`;
-			if (suffix) text += ` ${theme.fg("dim", suffix)}`;
-
+			const counts = Array.isArray(args?.edits) ? countEditTypes(args.edits) : undefined;
+			if (counts && counts.total > 0) {
+				text += ` ${theme.fg("dim", `(${counts.total} ${counts.total === 1 ? "edit" : "edits"})`)}`;
+			} else if (suffix) {
+				text += ` ${theme.fg("dim", suffix)}`;
+			}
+			text = clampLineToWidth(text, context.width);
 			const previewKey = buildEditPreviewKey(args ?? {});
 			const preview = resolvePendingDiffPreview(
 				context,
@@ -586,21 +594,20 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				previewKey,
 				() => buildPendingEditPreviewData(args ?? {}, context.cwd ?? process.cwd()),
 			);
-			text = formatPendingPreviewText(text, preview);
-
+			text = formatPendingPreviewText(text, preview, theme, context.width);
 			const component = context.lastComponent ?? new Text("", 0, 0);
 			component.setText(text);
 			return component;
 		},
-		renderResult(result: any, options: ToolRenderResultOptions, theme: any, ...rest: any[]) {
-			const context: { isPartial?: boolean; isError?: boolean; expanded?: boolean; lastComponent?: any } =
+			renderResult(result: any, options: ToolRenderResultOptions, theme: any, ...rest: any[]) {
+			const context: { isPartial?: boolean; isError?: boolean; expanded?: boolean; lastComponent?: any; width?: number } =
 				rest[0] ?? options ?? {};
 			const isPartial = context.isPartial ?? (options as any)?.isPartial ?? false;
 			const isError = context.isError ?? false;
-			const expanded = context.expanded ?? (options as any)?.expanded ?? false;
 
 			if (isPartial) {
-				return new Text(theme.fg("dim", "Editing\u2026"), 0, 0);
+				const width = (context as any).width ?? (options as any)?.width;
+				return new Text(clampLinesToWidth([summaryLine("pending edit")], width).join("\n"), 0, 0);
 			}
 
 			// Extract data from result
@@ -627,52 +634,26 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				semanticClassification: semanticClassification as any,
 			});
 
-			// Build display text
+			const expanded = isRendererExpanded(options as any, context as any);
+			const width = (context as any).width ?? (options as any)?.width;
+			const diffData = (details as any).diffData;
+			const stats = diffData?.stats ?? { added: 0, removed: 0 };
 			let text = "";
 
 			if (info.noOp) {
-				// No-op error
-				text = theme.fg("warning", "\u26a0 no-op");
-				if (expanded && info.errorText) {
-					text += `\n${theme.fg("error", info.errorText)}`;
-				}
+				text = summaryLine("no-op");
+				if (expanded && info.errorText) text += `\n${theme.fg("error", info.errorText)}`;
 			} else if (info.errorText) {
-				// Non-noop error
 				const firstLine = info.errorText.split("\n")[0] || "Error";
-				text = theme.fg("error", firstLine);
-				if (expanded && info.errorText.includes("\n")) {
-					text = theme.fg("error", info.errorText);
-				}
+				text = summaryLine(expanded ? info.errorText : firstLine);
 			} else {
-				// Success
-				const parts: string[] = [];
-				if (info.diffStats) {
-					parts.push(theme.fg("success", info.diffStats));
-				}
-				if (info.warningsBadge) {
-					parts.push(theme.fg("warning", info.warningsBadge));
-				}
-				if (info.semanticBadge) {
-					parts.push(theme.fg("dim", info.semanticBadge));
-				}
-				text = parts.join("  ") || theme.fg("success", "\u2713");
-
-				if (expanded) {
-					if (diff) {
-						text += `\n${renderDiff(diff)}`;
-					}
-					if (warnings.length > 0) {
-						text += `\n${theme.fg("warning", "Warnings:")}`;
-						for (const w of warnings) {
-							text += `\n  ${theme.fg("dim", w)}`;
-						}
-					}
-				}
+				const badges: string[] = [`edited +${stats.added} -${stats.removed}`];
+				if (info.semanticBadge) badges.push(info.semanticBadge.replace(/^✓\s*/, ""));
+				if (info.warningsBadge) badges.push(info.warningsBadge);
+				text = summaryLine(badges.join(" • "), { hidden: !!diffData && !expanded });
+				if (expanded && diffData) text += "\n" + renderTuiDiff({ diffData, width, theme, expanded: true }).lines.join("\n");
 			}
-
-			const component = context.lastComponent ?? new Text("", 0, 0);
-			component.setText(text);
-			return component;
+			return new Text(clampLinesToWidth(text.split("\n"), width).join("\n"), 0, 0);
 		},
 	} satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
 

--- a/src/find.ts
+++ b/src/find.ts
@@ -10,6 +10,7 @@ import * as findStat from "./find-stat.js";
 import { parseRelativeOrIsoDate, parseSize } from "./find-parsers.js";
 import { buildPtcError } from "./ptc-value.js";
 import { coerceObviousBase10Int } from "./coerce-obvious-int.js";
+import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine } from "./tui-render-utils.js";
 
 const MAX_BYTES = 50 * 1024; // 50 KB
 const DEFAULT_LIMIT = 1000;
@@ -600,21 +601,27 @@ export function registerFindTool(pi: ExtensionAPI) {
       };
     },
 
-    renderCall(args: any, theme: any) {
+    renderCall(args: any, theme: any, context: any = {}) {
       const { pattern, path } = args as { pattern: string; path?: string };
-      const label = theme.fg("toolTitle", "🔍 find");
       const target = path ? `${pattern} in ${path}` : pattern;
-      return new Text(`${label} ${theme.fg("muted", target)}`, 0, 0);
+      return new Text(clampLineToWidth(`${renderToolLabel(theme, "find")} ${theme.fg("muted", target)}`, context.width), 0, 0);
     },
 
-    renderResult(result: any, _options: any, theme: any) {
-      const output =
-        result.content[0]?.type === "text"
-          ? (result.content[0] as { type: "text"; text: string }).text
-          : "";
-      const lineCount = output.split("\n").filter((l: string) => l.length > 0 && !l.startsWith("[") && !l.startsWith("Hint")).length;
-      const summary = lineCount > 0 ? `${lineCount} results` : "no results";
-      return new Text(theme.fg("toolOutput", summary), 0, 0);
+    renderResult(result: any, options: any, theme: any, context: any = {}) {
+      const expanded = isRendererExpanded(options, context);
+      const width = context.width ?? options?.width;
+      const output = result.content[0]?.type === "text" ? (result.content[0] as { type: "text"; text: string }).text : "";
+      if (result.isError || context.isError) {
+        const firstLine = output.split("\n")[0] || "error";
+        const body = expanded && output ? output : firstLine;
+        return new Text(clampLinesToWidth(summaryLine(body).split("\n"), width).join("\n"), 0, 0);
+      }
+      const ptcValue = result.details?.ptcValue as { totalEntries?: number } | undefined;
+      const total = ptcValue?.totalEntries ?? output.split("\n").filter((l: string) => l.length > 0 && !l.startsWith("[") && !l.startsWith("Hint")).length;
+      if (total === 0) return new Text(summaryLine("no results"), 0, 0);
+      let text = summaryLine(`${total} ${total === 1 ? "result" : "results"} returned`, { hidden: !!output && !expanded });
+      if (expanded && output) text += `\n${output}`;
+      return new Text(clampLinesToWidth(text.split("\n"), width).join("\n"), 0, 0);
     },
   };
 

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -17,6 +17,7 @@ import { throwIfAborted } from "./runtime";
 import { Text } from "@earendil-works/pi-tui";
 import { formatGrepCallText, formatGrepResultText } from "./grep-render-helpers.js";
 import { coerceObviousBase10Int } from "./coerce-obvious-int.js";
+import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine } from "./tui-render-utils.js";
 
 const GREP_PROMPT_METADATA = defineToolPromptMetadata({
 	promptUrl: new URL("../prompts/grep.md", import.meta.url),
@@ -709,32 +710,30 @@ if (p.scope === "symbol" && !summary) {
 			};
 		},
 		renderCall(args: any, theme: any, ...rest: any[]) {
-			const _context = rest[0];
+			const context = rest[0] ?? {};
 			const { pattern, suffix } = formatGrepCallText(args);
-
-			let text = theme.fg("toolTitle", theme.bold("grep "));
-			text += theme.fg("accent", pattern);
-			if (suffix) {
-				text += theme.fg("dim", ` ${suffix}`);
-			}
-			return new Text(text, 0, 0);
+			let text = `${renderToolLabel(theme, "grep")} ${theme.fg("accent", `/${pattern}/`)}`;
+			if (suffix) text += theme.fg("dim", ` in ${suffix}`);
+			return new Text(clampLineToWidth(text, context.width), 0, 0);
 		},
 		renderResult(result: any, options: ToolRenderResultOptions, theme: any, ...rest: any[]) {
-			const context: { isPartial?: boolean; isError?: boolean; expanded?: boolean; cwd?: string } =
+			const context: { isPartial?: boolean; isError?: boolean; expanded?: boolean; cwd?: string; width?: number } =
 				rest[0] ?? options ?? {};
 			const isPartial = context.isPartial ?? (options as any)?.isPartial ?? false;
 			const isError = context.isError ?? false;
-			const expanded = context.expanded ?? (options as any)?.expanded ?? false;
+			const expanded = isRendererExpanded(options as any, context as any);
 			const cwd = context.cwd ?? process.cwd();
+			const width = (context as any).width ?? (options as any)?.width;
 
-			if (isPartial) return new Text(theme.fg("warning", "Searching\u2026"), 0, 0);
+			if (isPartial) return new Text(clampLinesToWidth([summaryLine("pending search")], width).join("\n"), 0, 0);
 
 			const content = result.content?.[0];
 			const textContent = content?.type === "text" ? content.text : "";
 
 			if (isError || result.isError) {
 				const firstLine = textContent.split("\n")[0] || "Error";
-				return new Text(theme.fg("error", firstLine), 0, 0);
+				const body = expanded && textContent ? textContent : firstLine;
+				return new Text(clampLinesToWidth(summaryLine(body).split("\n"), width).join("\n"), 0, 0);
 			}
 
 			const ptcValue = (result.details as any)?.ptcValue as {
@@ -759,44 +758,21 @@ if (p.scope === "symbol" && !summary) {
 				hasBinaryWarning,
 			});
 
-			if (info.noMatches && !hasBinaryWarning) {
-				return new Text(theme.fg("muted", "No matches"), 0, 0);
-			}
-
-			const parts: string[] = [];
-			if (info.summary) {
-				parts.push(theme.fg(info.truncated ? "warning" : "success", info.summary));
-			}
-
-			for (const badge of info.badges) {
-				if (badge.startsWith("\u26a0")) {
-					parts.push(theme.fg("warning", badge));
-				} else {
-					parts.push(theme.fg("dim", badge));
-				}
-			}
-
-			let text = parts.join("  ") || theme.fg("muted", "No matches");
-
+			if (info.noMatches && !hasBinaryWarning) return new Text(summaryLine("no matches"), 0, 0);
+			const matchCount = ptcValue?.totalMatches ?? 0;
+			const matchWord = matchCount === 1 ? "match" : "matches";
+			let text = summaryLine(`${matchCount} ${matchWord} returned`, { hidden: !!textContent && !expanded });
+			for (const badge of info.badges) text += theme.fg(badge.startsWith("⚠") ? "warning" : "dim", `  ${badge}`);
 			if (expanded && ptcValue?.records) {
 				const fileCounts = new Map<string, number>();
-				for (const r of ptcValue.records) {
-					if (r.path && r.kind === "match") {
-						fileCounts.set(r.path, (fileCounts.get(r.path) ?? 0) + 1);
-					}
-				}
-				const entries = [...fileCounts.entries()].sort((a, b) => b[1] - a[1]);
-				const showEntries = entries.slice(0, 20);
-				for (const [filePath, count] of showEntries) {
+				for (const r of ptcValue.records) if (r.path && r.kind === "match") fileCounts.set(r.path, (fileCounts.get(r.path) ?? 0) + 1);
+				for (const [filePath, count] of [...fileCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 20)) {
 					const display = path.relative(cwd, filePath) || filePath;
 					text += "\n" + theme.fg("dim", `  ${display} (${count})`);
 				}
-				if (entries.length > 20) {
-					text += "\n" + theme.fg("muted", `  \u2026 and ${entries.length - 20} more files`);
-				}
+				if (fileCounts.size > 20) text += "\n" + theme.fg("muted", `  … and ${fileCounts.size - 20} more files`);
 			}
-
-			return new Text(text, 0, 0);
+			return new Text(clampLinesToWidth(text.split("\n"), width).join("\n"), 0, 0);
 		},
 	} satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
 

--- a/src/ls.ts
+++ b/src/ls.ts
@@ -6,6 +6,7 @@ import { readdir, stat } from "node:fs/promises";
 import { resolveToCwd } from "./path-utils.js";
 import { buildPtcError } from "./ptc-value.js";
 import { coerceObviousBase10Int } from "./coerce-obvious-int.js";
+import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine } from "./tui-render-utils.js";
 
 const MAX_BYTES = 50 * 1024; // 50 KB
 const DEFAULT_LIMIT = 500;
@@ -261,19 +262,26 @@ export function registerLsTool(pi: ExtensionAPI) {
       };
     },
 
-    renderCall(args: any, theme: any) {
+    renderCall(args: any, theme: any, context: any = {}) {
       const { path } = args as { path?: string };
-      const label = theme.fg("toolTitle", "📁 ls");
-      const target = path ?? ".";
-      return new Text(`${label} ${theme.fg("muted", target)}`, 0, 0);
+      return new Text(clampLineToWidth(`${renderToolLabel(theme, "ls")} ${theme.fg("muted", path ?? ".")}`, context.width), 0, 0);
     },
 
-    renderResult(result: any, _options: any, theme: any) {
-      const output =
-        result.content[0]?.type === "text"
-          ? (result.content[0] as { type: "text"; text: string }).text
-          : "";
-      return new Text(theme.fg("toolOutput", output), 0, 0);
+    renderResult(result: any, options: any, theme: any, context: any = {}) {
+      const expanded = isRendererExpanded(options, context);
+      const width = context.width ?? options?.width;
+      const output = result.content[0]?.type === "text" ? (result.content[0] as { type: "text"; text: string }).text : "";
+      if (result.isError || context.isError) {
+        const firstLine = output.split("\n")[0] || "error";
+        const body = expanded && output ? output : firstLine;
+        return new Text(clampLinesToWidth(summaryLine(body).split("\n"), width).join("\n"), 0, 0);
+      }
+      const ptcValue = result.details?.ptcValue as { totalEntries?: number } | undefined;
+      const total = ptcValue?.totalEntries ?? output.split("\n").filter(Boolean).length;
+      if (total === 0) return new Text(summaryLine("no entries"), 0, 0);
+      let text = summaryLine(`${total} ${total === 1 ? "entry" : "entries"} returned`, { hidden: !!output && !expanded });
+      if (expanded && output) text += `\n${output}`;
+      return new Text(clampLinesToWidth(text.split("\n"), width).join("\n"), 0, 0);
     },
   };
 

--- a/src/nu.ts
+++ b/src/nu.ts
@@ -9,6 +9,7 @@ import { randomBytes } from "node:crypto";
 import { buildPtcError } from "./ptc-value.js";
 import { stripAnsi } from "./rtk/ansi.js";
 import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
+import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine } from "./tui-render-utils.js";
 
 const MAX_LINES = 2000;
 const MAX_BYTES = 50 * 1024; // 50 KB
@@ -385,22 +386,26 @@ export function registerNuTool(pi: ExtensionAPI): NuToolDefinition | false {
         },
       };
     },
-    renderCall(args: any, theme: any) {
+    renderCall(args: any, theme: any, context: any = {}) {
       const { command } = args as { command: string };
-      const label = theme.fg("toolTitle", "🐚 nushell");
       const firstLine = command.split("\n")[0];
       const preview = firstLine + (command.includes("\n") ? " …" : "");
-      const full = command.includes("\n")
-        ? "\n" + theme.fg("muted", command)
-        : "";
-      return new Text(`${label} ${theme.fg("muted", preview)}${full}`, 0, 0);
+      return new Text(clampLineToWidth(`${renderToolLabel(theme, "nu")} ${theme.fg("muted", preview)}`, context.width), 0, 0);
     },
-    renderResult(result, _options, theme) {
-      const output =
-        result.content[0]?.type === "text"
-          ? (result.content[0] as { type: "text"; text: string }).text
-          : "";
-      return new Text(theme.fg("toolOutput", output), 0, 0);
+    renderResult(result: any, options: any, theme: any, context: any = {}) {
+      const expanded = isRendererExpanded(options, context);
+      const width = context.width ?? options?.width;
+      const output = result.content[0]?.type === "text" ? (result.content[0] as { type: "text"; text: string }).text : "";
+      if (result.isError || context.isError) {
+        const firstLine = output.split("\n")[0] || "command failed";
+        const body = expanded && output ? output : firstLine;
+        return new Text(clampLinesToWidth(summaryLine(body).split("\n"), width).join("\n"), 0, 0);
+      }
+      if (!output.trim()) return new Text(summaryLine("command completed (no output)"), 0, 0);
+      const lineCount = output.split("\n").filter(Boolean).length;
+      let text = summaryLine(`${lineCount} ${lineCount === 1 ? "line" : "lines"} returned`, { hidden: !expanded });
+      if (expanded) text += `\n${output}`;
+      return new Text(clampLinesToWidth(text.split("\n"), width).join("\n"), 0, 0);
     },
   } satisfies NuToolDefinition;
   pi.registerTool(tool);

--- a/src/read.ts
+++ b/src/read.ts
@@ -25,6 +25,7 @@ import { buildLocalBundle } from "./read-local-bundle.js";
 import { coerceObviousBase10Int } from "./coerce-obvious-int.js";
 import { Text } from "@earendil-works/pi-tui";
 import { formatReadCallText, formatReadResultText } from "./read-render-helpers.js";
+import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine, wrapReadHashlinesForWidth } from "./tui-render-utils.js";
 
 const READ_PROMPT_METADATA = defineToolPromptMetadata({
 	promptUrl: new URL("../prompts/read.md", import.meta.url),
@@ -591,85 +592,48 @@ return succeed({
 });
 		},
 		renderCall(args: any, theme: any, ...rest: any[]) {
-			const _context = rest[0];
+			const context = rest[0] ?? {};
 			const { path: filePath, suffix } = formatReadCallText(args);
-
-			let text = theme.fg("toolTitle", theme.bold("read"));
-			if (filePath) {
-				text += ` ${theme.fg("accent", filePath)}`;
-			} else {
-				text += ` ${theme.fg("toolOutput", "...")}`;
-			}
-			if (suffix) {
-				text += ` ${theme.fg("dim", suffix)}`;
-			}
-			return new Text(text, 0, 0);
+			const rangeSuffix = typeof args?.offset === "number" && typeof args?.limit === "number" && args.offset > 0 && args.limit > 0
+				? `:${args.offset}-${args.offset + args.limit - 1}`
+				: "";
+			let text = renderToolLabel(theme, "read");
+			text += filePath ? ` ${theme.fg("accent", `${filePath}${rangeSuffix}`)}` : ` ${theme.fg("toolOutput", "...")}`;
+			if (!rangeSuffix && suffix) text += ` ${theme.fg("dim", suffix)}`;
+			return new Text(clampLineToWidth(text, context.width), 0, 0);
 		},
 		renderResult(result: any, options: ToolRenderResultOptions, theme: any, ...rest: any[]) {
-			const context: { isPartial?: boolean; isError?: boolean; expanded?: boolean; cwd?: string } =
-				rest[0] ?? options ?? {};
+			const context: { isPartial?: boolean; isError?: boolean; expanded?: boolean; cwd?: string; width?: number } = rest[0] ?? options ?? {};
 			const isPartial = context.isPartial ?? (options as any)?.isPartial ?? false;
 			const isError = context.isError ?? false;
-			const expanded = context.expanded ?? (options as any)?.expanded ?? false;
-
-			if (isPartial) return new Text(theme.fg("dim", "Reading\u2026"), 0, 0);
+			const expanded = isRendererExpanded(options as any, context as any);
+			const width = context.width ?? (options as any)?.width;
+			if (isPartial) return new Text(clampLinesToWidth([summaryLine("pending read")], width).join("\n"), 0, 0);
 
 			const content = result.content?.[0];
 			const textContent = content?.type === "text" ? content.text : "";
-
 			if (isError || result.isError) {
 				const firstLine = textContent.split("\n")[0] || "Error";
-				if (expanded) {
-					return new Text(theme.fg("error", textContent || firstLine), 0, 0);
-				}
-				return new Text(theme.fg("error", firstLine), 0, 0);
+				const errorText = expanded ? (textContent || firstLine) : firstLine;
+				return new Text(clampLinesToWidth([summaryLine(errorText)], width).join("\n"), 0, 0);
 			}
 
-			const ptcValue = (result.details as any)?.ptcValue as {
-				tool: "read";
-				range: { startLine: number; endLine: number; totalLines: number };
-				warnings: PtcWarning[];
-				truncation: { outputLines: number; totalLines: number; outputBytes: number; totalBytes: number } | null;
-				symbol: { query: string; name: string; kind: string; parentName?: string; startLine: number; endLine: number } | null;
-				map: { requested: boolean; appended: boolean };
-			} | undefined;
-
+			const ptcValue = (result.details as any)?.ptcValue as { range: { startLine: number; endLine: number; totalLines: number }; truncation: any; symbol: any; map: any; warnings: PtcWarning[] } | undefined;
 			if (!ptcValue) {
-				const lines = textContent.split("\n").length;
-				return new Text(theme.fg("success", `\u2713 ${lines} lines`), 0, 0);
+				const lines = textContent.split("\n").filter(Boolean).length || textContent.split("\n").length;
+				return new Text(summaryLine(`loaded ${lines} ${lines === 1 ? "line" : "lines"}`, { hidden: !!textContent && !expanded }), 0, 0);
 			}
 
-			const info = formatReadResultText({
-				range: ptcValue.range,
-				truncation: ptcValue.truncation,
-				symbol: ptcValue.symbol,
-				map: ptcValue.map,
-				warnings: ptcValue.warnings,
-			});
-
-			const parts: string[] = [];
-
-			if (info.symbolBadge) {
-				parts.push(theme.fg("success", `\u2713 ${info.symbolBadge}`));
-			}
-
-			parts.push(theme.fg(info.truncated ? "warning" : "success", info.summary));
-
-			for (const badge of info.badges) {
-				if (badge.startsWith("\u26a0")) {
-					parts.push(theme.fg("warning", badge));
-				} else {
-					parts.push(theme.fg("dim", badge));
-				}
-			}
-
-			let text = parts.join("  ");
-
-			if (expanded && textContent) {
-				text += "\n" + textContent;
-			}
-
-			return new Text(text, 0, 0);
+			const info = formatReadResultText({ range: ptcValue.range, truncation: ptcValue.truncation, symbol: ptcValue.symbol, map: ptcValue.map, warnings: ptcValue.warnings });
+			const visibleLines = info.truncated && ptcValue.truncation ? ptcValue.truncation.outputLines : ptcValue.range.endLine - ptcValue.range.startLine + 1;
+			const loadedWord = visibleLines === 1 ? "line" : "lines";
+			const summaryParts: string[] = [info.truncated ? `loaded ${visibleLines} of ${ptcValue.truncation?.totalLines ?? ptcValue.range.totalLines} ${loadedWord} (truncated)` : `loaded ${visibleLines} ${loadedWord}`];
+			if (info.symbolBadge) summaryParts.push(info.symbolBadge);
+			for (const badge of info.badges) summaryParts.push(badge);
+			const summary = summaryParts.join(" • ");
+			let text = summaryLine(summary, { hidden: !!textContent && !expanded });
+			if (expanded && textContent) text += "\n" + wrapReadHashlinesForWidth(textContent, width);
+			return new Text(clampLinesToWidth(text.split("\n"), width).join("\n"), 0, 0);
 		},
 	} satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
 

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -12,6 +12,7 @@ import { resolveToCwd } from "./path-utils.js";
 import type { FileSymbol } from "./readmap/types.js";
 import { buildSgOutput } from "./sg-output.js";
 import { buildAstSearchRehydrateDescriptor, isContextHygieneDebugEnabled } from "./context-hygiene.js";
+import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine } from "./tui-render-utils.js";
 
 type SgParams = { pattern: string; lang?: string; path?: string };
 const CONTEXT_HYGIENE_SG_SYMBOL_FILE_CAP = 20;
@@ -383,60 +384,50 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
       }
     },
     renderCall(args: any, theme: any, ...rest: any[]) {
-      const _context = rest[0];
-      let text = theme.fg("toolTitle", theme.bold("ast_search "));
-      text += theme.fg("accent", args.pattern);
-      if (args.lang) {
-        text += theme.fg("dim", ` (${args.lang})`);
-      }
-      if (args.path && args.path !== ".") {
-        text += theme.fg("dim", ` ${args.path}`);
-      }
-      return new Text(text, 0, 0);
+      const context = rest[0] ?? {};
+      let text = `${renderToolLabel(theme, "ast_search")} ${theme.fg("accent", `/${args.pattern}/`)}`;
+      text += theme.fg("dim", ` in ${args.path ?? "."}`);
+      if (args.lang) text += theme.fg("dim", ` (${args.lang})`);
+      return new Text(clampLineToWidth(text, context.width), 0, 0);
     },
     renderResult(result: any, options: ToolRenderResultOptions, theme: any, ...rest: any[]) {
-      const context: { isPartial?: boolean; isError?: boolean; expanded?: boolean; cwd?: string } =
+      const context: { isPartial?: boolean; isError?: boolean; expanded?: boolean; cwd?: string; width?: number } =
         rest[0] ?? options ?? {};
       // In older pi versions, options has expanded/isPartial directly.
       // In newer pi versions, context (4th arg) has expanded/isPartial/isError.
       const isPartial = context.isPartial ?? (options as any)?.isPartial ?? false;
       const isError = context.isError ?? false;
-      const expanded = context.expanded ?? (options as any)?.expanded ?? false;
+      const expanded = isRendererExpanded(options as any, context as any);
       const cwd = context.cwd ?? process.cwd();
+      const width = (context as any).width ?? (options as any)?.width;
 
-      if (isPartial) return new Text(theme.fg("warning", "Searching\u2026"), 0, 0);
+      if (isPartial) return new Text(clampLinesToWidth([summaryLine("pending search")], width).join("\n"), 0, 0);
 
       const content = result.content?.[0];
       const textContent = content?.type === "text" ? content.text : "";
       if (isError || result.isError) {
         const firstLine = textContent.split("\n")[0] || "Error";
-        return new Text(theme.fg("error", firstLine), 0, 0);
+        const body = expanded && textContent ? textContent : firstLine;
+        return new Text(clampLinesToWidth(summaryLine(body).split("\n"), width).join("\n"), 0, 0);
       }
       const ptcValue = (result.details as any)?.ptcValue as
         | { tool: "ast_search"; files: Array<{ path: string; lines: any[] }> }
         | undefined;
       const files = ptcValue?.files ?? [];
-      if (files.length === 0) {
-        return new Text(theme.fg("muted", "No matches"), 0, 0);
-      }
+      if (files.length === 0) return new Text(summaryLine("no matches"), 0, 0);
       const fileCount = files.length;
       const totalMatches = files.reduce((sum: number, f: any) => sum + f.lines.length, 0);
       const matchWord = totalMatches === 1 ? "match" : "matches";
       const fileWord = fileCount === 1 ? "file" : "files";
-      let text = theme.fg("success", `\u2713 ${totalMatches} ${matchWord} in ${fileCount} ${fileWord}`);
-
+      let text = summaryLine(`${totalMatches} ${matchWord} in ${fileCount} ${fileWord}`, { hidden: files.length > 0 && !expanded });
       if (expanded) {
-        const showFiles = files.slice(0, 20);
-        for (const file of showFiles) {
+        for (const file of files.slice(0, 20)) {
           const display = path.relative(cwd, file.path) || file.path;
           text += "\n" + theme.fg("dim", `  ${display} (${file.lines.length})`);
         }
-        if (files.length > 20) {
-          text += "\n" + theme.fg("muted", `  \u2026 and ${files.length - 20} more files`);
-        }
+        if (files.length > 20) text += "\n" + theme.fg("muted", `  … and ${files.length - 20} more files`);
       }
-
-      return new Text(text, 0, 0);
+      return new Text(clampLinesToWidth(text.split("\n"), width).join("\n"), 0, 0);
     },
   } satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
 

--- a/src/tui-diff-renderer.ts
+++ b/src/tui-diff-renderer.ts
@@ -1,0 +1,50 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import type { DiffData, DiffEntry, DiffSpan } from "./diff-data.js";
+import { clampLineToWidth, clampLinesToWidth, normalizeWidth, type RendererTheme } from "./tui-render-utils.js";
+
+export type TuiDiffMode = "split" | "unified" | "compact" | "summary";
+export type RenderTuiDiffInput = { diffData: DiffData; width: number; theme: RendererTheme; expanded: boolean };
+export type RenderTuiDiffOutput = { mode: TuiDiffMode; width: number; lines: string[] };
+
+function chooseMode(width: number): TuiDiffMode { return width >= 100 ? "split" : width >= 50 ? "unified" : width >= 24 ? "compact" : "summary"; }
+function hunkCount(data: DiffData): number { return Math.max(1, data.blockRanges?.length ?? (data.entries.some((e) => e.kind === "add" || e.kind === "remove") ? 1 : 0)); }
+function compactHeader(data: DiffData): string { return `↳ diff +${data.stats.added} -${data.stats.removed}`; }
+function header(data: DiffData, mode: TuiDiffMode, width: number): string {
+  if (mode === "summary" && width <= 10) return `↳ diff +${data.stats.added}`;
+  const full = `${compactHeader(data)} • ${hunkCount(data)} hunk • 1 file • ${mode === "split" ? "split" : "unified"}`;
+  return visibleWidth(full) <= width ? full : clampLineToWidth(compactHeader(data), width);
+}
+function lineNo(entry: DiffEntry): string { return String(entry.kind === "add" ? entry.newLine : entry.kind === "remove" ? entry.oldLine : entry.kind === "context" ? entry.newLine : ""); }
+function textOf(entry: DiffEntry): string { return "text" in entry ? entry.text : ""; }
+function tint(theme: RendererTheme, entry: DiffEntry, text: string): string { return entry.kind === "add" ? theme.fg("success", text) : entry.kind === "remove" ? theme.fg("error", text) : theme.fg("toolOutput", text); }
+function spans(theme: RendererTheme, spans: DiffSpan[] | undefined, fallback: string): string { return spans?.map((s) => s.kind === "add" ? theme.fg("success", s.text) : s.kind === "remove" ? theme.fg("error", s.text) : s.text).join("") ?? fallback; }
+function inlineText(input: RenderTuiDiffInput, index: number, entry: DiffEntry): string {
+  const pair = input.diffData.inlineDiffs?.find((d) => entry.kind === "remove" ? d.removeLineIndex === index : entry.kind === "add" ? d.addLineIndex === index : false);
+  if (!pair) return textOf(entry);
+  return entry.kind === "remove" ? spans(input.theme, pair.removeSpans, textOf(entry)) : entry.kind === "add" ? spans(input.theme, pair.addSpans, textOf(entry)) : textOf(entry);
+}
+function unifiedRows(input: RenderTuiDiffInput): string[] { return input.diffData.entries.map((e, i) => e.kind === "meta" ? null : tint(input.theme, e, `▌ ${lineNo(e)} │ ${inlineText(input, i, e)}`)).filter((row): row is string => row !== null); }
+function compactRows(input: RenderTuiDiffInput): string[] { return input.diffData.entries.map((e, i) => e.kind === "add" || e.kind === "remove" ? tint(input.theme, e, `▌ ${lineNo(e)} ${inlineText(input, i, e)}`) : null).filter((row): row is string => row !== null); }
+function splitRows(input: RenderTuiDiffInput, width: number): string[] {
+  const pane = Math.max(10, Math.floor((width - 3) / 2));
+  const rows = [`${"old".padEnd(pane)} │ new`];
+  for (const [i, e] of input.diffData.entries.entries()) {
+    if (e.kind === "remove") rows.push(`${clampLineToWidth(`▌ ${e.oldLine} │ ${inlineText(input, i, e)}`, pane)} │ ${""}`);
+    else if (e.kind === "add") rows.push(`${"".padEnd(pane)} │ ${clampLineToWidth(`▌ ${e.newLine} │ ${inlineText(input, i, e)}`, pane)}`);
+    else if (e.kind === "context") rows.push(`${clampLineToWidth(`  ${e.oldLine} │ ${e.text}`, pane)} │ ${clampLineToWidth(`  ${e.newLine} │ ${e.text}`, pane)}`);
+  }
+  return rows;
+}
+function hiddenHint(hiddenLines: number, hiddenHunks: number, width: number): string {
+  const forms = [`… (${hiddenLines} more diff lines • ${hiddenHunks} more hunk${hiddenHunks === 1 ? "" : "s"} • Ctrl+O to expand)`, `… (${hiddenLines} more lines • ${hiddenHunks} hunks)`, `… (+${hiddenLines} • +${hiddenHunks}h)`, "…"];
+  return forms.find((f) => visibleWidth(f) <= width) ?? "…";
+}
+export function renderTuiDiff(input: RenderTuiDiffInput): RenderTuiDiffOutput {
+  const width = normalizeWidth(input.width);
+  const mode = chooseMode(width);
+  const lines = [header(input.diffData, mode, width)];
+  if (!input.expanded) return { mode, width, lines: clampLinesToWidth([...lines, hiddenHint(input.diffData.entries.length, hunkCount(input.diffData), width)], width) };
+  if (mode === "summary") return { mode, width, lines: clampLinesToWidth(lines, width) };
+  const rows = mode === "split" ? splitRows(input, width) : mode === "compact" ? compactRows(input) : unifiedRows(input);
+  return { mode, width, lines: clampLinesToWidth([...lines, ...rows], width) };
+}

--- a/src/tui-render-utils.ts
+++ b/src/tui-render-utils.ts
@@ -1,0 +1,85 @@
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+
+export const SUMMARY_PREFIX = "↳";
+export const EXPAND_HINT = " • Ctrl+O to expand";
+
+export type RendererTheme = {
+  fg(style: string, text: string): string;
+  bold(text: string): string;
+};
+
+export function renderToolLabel(theme: RendererTheme, label: string): string {
+  const boldFn = typeof theme.bold === "function" ? theme.bold.bind(theme) : (text: string) => text;
+  return theme.fg("toolTitle", boldFn(label));
+}
+
+export function appendExpandHint(text: string, hidden: boolean): string {
+  return hidden ? `${text}${EXPAND_HINT}` : text;
+}
+
+export function summaryLine(summary: string, options: { hidden?: boolean } = {}): string {
+  return appendExpandHint(`${SUMMARY_PREFIX} ${summary}`, !!options.hidden);
+}
+
+export function isRendererExpanded(options?: { expanded?: boolean }, context?: { expanded?: boolean }): boolean {
+  return context?.expanded ?? options?.expanded ?? false;
+}
+
+export function normalizeWidth(width: unknown, fallback = 80): number {
+  return typeof width === "number" && Number.isFinite(width) && width > 0 ? Math.floor(width) : fallback;
+}
+
+export function clampLineToWidth(line: string, width: number | undefined): string {
+  if (width === undefined || width === null) return line;
+  const normalized = normalizeWidth(width);
+  return visibleWidth(line) <= normalized ? line : truncateToWidth(line, normalized);
+}
+
+export function clampLinesToWidth(lines: string[], width: number | undefined): string[] {
+  if (width === undefined || width === null) return lines;
+  return lines.map((line) => clampLineToWidth(line, width));
+}
+
+export function wrapLinesToWidth(lines: string[], width: number | undefined): string[] {
+  if (width === undefined || width === null) return lines;
+  const normalized = normalizeWidth(width);
+  return lines.flatMap((line) => {
+    if (visibleWidth(line) <= normalized) return [line];
+    return wrapTextWithAnsi(line, normalized).map((wrapped) => clampLineToWidth(wrapped, normalized));
+  });
+}
+
+const HASHLINE_CONTENT_RE = /^(\d+:[0-9a-fA-F]+\|)(.*)$/;
+
+export function wrapReadHashlinesForWidth(text: string, width: number | undefined): string {
+  if (width === undefined || width === null) return text;
+  const normalized = normalizeWidth(width);
+  const output: string[] = [];
+  for (const line of text.split("\n")) {
+    const match = line.match(HASHLINE_CONTENT_RE);
+    if (!match) {
+      output.push(line);
+      continue;
+    }
+    if (visibleWidth(line) <= normalized) {
+      output.push(line);
+      continue;
+    }
+
+    const prefix = match[1]!;
+    const content = match[2] ?? "";
+    const prefixWidth = visibleWidth(prefix);
+    const contentWidth = Math.max(1, normalized - prefixWidth);
+    const wrappedContent = wrapTextWithAnsi(content, contentWidth).map((wrapped) => clampLineToWidth(wrapped, contentWidth));
+    if (wrappedContent.length === 0) {
+      output.push(clampLineToWidth(prefix, normalized));
+      continue;
+    }
+    output.push(clampLineToWidth(prefix + wrappedContent[0], normalized));
+    const indent = " ".repeat(prefixWidth);
+    for (const continuation of wrappedContent.slice(1)) {
+      output.push(clampLineToWidth(indent + continuation, normalized));
+    }
+  }
+  return output.join("\n");
+}

--- a/src/write.ts
+++ b/src/write.ts
@@ -14,13 +14,18 @@ import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 import { buildPendingWritePreviewData, buildWritePreviewKey, resolvePendingDiffPreview, type PendingDiffPreviewResult } from "./pending-diff-preview.js";
 import { generateCompactOrFullDiff, normalizeToLF, hasBareCarriageReturn } from "./edit-diff.js";
 import { buildDiffData, type DiffData } from "./diff-data.js";
+import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine } from "./tui-render-utils.js";
+import { renderTuiDiff } from "./tui-diff-renderer.js";
 
 const WRITE_PENDING_PREVIEW_STATE_KEY = "hashline-write-pending-preview";
 
-function formatPendingWritePreviewText(summary: string, preview: PendingDiffPreviewResult | undefined): string {
-	if (!preview || preview.type !== "ok") return summary;
-	const diff = preview.data.diff ? `\n${preview.data.diff}` : "";
-	return `${summary}\n${preview.data.headerLabel}${diff}`;
+function formatPendingWritePreviewText(summary: string, preview: PendingDiffPreviewResult | undefined, theme: any, width: number | undefined): string {
+  if (!preview || preview.type !== "ok") return width === undefined ? summary : clampLinesToWidth(summary.split("\n"), width).join("\n");
+  const diffWidth = width ?? 80;
+  const diffData = buildDiffData({ path: preview.data.filePath, oldContent: preview.data.previousContent, newContent: preview.data.nextContent, diff: preview.data.diff });
+  const diffLines = renderTuiDiff({ diffData, width: diffWidth, theme, expanded: true }).lines;
+  const lines = [summary, summaryLine(preview.data.headerLabel), ...diffLines];
+  return width === undefined ? lines.join("\n") : clampLinesToWidth(lines, width).join("\n");
 }
 
 const MAX_LINES = 2000;
@@ -43,6 +48,7 @@ type WriteDiffFields = {
 export interface WriteResult extends WriteDiffFields {
   text: string;
   warnings: string[];
+  writeState?: "created" | "overwritten";
   ptcValue: {
     tool: "write";
     path: string;
@@ -169,6 +175,7 @@ export async function executeWrite(opts: {
     };
   }
   const previousContent = readPreviousTextForDiff(filePath);
+  const existedBeforeWrite = existsSync(filePath);
 
   // Create parent directories
   try {
@@ -257,6 +264,7 @@ export async function executeWrite(opts: {
   return {
     text,
     warnings,
+    writeState: existedBeforeWrite ? "overwritten" : "created",
     diff: diffResult.diff,
     diffData,
     ptcValue: {
@@ -367,6 +375,7 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
         details: {
           ...(result.diff !== undefined ? { diff: result.diff } : {}),
           ...(result.diffData !== undefined ? { diffData: result.diffData } : {}),
+          ...(result.writeState ? { writeState: result.writeState } : {}),
           ptcValue: result.ptcValue,
           warnings: result.warnings,
           contextHygiene: result.contextHygiene,
@@ -375,28 +384,33 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
       });
     },
     renderCall(args: any, theme: any, context: any = {}) {
-      const { path } = args as { path: string };
-      const label = theme.fg("toolTitle", "✏️ write");
-      let text = `${label} ${theme.fg("muted", path)}`;
+      const { path, content } = args as { path: string; content?: string };
+      const label = renderToolLabel(theme, "write");
+      const lineCount = typeof content === "string" ? content.split("\n").length : 0;
+      const bytes = typeof content === "string" ? Buffer.byteLength(content, "utf8") : 0;
+      let text = clampLineToWidth(`${label} ${theme.fg("muted", path)}${typeof content === "string" ? ` (${lineCount} ${lineCount === 1 ? "line" : "lines"} • ${bytes} B)` : ""}`, context.width);
       const previewKey = buildWritePreviewKey(args ?? {});
-      const preview = resolvePendingDiffPreview(
-        context,
-        WRITE_PENDING_PREVIEW_STATE_KEY,
-        previewKey,
-        () => buildPendingWritePreviewData(args ?? {}, context.cwd ?? process.cwd()),
-      );
-      text = formatPendingWritePreviewText(text, preview);
+      const preview = resolvePendingDiffPreview(context, WRITE_PENDING_PREVIEW_STATE_KEY, previewKey, () => buildPendingWritePreviewData(args ?? {}, context.cwd ?? process.cwd()));
+      text = formatPendingWritePreviewText(text, preview, theme, context.width);
       const component = context.lastComponent ?? new Text("", 0, 0);
       component.setText(text);
       return component;
     },
-    renderResult(result: any, _options: any, theme: any) {
-      const output = result.content[0]?.type === "text"
-        ? (result.content[0] as { type: "text"; text: string }).text
-        : "";
-      const lineCount = output.split("\n").filter((l: string) => /^\d+:[0-9a-f]{3}\|/.test(l)).length;
-      const summary = lineCount > 0 ? `${lineCount} lines written` : "written";
-      return new Text(theme.fg("toolOutput", summary), 0, 0);
+    renderResult(result: any, options: any, theme: any, context: any = {}) {
+      const expanded = isRendererExpanded(options, context);
+      const width = context.width ?? options?.width;
+      const details = result.details ?? {};
+      const output = result.content?.[0]?.type === "text" ? result.content[0].text : "";
+      if (result.isError || details.ptcValue?.ok === false) {
+        const firstLine = output.split("\n")[0] || "write failed";
+        const body = expanded && output ? output : firstLine;
+        return new Text(clampLinesToWidth(summaryLine(body).split("\n"), width).join("\n"), 0, 0);
+      }
+      const diffData = details.diffData;
+      const state = details.writeState === "overwritten" ? "overwritten" : "created";
+      let text = summaryLine(state, { hidden: !!diffData && !expanded });
+      if (expanded && diffData) text += "\n" + renderTuiDiff({ diffData, width, theme, expanded: true }).lines.join("\n");
+      return new Text(clampLinesToWidth(text.split("\n"), width).join("\n"), 0, 0);
     },
   };
   pi.registerTool(tool);

--- a/tests/bash-renderer-wrapper.test.ts
+++ b/tests/bash-renderer-wrapper.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { registerBashRendererTool } from "../src/bash-renderer.js";
+
+const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
+function textOf(component: any): string { return component?.text ?? component?.render?.(80)?.join("\n") ?? ""; }
+
+describe("bash renderer wrapper", () => {
+  it("delegates execution to a built-in bash tool and renders compact summaries", async () => {
+    const execute = vi.fn(async (_toolCallId, _params, _signal, _onUpdate) => ({ content: [{ type: "text", text: "ok\n" }], details: { delegated: true } }));
+    const createBuiltIn = vi.fn(() => ({ name: "bash", label: "bash", description: "bash", parameters: {}, execute }));
+    let registered: any;
+    registerBashRendererTool({ registerTool(def: any) { registered = def; } } as any, { createBuiltInBashTool: createBuiltIn, cwd: "/tmp/work" });
+
+    expect(textOf(registered.renderCall({ command: "npm test" }, theme))).toBe("bash npm test");
+    await expect(registered.execute("call-1", { command: "npm test" }, undefined, undefined, { cwd: "/tmp/work" })).resolves.toMatchObject({ details: { delegated: true } });
+    expect(createBuiltIn).toHaveBeenCalledWith("/tmp/work");
+    expect(execute).toHaveBeenCalledWith("call-1", { command: "npm test" }, undefined, undefined);
+    expect(textOf(registered.renderResult({ content: [{ type: "text", text: "ok\n" }] }, {}, theme, {}))).toBe("↳ 1 line returned • Ctrl+O to expand");
+    expect(textOf(registered.renderResult({ content: [{ type: "text", text: "" }] }, {}, theme, {}))).toBe("↳ command completed (no output)");
+  });
+
+  it("keeps renderResult diagnostics clean for intentionally unused theme", () => {
+    const source = readFileSync(new URL("../src/bash-renderer.ts", import.meta.url), "utf8");
+    expect(source).not.toContain("renderResult(result: any, optionsArg: any, theme: any");
+  });
+
+  it("forwards the built-in bash description and parameters so the model sees the real schema", () => {
+    const params = { type: "object", properties: { command: { type: "string" } }, required: ["command"] };
+    const builtIn = { name: "bash", label: "bash", description: "real bash description", parameters: params, execute: async () => ({ content: [{ type: "text", text: "" }] }) };
+    let registered: any;
+    registerBashRendererTool({ registerTool(def: any) { registered = def; } } as any, { createBuiltInBashTool: () => builtIn, cwd: "/tmp/work" });
+    expect(registered.description).toBe("real bash description");
+    expect(registered.parameters).toBe(params);
+  });
+});

--- a/tests/edit-pending-diff-render-success.test.ts
+++ b/tests/edit-pending-diff-render-success.test.ts
@@ -35,7 +35,7 @@ describe("edit renderCall pending diff preview", () => {
 		const rendered = textOf(second);
 
 		expect(rendered).toContain("pending edit");
-		expect(rendered).toContain("-1 const unique = 1;");
-		expect(rendered).toContain("+1 const unique = 2;");
+		expect(rendered).toContain("↳ diff +1 -1");
+		expect(rendered).toContain("▌ 1 │ const unique = 2;");
 	});
 });

--- a/tests/edit-render-tui.test.ts
+++ b/tests/edit-render-tui.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { registerEditTool } from "../src/edit.js";
+
+const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
+function textOf(component: any): string { return component?.text ?? component?.render?.(120)?.join("\n") ?? ""; }
+function tool(): any { let registered: any; registerEditTool({ registerTool(def: any) { registered = def; } } as any, { wasReadInSession: () => true } as any); return registered; }
+
+describe("edit TUI renderer", () => {
+  it("shows edit summary before final diff and preserves model-facing data", () => {
+    const result: any = { content: [{ type: "text", text: "1:abc|one\n2:def|TWO" }], details: { diff: "-2 two\n+2 TWO", diffData: { version: 1, stats: { added: 1, removed: 1, context: 0 }, entries: [{ kind: "remove", oldLine: 2, text: "two" }, { kind: "add", newLine: 2, text: "TWO" }] }, ptcValue: { warnings: [], noopEdits: [], semanticSummary: { classification: "semantic" }, diffData: { sentinel: true } } } };
+    const before = JSON.stringify(result.details);
+    const rendered = textOf(tool().renderResult(result, { expanded: true, width: 80 }, theme, { expanded: true, width: 80 }));
+    expect(rendered.split("\n")[0]).toBe("↳ edited +1 -1 • semantic");
+    expect(rendered).toContain("↳ diff +1 -1 • 1 hunk • 1 file • unified");
+    expect(rendered).toContain("▌ 2 │ TWO");
+    expect(JSON.stringify(result.details)).toBe(before);
+  });
+
+
+  it("renders compact edit call grammar", () => {
+    const t = tool();
+    expect(textOf(t.renderCall({ path: "tmp/file.txt", edits: [{ replace: { old_text: "a", new_text: "b" } }] }, theme, { argsComplete: true }))).toBe("edit tmp/file.txt (1 edit)");
+  });
+
+  it("keeps no-op and expanded error details visible", () => {
+    const t = tool();
+    const err = { isError: true, content: [{ type: "text", text: "First line\nSecond line" }], details: { diff: "", ptcValue: { warnings: [], noopEdits: [] } } };
+    expect(textOf(t.renderResult(err, {}, theme, {}))).toBe("↳ First line");
+    expect(textOf(t.renderResult(err, { expanded: true }, theme, { expanded: true }))).toContain("Second line");
+    const noop = { isError: true, content: [{ type: "text", text: "No changes made" }], details: { diff: "", ptcValue: { warnings: [], noopEdits: [{}] } } };
+    expect(textOf(t.renderResult(noop, {}, theme, {}))).toBe("↳ no-op");
+  });
+
+
+  it("uses summary grammar for pending edit results", () => {
+    expect(textOf(tool().renderResult({ content: [] }, {}, theme, { isPartial: true }))).toBe("↳ pending edit");
+  });
+
+  it("uses the same visual grammar for pending edit previews", async () => {
+    const cwd = mkdtempSync(resolve(tmpdir(), "pi-edit-render-"));
+    const filePath = resolve(cwd, "sample.ts");
+    writeFileSync(filePath, "const value = 1;\n", "utf-8");
+    const t = tool();
+    const args = { path: filePath, edits: [{ replace: { old_text: "const value = 1;", new_text: "const value = 2;" } }] };
+    const context: any = { argsComplete: false, cwd, state: {}, invalidate: vi.fn() };
+    const first = t.renderCall(args, theme, context);
+    await Promise.resolve();
+    const second = t.renderCall(args, theme, { ...context, lastComponent: first });
+    const rendered = textOf(second);
+    expect(rendered).toContain("↳ pending edit");
+    expect(rendered).toContain("↳ diff +1 -1");
+  });
+});

--- a/tests/list-render-tui.test.ts
+++ b/tests/list-render-tui.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { registerFindTool } from "../src/find.js";
+import { registerLsTool } from "../src/ls.js";
+
+const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
+function capture(register: (pi: any) => any): any { let registered: any; register({ registerTool(def: any) { registered = def; } }); return registered; }
+function textOf(component: any): string { return component?.text ?? component?.render?.(80)?.join("\n") ?? ""; }
+
+describe("list TUI renderers", () => {
+  it("renders compact find output", () => {
+    const find = capture(registerFindTool as any);
+    expect(textOf(find.renderCall({ pattern: "*.ts", path: "src" }, theme))).toBe("find *.ts in src");
+    const result = { content: [{ type: "text", text: "a.ts\nb.ts" }], details: { ptcValue: { tool: "find", totalEntries: 2, truncated: false, entries: ["a.ts", "b.ts"] } } };
+    expect(textOf(find.renderResult(result, {}, theme, {}))).toBe("↳ 2 results returned • Ctrl+O to expand");
+  });
+
+  it("renders compact ls output", () => {
+    const ls = capture(registerLsTool as any);
+    expect(textOf(ls.renderCall({ path: "src" }, theme))).toBe("ls src");
+    const result = { content: [{ type: "text", text: "read.ts\nwrite.ts" }], details: { ptcValue: { tool: "ls", totalEntries: 2, truncated: false, entries: ["read.ts", "write.ts"] } } };
+    expect(textOf(ls.renderResult(result, {}, theme, {}))).toBe("↳ 2 entries returned • Ctrl+O to expand");
+  });
+
+
+  it("keeps find and ls error summaries visible and expands details", () => {
+    const find = capture(registerFindTool as any);
+    const ls = capture(registerLsTool as any);
+    const failed = { isError: true, content: [{ type: "text", text: "permission denied\nfull detail" }] };
+
+    expect(textOf(find.renderResult(failed, {}, theme, {}))).toBe("↳ permission denied");
+    expect(textOf(find.renderResult(failed, { expanded: true }, theme, { expanded: true }))).toContain("full detail");
+    expect(textOf(ls.renderResult(failed, {}, theme, {}))).toBe("↳ permission denied");
+    expect(textOf(ls.renderResult(failed, { expanded: true }, theme, { expanded: true }))).toContain("full detail");
+  });
+});

--- a/tests/nu-render-tui.test.ts
+++ b/tests/nu-render-tui.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { registerNuTool } from "../src/nu.js";
+
+const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
+function textOf(component: any): string { return component?.text ?? component?.render?.(80)?.join("\n") ?? ""; }
+
+describe("nu TUI renderer", () => {
+  it("renders compact collapsed and empty command summaries", () => {
+    let registered: any;
+    registerNuTool({ registerTool(def: any) { registered = def; } } as any);
+    expect(textOf(registered.renderCall({ command: "ls | first 1" }, theme))).toBe("nu ls | first 1");
+    expect(textOf(registered.renderResult({ content: [{ type: "text", text: "row" }] }, {}, theme, {}))).toBe("↳ 1 line returned • Ctrl+O to expand");
+    expect(textOf(registered.renderResult({ content: [{ type: "text", text: "" }] }, {}, theme, {}))).toBe("↳ command completed (no output)");
+  });
+
+
+  it("keeps command failure summaries visible and expands details", () => {
+    let registered: any;
+    registerNuTool({ registerTool(def: any) { registered = def; } } as any);
+    const failed = { isError: true, content: [{ type: "text", text: "command failed\nstack detail" }] };
+    expect(textOf(registered.renderResult(failed, {}, theme, {}))).toBe("↳ command failed");
+    expect(textOf(registered.renderResult(failed, { expanded: true }, theme, { expanded: true }))).toContain("stack detail");
+  });
+});

--- a/tests/read-hashline-wrap.test.ts
+++ b/tests/read-hashline-wrap.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { wrapReadHashlinesForWidth } from "../src/tui-render-utils.js";
+
+const red = "\u001b[31m";
+const reset = "\u001b[0m";
+
+describe("wrapReadHashlinesForWidth", () => {
+  it("wraps hashline content under the observed prefix", () => {
+    const source = "99999:abcdef|export function veryLongName(argumentOne: string, argumentTwo: string): void {}";
+    const rendered = wrapReadHashlinesForWidth(source, 48);
+    const lines = rendered.split("\n");
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines[0]).toMatch(/^99999:abcdef\|export function/);
+    expect(lines[1]).toMatch(/^             /);
+    expect(lines.every((line) => visibleWidth(line) <= 48)).toBe(true);
+  });
+
+  it("does not wrap non-content lines with the hashline continuation algorithm", () => {
+    const header = "[Showing lines 1-2 of 2. Use offset=3 to continue.]";
+    expect(wrapReadHashlinesForWidth(header, 20)).toBe(header);
+  });
+
+  it("is a no-op when wide enough", () => {
+    const source = "1:abc|short";
+    expect(wrapReadHashlinesForWidth(source, 80)).toBe(source);
+  });
+
+  it("preserves ANSI styling while respecting tabs and visible width", () => {
+    const source = `12:abc|${red}const\tmessage = "hello hello hello hello";${reset}`;
+    const rendered = wrapReadHashlinesForWidth(source, 30);
+    expect(rendered).toContain(red);
+    expect(rendered).toContain(reset);
+    expect(rendered.split("\n").every((line) => visibleWidth(line) <= 30)).toBe(true);
+  });
+});

--- a/tests/read-render-tui.test.ts
+++ b/tests/read-render-tui.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { registerReadTool } from "../src/read.js";
+
+const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
+function tool(): any { let registered: any; registerReadTool({ registerTool(def: any) { registered = def; } } as any, {} as any); return registered; }
+function textOf(component: any, width = 80): string { return component?.text ?? component?.render?.(width)?.join("\n") ?? ""; }
+const result = { content: [{ type: "text", text: "1:abc|export function veryLongName(argumentOne: string, argumentTwo: string): void {}" }], details: { ptcValue: { tool: "read", range: { startLine: 1, endLine: 1, totalLines: 1 }, truncation: null, symbol: null, map: { requested: false, appended: false }, warnings: [], lines: [{ line: 1, anchor: "1:abc", text: "export" }] } } };
+
+describe("read TUI renderer", () => {
+  it("uses compact call and collapsed summary by default", () => {
+    expect(textOf(tool().renderCall({ path: "src/edit.ts", offset: 120, limit: 61 }, theme))).toBe("read src/edit.ts:120-180");
+    expect(textOf(tool().renderResult(result, {}, theme, {}))).toBe("↳ loaded 1 line • Ctrl+O to expand");
+  });
+
+
+  it("uses summary grammar for pending reads", () => {
+    expect(textOf(tool().renderResult({ content: [] }, {}, theme, { isPartial: true }))).toBe("↳ pending read");
+  });
+
+  it("renders expanded wrapped detail without changing model-visible payload", () => {
+    const beforeText = result.content[0].text;
+    const beforePtc = JSON.stringify(result.details.ptcValue);
+    const rendered = textOf(tool().renderResult(result, { expanded: true, width: 36 }, theme, { expanded: true, width: 36 }), 36);
+    expect(rendered).toContain("↳ loaded 1 line");
+    expect(rendered).toContain("1:abc|");
+    expect(rendered.split("\n").every((line) => visibleWidth(line) <= 36)).toBe(true);
+    expect(result.content[0].text).toBe(beforeText);
+    expect(JSON.stringify(result.details.ptcValue)).toBe(beforePtc);
+  });
+});

--- a/tests/renderer-expanded-width-coverage.test.ts
+++ b/tests/renderer-expanded-width-coverage.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { registerBashRendererTool } from "../src/bash-renderer.js";
+import { registerEditTool } from "../src/edit.js";
+import { registerFindTool } from "../src/find.js";
+import { registerGrepTool } from "../src/grep.js";
+import { registerLsTool } from "../src/ls.js";
+import { registerNuTool } from "../src/nu.js";
+import { registerReadTool } from "../src/read.js";
+import { registerSgTool } from "../src/sg.js";
+import { registerWriteTool } from "../src/write.js";
+
+const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
+function textOf(component: any, width = 80): string { return component?.text ?? component?.render?.(width)?.join("\n") ?? ""; }
+function capture(register: (pi: any, options?: any) => any, options: any = {}): any { let registered: any; register({ registerTool(def: any) { registered = def; } }, options); return registered; }
+function linesFit(text: string, width: number): boolean { return text.split("\n").every((line) => visibleWidth(line) <= width); }
+
+describe("owned renderer expanded and width coverage", () => {
+  it("covers expanded successful output for every owned renderer", async () => {
+    const cwd = process.cwd();
+    const read = capture(registerReadTool as any, {});
+    const grep = capture(registerGrepTool as any, {});
+    const find = capture(registerFindTool as any);
+    const ls = capture(registerLsTool as any);
+    const edit = capture(registerEditTool as any, { wasReadInSession: () => true });
+    const write = capture(registerWriteTool as any, {});
+    const nu = capture(registerNuTool as any);
+    const sg = capture(registerSgTool as any, {});
+    const execute = vi.fn(async () => ({ content: [{ type: "text", text: "ok\nsecond" }] }));
+    let bash: any;
+    registerBashRendererTool({ registerTool(def: any) { bash = def; } } as any, { cwd, createBuiltInBashTool: () => ({ execute, parameters: {} }) });
+
+    const readText = textOf(read.renderResult({ content: [{ type: "text", text: "1:abc|const value = 1;" }], details: { ptcValue: { range: { startLine: 1, endLine: 1, totalLines: 1 }, truncation: null, symbol: null, map: {}, warnings: [] } } }, { expanded: true }, theme, { expanded: true }), 80);
+    expect(readText).toContain("1:abc|const value = 1;");
+
+    const grepText = textOf(grep.renderResult({ content: [{ type: "text", text: "src/a.ts:1:abc|needle" }], details: { ptcValue: { totalMatches: 1, records: [{ path: `${cwd}/src/a.ts`, kind: "match" }] } } }, { expanded: true }, theme, { expanded: true, cwd }), 80);
+    expect(grepText).toContain("src/a.ts (1)");
+
+    const findText = textOf(find.renderResult({ content: [{ type: "text", text: "src/a.ts\nsrc/b.ts" }], details: { ptcValue: { totalEntries: 2 } } }, { expanded: true }, theme, { expanded: true }), 80);
+    expect(findText).toContain("src/a.ts");
+
+    const lsText = textOf(ls.renderResult({ content: [{ type: "text", text: "read.ts\nwrite.ts" }], details: { ptcValue: { totalEntries: 2 } } }, { expanded: true }, theme, { expanded: true }), 80);
+    expect(lsText).toContain("read.ts");
+
+    const editText = textOf(edit.renderResult({ content: [{ type: "text", text: "1:abc|new" }], details: { diffData: { version: 1, stats: { added: 1, removed: 0, context: 0 }, entries: [{ kind: "add", newLine: 1, text: "new" }] }, ptcValue: { warnings: [], noopEdits: [], semanticSummary: { classification: "semantic" } } } }, { expanded: true }, theme, { expanded: true }), 80);
+    expect(editText).toContain("↳ diff +1 -0");
+
+    const writeText = textOf(write.renderResult({ content: [{ type: "text", text: "1:abc|new" }], details: { writeState: "created", diffData: { version: 1, stats: { added: 1, removed: 0, context: 0 }, entries: [{ kind: "add", newLine: 1, text: "new" }] } } }, { expanded: true }, theme, { expanded: true }), 80);
+    expect(writeText).toContain("↳ diff +1 -0");
+
+    const nuText = textOf(nu.renderResult({ content: [{ type: "text", text: "row\nsecond" }] }, { expanded: true }, theme, { expanded: true }), 80);
+    expect(nuText).toContain("second");
+
+    const sgText = textOf(sg.renderResult({ content: [{ type: "text", text: "src/a.ts\n1:abc|console.log(a)" }], details: { ptcValue: { files: [{ path: `${cwd}/src/a.ts`, lines: [{ line: 1 }] }] } } }, { expanded: true }, theme, { expanded: true, cwd }), 80);
+    expect(sgText).toContain("src/a.ts (1)");
+
+    const bashText = textOf(bash.renderResult({ content: [{ type: "text", text: "ok\nsecond" }] }, { expanded: true }, theme, { expanded: true }), 80);
+    expect(bashText).toContain("second");
+  });
+
+  it("keeps representative call and result output from every owned renderer within supplied width", () => {
+    const width = 24;
+    const cwd = process.cwd();
+    const renderers = {
+      read: capture(registerReadTool as any, {}),
+      grep: capture(registerGrepTool as any, {}),
+      find: capture(registerFindTool as any),
+      ls: capture(registerLsTool as any),
+      edit: capture(registerEditTool as any, { wasReadInSession: () => true }),
+      write: capture(registerWriteTool as any, {}),
+      nu: capture(registerNuTool as any),
+      sg: capture(registerSgTool as any, {}),
+    };
+    let bash: any;
+    registerBashRendererTool({ registerTool(def: any) { bash = def; } } as any, { cwd, createBuiltInBashTool: () => ({ execute: vi.fn(), parameters: {} }) });
+
+    const samples = [
+      textOf(renderers.read.renderCall({ path: "src/very/long/path/read-target.ts", offset: 100, limit: 25 }, theme, { width }), width),
+      textOf(renderers.read.renderResult({ content: [{ type: "text", text: "1:abc|const veryLongIdentifierName = 'value';" }], details: { ptcValue: { range: { startLine: 1, endLine: 1, totalLines: 1 }, truncation: null, symbol: null, map: {}, warnings: [] } } }, { expanded: true, width }, theme, { expanded: true, width }), width),
+      textOf(renderers.grep.renderCall({ pattern: "veryLongSearchPattern", path: "src/very/long/path" }, theme, { width }), width),
+      textOf(renderers.grep.renderResult({ content: [{ type: "text", text: "src/a.ts:1:abc|needle" }], details: { ptcValue: { totalMatches: 1, records: [{ path: `${cwd}/src/a.ts`, kind: "match" }] } } }, { expanded: true, width }, theme, { expanded: true, width, cwd }), width),
+      textOf(renderers.find.renderCall({ pattern: "*.typescript", path: "src/very/long/path" }, theme, { width }), width),
+      textOf(renderers.find.renderResult({ content: [{ type: "text", text: "src/very-long-file-name.ts" }], details: { ptcValue: { totalEntries: 1 } } }, { expanded: true, width }, theme, { expanded: true, width }), width),
+      textOf(renderers.ls.renderCall({ path: "src/very/long/path" }, theme, { width }), width),
+      textOf(renderers.ls.renderResult({ content: [{ type: "text", text: "very-long-file-name.ts" }], details: { ptcValue: { totalEntries: 1 } } }, { expanded: true, width }, theme, { expanded: true, width }), width),
+      textOf(renderers.edit.renderCall({ path: "src/very/long/path/edit-target.ts", edits: [{ replace: { old_text: "old", new_text: "new" } }] }, theme, { width, argsComplete: true }), width),
+      textOf(renderers.edit.renderResult({ content: [{ type: "text", text: "1:abc|new" }], details: { diffData: { version: 1, stats: { added: 1, removed: 0, context: 0 }, entries: [{ kind: "add", newLine: 1, text: "new value with a long tail" }] }, ptcValue: { warnings: [], noopEdits: [] } } }, { expanded: true, width }, theme, { expanded: true, width }), width),
+      textOf(renderers.write.renderCall({ path: "src/very/long/path/write-target.ts", content: "one\ntwo" }, theme, { width }), width),
+      textOf(renderers.write.renderResult({ content: [{ type: "text", text: "1:abc|new" }], details: { writeState: "created", diffData: { version: 1, stats: { added: 1, removed: 0, context: 0 }, entries: [{ kind: "add", newLine: 1, text: "new value with a long tail" }] } } }, { expanded: true, width }, theme, { expanded: true, width }), width),
+      textOf(renderers.nu.renderCall({ command: "ls | where name =~ very-long-pattern" }, theme, { width }), width),
+      textOf(renderers.nu.renderResult({ content: [{ type: "text", text: "very long output row" }] }, { expanded: true, width }, theme, { expanded: true, width }), width),
+      textOf(renderers.sg.renderCall({ pattern: "console.log($VERY_LONG_ARGUMENT)", path: "src/very/long/path", lang: "typescript" }, theme, { width }), width),
+      textOf(renderers.sg.renderResult({ content: [{ type: "text", text: "src/a.ts\n1:abc|console.log(a)" }], details: { ptcValue: { files: [{ path: `${cwd}/src/a.ts`, lines: [{ line: 1 }] }] } } }, { expanded: true, width }, theme, { expanded: true, width, cwd }), width),
+      textOf(bash.renderCall({ command: "npm run very-long-script-name -- --flag" }, theme, { width }), width),
+      textOf(bash.renderResult({ content: [{ type: "text", text: "very long bash output row" }] }, { expanded: true, width }, theme, { expanded: true, width }), width),
+    ];
+
+    for (const sample of samples) expect(linesFit(sample, width), sample).toBe(true);
+  });
+});

--- a/tests/renderer-no-width-context.test.ts
+++ b/tests/renderer-no-width-context.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { registerFindTool } from "../src/find.js";
+import { registerLsTool } from "../src/ls.js";
+import { registerNuTool } from "../src/nu.js";
+import { registerWriteTool } from "../src/write.js";
+import { registerBashRendererTool } from "../src/bash-renderer.js";
+import { registerReadTool } from "../src/read.js";
+import { registerGrepTool } from "../src/grep.js";
+
+// A Theme-like *class instance* — methods live on the prototype, not as own
+// properties. This catches the "{ ...theme }" spread bug that destroys the
+// prototype and the "context.width ?? 80" bug that pre-truncates at 80 cols
+// when the real ToolRenderContext has no width field.
+class FakeTheme {
+  fg(_style: string, text: string): string { return text; }
+  bold(text: string): string { return text; }
+}
+
+function register(fn: (api: any, ...rest: any[]) => void, ...rest: any[]): any {
+  let registered: any;
+  fn({ registerTool(def: any) { registered = def; } } as any, ...rest);
+  return registered;
+}
+
+function textOf(component: any, width = 500): string {
+  // Use a generous width so any pre-clamping at 80 would be visible as
+  // truncation. The component.text field (set by `new Text(text, ...)`)
+  // is captured before any width-based wrap.
+  return component?.text ?? component?.render?.(width)?.join("\n") ?? "";
+}
+
+// 200-char path — well over 80 cols. If anything is pre-clamping to 80, this
+// will be truncated and the assertion fails.
+const LONG = "a/very/long/path/segment".repeat(8) + "/end.txt";
+
+describe("renderers with no context.width (real ToolRenderContext shape)", () => {
+  it("find renderCall shows full pattern without 80-col truncation", () => {
+    const tool = register(registerFindTool);
+    const out = textOf(tool.renderCall({ pattern: LONG }, new FakeTheme(), {} as any));
+    expect(out).toContain(LONG);
+    expect(out).toContain("find");
+  });
+
+  it("ls renderCall shows full path without 80-col truncation", () => {
+    const tool = register(registerLsTool);
+    const out = textOf(tool.renderCall({ path: LONG }, new FakeTheme(), {} as any));
+    expect(out).toContain(LONG);
+    expect(out).toContain("ls");
+  });
+
+  it("nu renderCall shows full command without 80-col truncation", () => {
+    const tool = register(registerNuTool);
+    const cmd = "ls | where name == " + JSON.stringify(LONG) + " | first 1";
+    const out = textOf(tool.renderCall({ command: cmd }, new FakeTheme(), {} as any));
+    expect(out).toContain(LONG);
+    expect(out).toContain("nu");
+  });
+
+  it("write renderCall shows full path without 80-col truncation", () => {
+    const tool = register(registerWriteTool);
+    const out = textOf(tool.renderCall({ path: LONG, content: "x" }, new FakeTheme(), {} as any));
+    expect(out).toContain(LONG);
+    expect(out).toContain("write");
+  });
+
+  it("bash renderCall shows full command without 80-col truncation", () => {
+    const tool = register(registerBashRendererTool);
+    const cmd = "echo " + LONG;
+    const out = textOf(tool.renderCall({ command: cmd }, new FakeTheme(), {} as any));
+    expect(out).toContain(LONG);
+    expect(out).toContain("bash");
+  });
+
+  it("read renderCall shows full path without 80-col truncation", () => {
+    const tool = register(registerReadTool);
+    const out = textOf(tool.renderCall({ path: LONG }, new FakeTheme(), {} as any));
+    expect(out).toContain(LONG);
+  });
+
+  it("grep renderCall shows full pattern without 80-col truncation", () => {
+    const tool = register(registerGrepTool);
+    const out = textOf(tool.renderCall({ pattern: LONG }, new FakeTheme(), {} as any));
+    expect(out).toContain(LONG);
+  });
+});

--- a/tests/search-render-tui.test.ts
+++ b/tests/search-render-tui.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { registerGrepTool } from "../src/grep.js";
+import { registerSgTool } from "../src/sg.js";
+
+const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
+function capture(register: (pi: any, options?: any) => any): any { let registered: any; register({ registerTool(def: any) { registered = def; } }, {}); return registered; }
+function textOf(component: any): string { return component?.text ?? component?.render?.(80)?.join("\n") ?? ""; }
+
+describe("search TUI renderers", () => {
+  it("renders compact grep summaries and expanded details", () => {
+    const grep = capture(registerGrepTool as any);
+    expect(textOf(grep.renderCall({ pattern: "diffData", path: "src" }, theme))).toBe("grep /diffData/ in src");
+    const result = { content: [{ type: "text", text: "src/a.ts:1:abc|diffData" }], details: { ptcValue: { tool: "grep", summary: false, totalMatches: 1, records: [{ path: `${process.cwd()}/src/a.ts`, kind: "match" }] } } };
+    expect(textOf(grep.renderResult(result, {}, theme, { cwd: process.cwd() }))).toBe("↳ 1 match returned • Ctrl+O to expand");
+    expect(textOf(grep.renderResult(result, { expanded: true }, theme, { expanded: true, cwd: process.cwd() }))).toContain("src/a.ts (1)");
+  });
+
+  it("renders compact ast_search summaries", () => {
+    const sg = capture(registerSgTool as any);
+    expect(textOf(sg.renderCall({ pattern: "console.log($A)", path: "src", lang: "typescript" }, theme))).toBe("ast_search /console.log($A)/ in src (typescript)");
+    const result = { content: [{ type: "text", text: "src/a.ts\n1:abc|console.log(a)" }], details: { ptcValue: { tool: "ast_search", files: [{ path: `${process.cwd()}/src/a.ts`, lines: [{ line: 1 }] }] } } };
+    expect(textOf(sg.renderResult(result, {}, theme, { cwd: process.cwd() }))).toBe("↳ 1 match in 1 file • Ctrl+O to expand");
+  });
+
+
+  it("uses summary grammar for pending and error states", () => {
+    const grep = capture(registerGrepTool as any);
+    const sg = capture(registerSgTool as any);
+    const failed = { isError: true, content: [{ type: "text", text: "first line\nfull detail" }] };
+
+    expect(textOf(grep.renderResult({ content: [] }, {}, theme, { isPartial: true }))).toBe("↳ pending search");
+    expect(textOf(grep.renderResult(failed, {}, theme, {}))).toBe("↳ first line");
+    expect(textOf(grep.renderResult(failed, { expanded: true }, theme, { expanded: true }))).toContain("full detail");
+
+    expect(textOf(sg.renderResult({ content: [] }, {}, theme, { isPartial: true }))).toBe("↳ pending search");
+    expect(textOf(sg.renderResult(failed, {}, theme, {}))).toBe("↳ first line");
+    expect(textOf(sg.renderResult(failed, { expanded: true }, theme, { expanded: true }))).toContain("full detail");
+  });
+});

--- a/tests/tui-diff-renderer.test.ts
+++ b/tests/tui-diff-renderer.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { renderTuiDiff } from "../src/tui-diff-renderer.js";
+import type { DiffData } from "../src/diff-data.js";
+
+const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
+const diffData: DiffData = { version: 1, stats: { added: 2, removed: 1, context: 1 }, entries: [
+  { kind: "context", oldLine: 1, newLine: 1, text: "one" },
+  { kind: "remove", oldLine: 2, text: "two" },
+  { kind: "add", newLine: 2, text: "TWO" },
+  { kind: "add", newLine: 3, text: "three" },
+], inlineDiffs: [{ removeLineIndex: 1, addLineIndex: 2, removeSpans: [{ kind: "remove", text: "two" }], addSpans: [{ kind: "add", text: "TWO" }] }] };
+
+describe("renderTuiDiff", () => {
+  it("renders unified, compact, split, and summary modes within width", () => {
+    const wide = renderTuiDiff({ diffData, width: 120, theme, expanded: true });
+    expect(wide.mode).toBe("split");
+    expect(wide.lines.join("\n")).toContain("old");
+    expect(wide.lines.join("\n")).toContain("new");
+    const normal = renderTuiDiff({ diffData, width: 80, theme, expanded: true });
+    expect(normal.mode).toBe("unified");
+    expect(normal.lines[0]).toBe("↳ diff +2 -1 • 1 hunk • 1 file • unified");
+    expect(normal.lines.join("\n")).toContain("▌ 2 │ TWO");
+    const narrow = renderTuiDiff({ diffData, width: 28, theme, expanded: true });
+    expect(narrow.mode).toBe("compact");
+    expect(narrow.lines[0]).toBe("↳ diff +2 -1");
+    const tiny = renderTuiDiff({ diffData, width: 10, theme, expanded: true });
+    expect(tiny.mode).toBe("summary");
+    expect(tiny.lines).toEqual(["↳ diff +2"]);
+    for (const rendered of [wide, normal, narrow, tiny]) expect(rendered.lines.every((line) => visibleWidth(line) <= rendered.width)).toBe(true);
+  });
+
+  it("renders collapsed progressive hidden-content hints", () => {
+    const collapsed = renderTuiDiff({ diffData, width: 80, theme, expanded: false });
+    expect(collapsed.lines[0]).toBe("↳ diff +2 -1 • 1 hunk • 1 file • unified");
+    expect(collapsed.lines[1]).toBe("… (4 more diff lines • 1 more hunk • Ctrl+O to expand)");
+    expect(renderTuiDiff({ diffData, width: 36, theme, expanded: false }).lines.at(-1)).toMatch(/^… \(/);
+    expect(renderTuiDiff({ diffData, width: 8, theme, expanded: false }).lines.at(-1)).toBe("…");
+  });
+});

--- a/tests/tui-render-utils.test.ts
+++ b/tests/tui-render-utils.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import {
+  EXPAND_HINT,
+  appendExpandHint,
+  clampLinesToWidth,
+  isRendererExpanded,
+  renderToolLabel,
+  summaryLine,
+  wrapLinesToWidth,
+} from "../src/tui-render-utils.js";
+
+const theme = {
+  fg: (_style: string, text: string) => text,
+  bold: (text: string) => `**${text}**`,
+};
+
+describe("shared TUI renderer utilities", () => {
+  it("renders plain bold labels and summary hints consistently", () => {
+    expect(renderToolLabel(theme, "read")).toBe("**read**");
+    expect(summaryLine("loaded 2 lines", { hidden: true })).toBe(`↳ loaded 2 lines${EXPAND_HINT}`);
+    expect(summaryLine("command completed (no output)", { hidden: false })).toBe("↳ command completed (no output)");
+    expect(appendExpandHint("↳ loaded", true)).toBe(`↳ loaded${EXPAND_HINT}`);
+    expect(appendExpandHint("↳ loaded", false)).toBe("↳ loaded");
+  });
+
+  it("accepts both options.expanded and context.expanded", () => {
+    expect(isRendererExpanded({ expanded: true })).toBe(true);
+    expect(isRendererExpanded({}, { expanded: true })).toBe(true);
+    expect(isRendererExpanded({ expanded: false }, { expanded: true })).toBe(true);
+    expect(isRendererExpanded(undefined, undefined)).toBe(false);
+  });
+
+  it("clamps and wraps every line using visible terminal width", () => {
+    const clamped = clampLinesToWidth(["abcdef", "wide 字字字"], 5);
+    expect(clamped.every((line) => visibleWidth(line) <= 5)).toBe(true);
+
+    const wrapped = wrapLinesToWidth(["abcdef", "ghijkl"], 4);
+    expect(wrapped).toEqual(["abcd", "ef", "ghij", "kl"]);
+    expect(wrapped.every((line) => visibleWidth(line) <= 4)).toBe(true);
+  });
+
+
+  it("uses pi-tui wrapping helpers instead of hand-rolled ANSI wrapping", () => {
+    const source = readFileSync(new URL("../src/tui-render-utils.ts", import.meta.url), "utf8");
+    expect(source).not.toContain("hardWrapTextWithAnsi");
+    expect(source).not.toContain("ANSI_RE");
+  });
+});

--- a/tests/write-pending-diff-render-success.test.ts
+++ b/tests/write-pending-diff-render-success.test.ts
@@ -30,8 +30,9 @@ describe("write renderCall pending diff preview", () => {
 		const rendered = tool.renderCall({ path: "sample.txt", content: "new value\n" }, theme, context);
 		const text = textOf(rendered);
 
-		expect(text).toContain("pending overwrite");
-		expect(text).toContain("-1 old value");
-		expect(text).toContain("+1 new value");
+		expect(text).toContain("↳ pending overwrite");
+		expect(text).toContain("↳ diff +1 -1");
+		expect(text).toContain("▌ 1 │ old value");
+		expect(text).toContain("▌ 1 │ new value");
 	});
 });

--- a/tests/write-render-tui.test.ts
+++ b/tests/write-render-tui.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { registerWriteTool } from "../src/write.js";
+
+const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
+function textOf(component: any): string { return component?.text ?? component?.render?.(120)?.join("\n") ?? ""; }
+function tool(): any { let registered: any; registerWriteTool({ registerTool(def: any) { registered = def; } } as any, {} as any); return registered; }
+
+describe("write TUI renderer", () => {
+  it("shows created and overwritten state before final diff without mutating details", () => {
+    const t = tool();
+    expect(textOf(t.renderCall({ path: "tmp/file.txt", content: "one\ntwo\nthree" }, theme, {}))).toBe("write tmp/file.txt (3 lines • 13 B)");
+    const baseDiffData = { version: 1, stats: { added: 3, removed: 0, context: 0 }, entries: [{ kind: "add", newLine: 1, text: "one" }, { kind: "add", newLine: 2, text: "two" }, { kind: "add", newLine: 3, text: "three" }] };
+    const created: any = { content: [{ type: "text", text: "1:abc|one\n2:def|two\n3:aaa|three" }], details: { writeState: "created", diffData: baseDiffData, ptcValue: { tool: "write", diffData: { sentinel: true } } } };
+    const before = JSON.stringify(created.details);
+    const rendered = textOf(t.renderResult(created, { expanded: true, width: 80 }, theme, { expanded: true, width: 80 }));
+    expect(rendered.split("\n")[0]).toBe("↳ created");
+    expect(rendered).toContain("↳ diff +3 -0 • 1 hunk • 1 file • unified");
+    expect(rendered).toContain("▌ 1 │ one");
+    expect(JSON.stringify(created.details)).toBe(before);
+
+    const overwritten: any = { content: created.content, details: { ...created.details, writeState: "overwritten" } };
+    expect(textOf(t.renderResult(overwritten, {}, theme, {}))).toBe("↳ overwritten • Ctrl+O to expand");
+  });
+
+
+  it("keeps write error summaries visible and expands details", () => {
+    const t = tool();
+    const failed: any = { isError: true, content: [{ type: "text", text: "Permission denied\nfull detail" }], details: { ptcValue: { ok: false } } };
+    expect(textOf(t.renderResult(failed, {}, theme, {}))).toBe("↳ Permission denied");
+    expect(textOf(t.renderResult(failed, { expanded: true }, theme, { expanded: true }))).toContain("full detail");
+  });
+
+  it("uses the same visual grammar for pending write previews", () => {
+    const cwd = mkdtempSync(resolve(tmpdir(), "pi-write-render-"));
+    writeFileSync(resolve(cwd, "old.txt"), "old\n", "utf-8");
+    const t = tool();
+    const createContext: any = { cwd, state: {}, invalidate: vi.fn() };
+    const first = t.renderCall({ path: "new.txt", content: "one\ntwo" }, theme, createContext);
+    const second = t.renderCall({ path: "new.txt", content: "one\ntwo" }, theme, { ...createContext, lastComponent: first });
+    expect(textOf(second)).toContain("↳ pending create");
+    expect(textOf(second)).toContain("↳ diff +2 -0");
+
+    const overwriteContext: any = { cwd, state: {}, invalidate: vi.fn() };
+    const third = t.renderCall({ path: "old.txt", content: "old\nnew" }, theme, overwriteContext);
+    const fourth = t.renderCall({ path: "old.txt", content: "old\nnew" }, theme, { ...overwriteContext, lastComponent: third });
+    expect(textOf(fourth)).toContain("↳ pending overwrite");
+  });
+});


### PR DESCRIPTION
Closes #180.

## Summary

Overhauls the TUI tool-display layer to mirror the pi built-in tool-display shape: a compact title line, then a collapsed `↳ summary` that expands to a width-aware detail view on Ctrl+O. Covers `read`, `edit`, `grep`, `ast_search`, `find`, `ls`, `nu`, `write`, and `bash`.

## What changed

- **`src/tui-render-utils.ts`** — shared helpers: `clampLineToWidth`, `clampLinesToWidth`, `wrapLinesToWidth`, `wrapReadHashlinesForWidth`, `summaryLine` + `EXPAND_HINT`, `renderToolLabel`, `isRendererExpanded`. Width helpers pass through when width is undefined so the `Text` component wraps at real render width.
- **`src/tui-diff-renderer.ts`** — width-aware diff renderer (split / unified / compact / summary modes) used by `edit` and `write`.
- **`src/bash-renderer.ts`** — wrapper that delegates execution to pi's built-in bash tool but takes over rendering for consistent compact display.
- **Per-tool renderers** (`read`, `edit`, `grep`, `sg`, `find`, `ls`, `nu`, `write`): new `renderCall` / `renderResult` using the shared helpers. Result badges expose symbol/truncation/map (read), edit counts (edit/write), match totals (grep/sg), entry counts (find/ls), and output line counts (nu/bash).
- **`write`** also surfaces `writeState: "created" | "overwritten"` on result details for the renderer.

## Regression coverage added during smoke testing

The second commit (`test(tui): regression coverage for Theme prototype + missing context.width`) locks in two real bugs that manual TUI testing exposed during this work:

1. `{ ...theme }` spread broke `Theme` class instances by dropping prototype methods (`fg`, `bold`), so `renderCall` threw and the TUI showed a stub without the file/command/pattern.
2. `context.width ?? 80` pre-clamped every renderer to 80 columns because the real `ToolRenderContext` has no `width` field.

The new test (`tests/renderer-no-width-context.test.ts`) drives every renderer with a class-instance theme and a context without `width`, asserting the full long string survives. Would have caught both bugs earlier.

## Verification

- `npm test` → **1403 / 1403** ✅ (315 → 316 test files, +28 new tests across this PR)
- `npm run typecheck` → clean ✅
- Manual smoke test of every tool exercised in two fresh sessions

## Commits

1. `feat(tui): pi-inspired tool-display renderer for read/edit/grep/sg/find/ls/nu/write/bash`
2. `test(tui): regression coverage for Theme prototype + missing context.width`