### PR TITLE
feat(edit): add opt-in post-write verification (#184)

### DIFF
--- a/prompts/edit.md
+++ b/prompts/edit.md
@@ -33,6 +33,12 @@ Prefer `set_line`, `replace_lines`, and `insert_after`: they verify the file sti
 
 Use only the variant(s) needed for the task; the example shows all shapes together for reference. Each `edits[]` entry must contain exactly one variant key. `new_text` / `new_body` is plain file content — no hash prefixes or diff markers.
 
+## Optional post-edit verification
+
+`postEditVerify: true` opts into post-write persisted-content verification for this one call. It is default off: when omitted or false, successful edits use the normal fast path and do not perform an extra read-back check.
+
+When enabled, `edit` first runs the normal validation and write path. Only after the write succeeds, it reads the file back from disk and compares the persisted content to the exact intended content, including BOM restoration and original line-ending restoration. This is not syntax validation; syntax validation is the separate pre-write `syntaxValidate` / `PI_HASHLINE_SYNTAX_VALIDATE` guard described below.
+
 ## `replace_symbol`
 
 Use `replace_symbol` to replace one function, class, method, interface, type, enum, or similar symbol. Query symbols like `read symbol:`: `Name`, `Class.method`, or `Name@<line>`.

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -20,6 +20,7 @@ import { buildEditPreviewKey, buildPendingEditPreviewData, resolvePendingDiffPre
 import { buildDiffData, type DiffBlockRange } from "./diff-data.js";
 import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, summaryLine } from "./tui-render-utils.js";
 import { renderTuiDiff } from "./tui-diff-renderer.js";
+import { buildContextHygieneMetadata, buildFileResource, type ContextHygieneMetadata } from "./context-hygiene.js";
 
 const EDIT_PENDING_PREVIEW_STATE_KEY = "hashline-edit-pending-preview";
 
@@ -69,6 +70,9 @@ const hashlineEditSchema = Type.Object(
 	{
 		path: Type.String({ description: "File path (relative or absolute)" }),
 		edits: Type.Optional(Type.Array(hashlineEditItemSchema, { description: "Array of edit operations" })),
+		postEditVerify: Type.Optional(Type.Boolean({
+			description: "Opt in to post-write persisted-content verification. Default false.",
+		})),
 	},
 	{ additionalProperties: true },
 );
@@ -91,10 +95,11 @@ function buildEditError(
 	message: string,
 	hint?: string,
 	errorDetails?: Record<string, unknown>,
+	contextHygiene?: ContextHygieneMetadata,
 ): {
 	content: [{ type: "text"; text: string }];
 	isError: true;
-	details: EditToolDetails & { ptcValue: any };
+	details: EditToolDetails & { ptcValue: any; contextHygiene?: ContextHygieneMetadata };
 } {
 	return {
 		content: [{ type: "text", text: message }],
@@ -108,7 +113,8 @@ function buildEditError(
 				path,
 				error: buildPtcError(code, message, hint, errorDetails),
 			},
-		} as EditToolDetails & { ptcValue: any },
+			...(contextHygiene ? { contextHygiene } : {}),
+		} as EditToolDetails & { ptcValue: any; contextHygiene?: ContextHygieneMetadata },
 	};
 }
 
@@ -479,8 +485,9 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 					syntaxWarning = message;
 				}
 			}
+			const writeContent = bom + restoreLineEndings(result, originalEnding);
 			try {
-				await fsWriteFile(absolutePath, bom + restoreLineEndings(result, originalEnding), "utf-8");
+				await fsWriteFile(absolutePath, writeContent, "utf-8");
 			} catch (err: any) {
 				const wrapped = wrapWriteError(err, path);
 				const code =
@@ -494,6 +501,36 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				return buildEditError(absolutePath, code, message, undefined, code === "fs-error"
 					? { fsCode: err?.code, fsMessage: err?.message }
 					: undefined);
+			}
+
+			if (input.postEditVerify === true) {
+				const postWriteMutationContextHygiene = buildContextHygieneMetadata({
+					tool: "edit",
+					classification: "mutation",
+					resources: [buildFileResource(absolutePath)],
+				});
+				let verifiedContent: string;
+				try {
+					const verified = await fsReadFile(absolutePath, "utf-8");
+					verifiedContent = verified;
+				} catch (err: any) {
+					const message = `Edit write completed but post-edit verification failed: could not read ${path} after writing.`;
+					return buildEditError(absolutePath, "post-edit-verification-read-failed", message, undefined, {
+							fsCode: err?.code,
+							fsMessage: err?.message,
+						},
+						postWriteMutationContextHygiene,
+					);
+				}
+				if (verifiedContent !== writeContent) {
+					const message = `Edit write completed but post-edit verification did not confirm the intended content for ${path}. Re-read the file before making follow-up edits.`;
+					return buildEditError(absolutePath, "post-edit-verification-mismatch", message, undefined, {
+							expectedLength: writeContent.length,
+							actualLength: verifiedContent.length,
+						},
+						postWriteMutationContextHygiene,
+					);
+				}
 			}
 
 			const diffResult = generateCompactOrFullDiff(originalNormalized, result);

--- a/tests/edit-post-verify-default.test.ts
+++ b/tests/edit-post-verify-default.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { computeLineHash, ensureHashInit } from "../src/hashline.js";
+
+const fsMock = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  return { ...actual, readFile: fsMock.readFile, writeFile: fsMock.writeFile };
+});
+
+import { registerEditTool } from "../src/edit.js";
+
+function captureEditTool() {
+  let tool: any;
+  registerEditTool({ registerTool(def: any) { tool = def; } } as any, { wasReadInSession: () => true });
+  if (!tool) throw new Error("edit tool was not registered");
+  return tool;
+}
+
+describe("edit postEditVerify default", () => {
+  beforeEach(async () => {
+    await ensureHashInit();
+    fsMock.readFile.mockReset();
+    fsMock.writeFile.mockReset();
+  });
+
+  it("documents the explicit option and leaves verification off when absent", async () => {
+    const tool = captureEditTool();
+    expect(tool.parameters.properties.postEditVerify).toBeTruthy();
+    expect(tool.parameters.properties.postEditVerify.type).toBe("boolean");
+
+    fsMock.readFile.mockResolvedValue(Buffer.from("alpha\nbeta", "utf8"));
+    fsMock.writeFile.mockResolvedValue(undefined);
+    const anchor = `1:${computeLineHash(1, "alpha")}`;
+
+    const result = await tool.execute(
+      "tc",
+      { path: "/tmp/post-edit-default.txt", edits: [{ set_line: { anchor, new_text: "ALPHA" } }] },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(fsMock.writeFile).toHaveBeenCalledWith("/tmp/post-edit-default.txt", "ALPHA\nbeta", "utf-8");
+    expect(fsMock.readFile).toHaveBeenCalledTimes(1);
+    expect(result.content[0].text).toContain("Edited /tmp/post-edit-default.txt");
+    expect(result.details.diff).toContain("alpha");
+    expect(result.details.diffData).toEqual(result.details.ptcValue.diffData);
+    expect(result.details.ptcValue.ok).toBe(true);
+    expect(result.details.ptcValue.warnings).toEqual([]);
+    expect(result.details.ptcValue.semanticSummary).toBeTruthy();
+    expect(result.details.firstChangedLine).toBe(1);
+    expect(result.details.contextHygiene.classification).toBe("mutation");
+  });
+});

--- a/tests/edit-post-verify-line-endings.test.ts
+++ b/tests/edit-post-verify-line-endings.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { computeLineHash, ensureHashInit } from "../src/hashline.js";
+import { registerEditTool } from "../src/edit.js";
+
+function captureEditTool() {
+  let tool: any;
+  registerEditTool({ registerTool(def: any) { tool = def; } } as any, { wasReadInSession: () => true });
+  if (!tool) throw new Error("edit tool was not registered");
+  return tool;
+}
+
+describe("edit postEditVerify line endings", () => {
+  beforeAll(async () => { await ensureHashInit(); });
+
+  it("confirms persisted LF, CRLF, and BOM-preserving edits", async () => {
+    const cases = [
+      { name: "lf", original: "alpha\nbeta", expected: "ALPHA\nbeta" },
+      { name: "crlf", original: "alpha\r\nbeta", expected: "ALPHA\r\nbeta" },
+      { name: "bom-crlf", original: "\uFEFFalpha\r\nbeta", expected: "\uFEFFALPHA\r\nbeta" },
+    ];
+
+    for (const testCase of cases) {
+      const dir = mkdtempSync(resolve(tmpdir(), `pi-edit-post-verify-${testCase.name}-`));
+      const filePath = resolve(dir, "sample.txt");
+      writeFileSync(filePath, testCase.original, "utf8");
+      const anchor = `1:${computeLineHash(1, "alpha")}`;
+      const tool = captureEditTool();
+
+      const result = await tool.execute(
+        "tc",
+        { path: filePath, postEditVerify: true, edits: [{ set_line: { anchor, new_text: "ALPHA" } }] },
+        new AbortController().signal,
+        () => {},
+        { cwd: process.cwd() },
+      );
+
+      expect(result.isError, testCase.name).toBeUndefined();
+      expect(readFileSync(filePath, "utf8"), testCase.name).toBe(testCase.expected);
+    }
+  });
+});

--- a/tests/edit-post-verify-mismatch.test.ts
+++ b/tests/edit-post-verify-mismatch.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { computeLineHash, ensureHashInit } from "../src/hashline.js";
+
+const fsMock = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  return { ...actual, readFile: fsMock.readFile, writeFile: fsMock.writeFile };
+});
+
+import { registerEditTool } from "../src/edit.js";
+
+function captureEditTool() {
+  let tool: any;
+  registerEditTool({ registerTool(def: any) { tool = def; } } as any, { wasReadInSession: () => true });
+  if (!tool) throw new Error("edit tool was not registered");
+  return tool;
+}
+
+describe("edit postEditVerify mismatch", () => {
+  beforeEach(async () => {
+    await ensureHashInit();
+    fsMock.readFile.mockReset();
+    fsMock.writeFile.mockReset();
+  });
+
+  it("returns a structured error when persisted content differs after the write completed", async () => {
+    const tool = captureEditTool();
+    fsMock.readFile
+      .mockResolvedValueOnce(Buffer.from("alpha\nbeta", "utf8"))
+      .mockResolvedValueOnce("tampered\nbeta");
+    fsMock.writeFile.mockResolvedValue(undefined);
+    const anchor = `1:${computeLineHash(1, "alpha")}`;
+
+    const result = await tool.execute(
+      "tc",
+      { path: "/tmp/post-edit-mismatch.txt", postEditVerify: true, edits: [{ set_line: { anchor, new_text: "ALPHA" } }] },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    expect(fsMock.writeFile).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("write completed but post-edit verification did not confirm the intended content");
+    expect(result.details.ptcValue.ok).toBe(false);
+    expect(result.details.ptcValue.error.code).toBe("post-edit-verification-mismatch");
+    expect(result.details.ptcValue.error.details).toEqual({ expectedLength: "ALPHA\nbeta".length, actualLength: "tampered\nbeta".length });
+    expect(result.details.contextHygiene.classification).toBe("mutation");
+    expect(result.details.contextHygiene.resources).toEqual([
+      { kind: "file", path: "/tmp/post-edit-mismatch.txt", key: "file:/tmp/post-edit-mismatch.txt" },
+    ]);
+  });
+});

--- a/tests/edit-post-verify-prewrite-guards.test.ts
+++ b/tests/edit-post-verify-prewrite-guards.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { computeLineHash, ensureHashInit } from "../src/hashline.js";
+
+const fsMock = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  return { ...actual, readFile: fsMock.readFile, writeFile: fsMock.writeFile };
+});
+
+import { registerEditTool } from "../src/edit.js";
+
+function captureEditTool() {
+  let tool: any;
+  registerEditTool({ registerTool(def: any) { tool = def; } } as any, { wasReadInSession: () => true });
+  if (!tool) throw new Error("edit tool was not registered");
+  return tool;
+}
+
+describe("edit postEditVerify pre-write guards", () => {
+  beforeEach(async () => {
+    await ensureHashInit();
+    fsMock.readFile.mockReset();
+    fsMock.writeFile.mockReset();
+  });
+
+  it("does not write or read back when a pre-write no-op guard rejects the edit", async () => {
+    const tool = captureEditTool();
+    fsMock.readFile.mockResolvedValue(Buffer.from("alpha\nbeta", "utf8"));
+    fsMock.writeFile.mockResolvedValue(undefined);
+    const anchor = `1:${computeLineHash(1, "alpha")}`;
+
+    const result = await tool.execute(
+      "tc",
+      { path: "/tmp/post-edit-noop.txt", postEditVerify: true, edits: [{ set_line: { anchor, new_text: "alpha" } }] },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.details.ptcValue.error.code).toBe("no-op");
+    expect(fsMock.writeFile).not.toHaveBeenCalled();
+    expect(fsMock.readFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/edit-post-verify-read-failure.test.ts
+++ b/tests/edit-post-verify-read-failure.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { computeLineHash, ensureHashInit } from "../src/hashline.js";
+
+const fsMock = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  return { ...actual, readFile: fsMock.readFile, writeFile: fsMock.writeFile };
+});
+
+import { registerEditTool } from "../src/edit.js";
+
+function captureEditTool() {
+  let tool: any;
+  registerEditTool({ registerTool(def: any) { tool = def; } } as any, { wasReadInSession: () => true });
+  if (!tool) throw new Error("edit tool was not registered");
+  return tool;
+}
+
+describe("edit postEditVerify read failure", () => {
+  beforeEach(async () => {
+    await ensureHashInit();
+    fsMock.readFile.mockReset();
+    fsMock.writeFile.mockReset();
+  });
+
+  it("returns a structured error when read-back fails after the write completed", async () => {
+    const tool = captureEditTool();
+    const readError = Object.assign(new Error("simulated read-back failure"), { code: "EIO" });
+    fsMock.readFile
+      .mockResolvedValueOnce(Buffer.from("alpha\nbeta", "utf8"))
+      .mockRejectedValueOnce(readError);
+    fsMock.writeFile.mockResolvedValue(undefined);
+    const anchor = `1:${computeLineHash(1, "alpha")}`;
+
+    const result = await tool.execute(
+      "tc",
+      { path: "/tmp/post-edit-read-fail.txt", postEditVerify: true, edits: [{ set_line: { anchor, new_text: "ALPHA" } }] },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    expect(fsMock.writeFile).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("write completed but post-edit verification failed");
+    expect(result.details.ptcValue.ok).toBe(false);
+    expect(result.details.ptcValue.error.code).toBe("post-edit-verification-read-failed");
+    expect(result.details.ptcValue.error.message).toContain("write completed");
+    expect(result.details.ptcValue.error.details).toEqual({ fsCode: "EIO", fsMessage: "simulated read-back failure" });
+    expect(result.details.contextHygiene.classification).toBe("mutation");
+    expect(result.details.contextHygiene.resources).toEqual([
+      { kind: "file", path: "/tmp/post-edit-read-fail.txt", key: "file:/tmp/post-edit-read-fail.txt" },
+    ]);
+  });
+});

--- a/tests/edit-post-verify-success.test.ts
+++ b/tests/edit-post-verify-success.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { computeLineHash, ensureHashInit } from "../src/hashline.js";
+
+const fsMock = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  return { ...actual, readFile: fsMock.readFile, writeFile: fsMock.writeFile };
+});
+
+import { registerEditTool } from "../src/edit.js";
+
+function captureEditTool() {
+  let tool: any;
+  registerEditTool({ registerTool(def: any) { tool = def; } } as any, { wasReadInSession: () => true });
+  if (!tool) throw new Error("edit tool was not registered");
+  return tool;
+}
+
+describe("edit postEditVerify success", () => {
+  beforeEach(async () => {
+    await ensureHashInit();
+    fsMock.readFile.mockReset();
+    fsMock.writeFile.mockReset();
+  });
+
+  it("reads back after a successful opt-in write and preserves the normal success details", async () => {
+    const tool = captureEditTool();
+    let persisted = "";
+    fsMock.readFile
+      .mockResolvedValueOnce(Buffer.from("alpha\nbeta", "utf8"))
+      .mockImplementationOnce(async () => persisted);
+    fsMock.writeFile.mockImplementation(async (_path: string, content: string) => { persisted = content; });
+    const anchor = `1:${computeLineHash(1, "alpha")}`;
+
+    const result = await tool.execute(
+      "tc",
+      { path: "/tmp/post-edit-success.txt", postEditVerify: true, edits: [{ set_line: { anchor, new_text: "ALPHA" } }] },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(fsMock.writeFile).toHaveBeenCalledWith("/tmp/post-edit-success.txt", "ALPHA\nbeta", "utf-8");
+    expect(fsMock.readFile).toHaveBeenCalledTimes(2);
+    expect(fsMock.readFile.mock.invocationCallOrder[1]).toBeGreaterThan(fsMock.writeFile.mock.invocationCallOrder[0]);
+    expect(result.content[0].text).toContain("Edited /tmp/post-edit-success.txt");
+    expect(result.details.diff).toContain("alpha");
+    expect(result.details.diffData).toEqual(result.details.ptcValue.diffData);
+    expect(result.details.ptcValue.ok).toBe(true);
+    expect(result.details.ptcValue.warnings).toEqual([]);
+    expect(result.details.ptcValue.semanticSummary).toBeTruthy();
+    expect(result.details.firstChangedLine).toBe(1);
+    expect(result.details.contextHygiene.classification).toBe("mutation");
+  });
+});

--- a/tests/edit-post-verify-syntax-block.test.ts
+++ b/tests/edit-post-verify-syntax-block.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+import { registerEditTool } from "../src/edit.js";
+
+function captureEditTool(opts?: any) {
+  let captured: any = null;
+  registerEditTool({ registerTool(def: any) { captured = def; } } as any, opts);
+  if (!captured) throw new Error("edit tool was not registered");
+  return captured;
+}
+
+describe("edit postEditVerify syntax validation ordering", () => {
+  beforeAll(async () => { await ensureHashInit(); });
+
+  it("block mode aborts before writing even when postEditVerify is true", async () => {
+    const tool = captureEditTool({ syntaxValidate: "block" });
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-post-verify-syntax-block-"));
+    const fp = resolve(dir, "sample.rs");
+    const original = "fn a() { 1 }\n";
+    writeFileSync(fp, original, "utf8");
+    try {
+      const anchor = `1:${computeLineHash(1, "fn a() { 1 }")}`;
+      const res = await tool.execute(
+        "block-post-verify",
+        {
+          path: fp,
+          postEditVerify: true,
+          edits: [
+            { set_line: { anchor, new_text: "fn a( {" } },
+            { insert_after: { anchor, new_text: "fn b(\n" } },
+          ],
+        },
+        new AbortController().signal,
+        () => {},
+        { cwd: process.cwd() },
+      );
+
+      expect(res.isError).toBe(true);
+      expect(res.details?.ptcValue?.error?.code).toBe("syntax-regression");
+      expect(readFileSync(fp, "utf8")).toBe(original);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/edit-prompt-coverage.test.ts
+++ b/tests/edit-prompt-coverage.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 describe("prompts/edit.md coverage", () => {
-  it("documents recovery, variants, replace safety, anchor sources, and validation warnings", () => {
+  it("documents recovery, variants, replace safety, anchor sources, validation warnings, and post-edit verification", () => {
     const content = readFileSync(resolve("prompts/edit.md"), "utf8");
 
     expect(content).toContain("hash mismatch");
@@ -26,6 +26,10 @@ describe("prompts/edit.md coverage", () => {
     expect(content).toContain("anchored edits");
     expect(content).toContain("file-not-read");
     expect(content).toContain("syntax-regression");
+    expect(content).toContain("postEditVerify");
+    expect(content).toContain("default off");
+    expect(content).toContain("post-write persisted-content verification");
+    expect(content).toContain("not syntax validation");
     expect(content.split("\n").length).toBeGreaterThanOrEqual(70);
   });
 });


### PR DESCRIPTION
Closes #184.

## Summary

Adds an explicit, default-off `postEditVerify: true` option to `edit` so callers can confirm a successful write persisted exactly as intended. The default fast path remains unchanged; the opt-in path verifies exact BOM- and line-ending-restored content after `fsWriteFile` succeeds.

## What changed

- Added `postEditVerify` to the `edit` tool input schema.
- Added post-write read-back verification after successful `fsWriteFile` only.
- Compared read-back content against exact intended persisted content: BOM restoration plus original line-ending restoration.
- Added structured post-write verification errors:
  - `post-edit-verification-read-failed`
  - `post-edit-verification-mismatch`
- Marked post-write verification failure results with mutation `contextHygiene`, because the file was already written.
- Preserved the existing default success path and output contract from `buildEditOutput`.
- Documented the option in `prompts/edit.md`.
- Added focused regression tests for default-off behavior, opt-in success, verification failures, line endings/BOM, pre-write guard ordering, syntax-validation ordering, and docs coverage.

## Acceptance Criteria

- [x] AC1 — `edit` accepts explicit per-call `postEditVerify` in its input schema.
- [x] AC2 — Post-edit verification is disabled by default when omitted.
- [x] AC3 — Default-off successful edits do not perform verification read-back and preserve the existing success contract.
- [x] AC4 — Opt-in verification runs only after `fsWriteFile` succeeds.
- [x] AC5 — Verification compares against exact persisted content, including BOM and original line endings.
- [x] AC6 — LF, CRLF, and BOM-preserving edits verify successfully when persisted content matches.
- [x] AC7 — Successful verification preserves diff, `diffData`, `ptcValue`, warnings, semantic summary, first changed line, and context hygiene.
- [x] AC8 — Read-back failure after write returns a structured `post-edit-verification-read-failed` error.
- [x] AC9 — Persisted-content mismatch after write returns a structured `post-edit-verification-mismatch` error.
- [x] AC10 — Verification failures use the existing edit error envelope style and include useful structured details.
- [x] AC11 — Existing pre-write edit guards still run before write or post-write verification.
- [x] AC12 — Syntax validation remains independent and block mode still aborts before writing.
- [x] AC13 — Prompt docs describe opt-in/default-off post-write persisted-content verification and distinguish it from syntax validation.
- [x] AC14 — Tests cover default-off, opt-in success, read-back failure, mismatch, LF/CRLF/BOM behavior, guard ordering, syntax ordering, and successful-output preservation.

## Verification

```text
npm test

Test Files  326 passed (326)
Tests       1436 passed (1436)
```

```text
npm run typecheck

> pi-hashline-readmap@0.8.7 typecheck
> tsc --noEmit
```

Focused post-edit verification tests also passed:

```text
npx vitest run tests/edit-post-verify-default.test.ts tests/edit-post-verify-success.test.ts tests/edit-post-verify-read-failure.test.ts tests/edit-post-verify-mismatch.test.ts tests/edit-post-verify-line-endings.test.ts tests/edit-post-verify-prewrite-guards.test.ts tests/edit-post-verify-syntax-block.test.ts tests/edit-prompt-coverage.test.ts

Test Files  8 passed (8)
Tests       8 passed (8)
```
