### PR TITLE
fix(security): remove shell injection from readmap mappers

### DIFF
--- a/src/readmap/mappers/_subprocess-utils.ts
+++ b/src/readmap/mappers/_subprocess-utils.ts
@@ -1,0 +1,54 @@
+import { execFile, type ExecFileOptionsWithStringEncoding } from "node:child_process";
+import { readFile } from "node:fs/promises";
+
+export interface ExecFileSafeOptions {
+  cwd?: string;
+  signal?: AbortSignal;
+  timeout?: number;
+  maxBuffer?: number;
+}
+
+export interface ExecFileSafeResult {
+  stdout: string;
+  stderr: string;
+}
+
+export function execFileSafe(
+  command: string,
+  args: string[],
+  options: ExecFileSafeOptions = {}
+): Promise<ExecFileSafeResult> {
+  return new Promise((resolve, reject) => {
+    const execOptions: ExecFileOptionsWithStringEncoding = {
+      ...options,
+      encoding: "utf8",
+    };
+
+    execFile(command, args, execOptions, (error, stdout, stderr) => {
+      if (error) {
+        (error as NodeJS.ErrnoException & { stdout?: string; stderr?: string }).stdout = stdout;
+        (error as NodeJS.ErrnoException & { stdout?: string; stderr?: string }).stderr = stderr;
+        reject(error);
+        return;
+      }
+
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+export async function countLinesWcStyle(
+  filePath: string,
+  signal?: AbortSignal
+): Promise<number> {
+  const buffer = await readFile(filePath, { signal });
+  let lines = 0;
+
+  for (const byte of buffer) {
+    if (byte === 0x0a) {
+      lines += 1;
+    }
+  }
+
+  return lines;
+}

--- a/src/readmap/mappers/ctags.ts
+++ b/src/readmap/mappers/ctags.ts
@@ -4,17 +4,14 @@
  * Uses universal-ctags when installed to extract symbols.
  * Falls back gracefully when ctags is not available.
  */
-import { exec } from "node:child_process";
 import { stat } from "node:fs/promises";
-import { promisify } from "node:util";
 
 import type { FileMap, FileSymbol } from "../types.js";
 
 import { DetailLevel, SymbolKind } from "../enums.js";
 import { detectLanguage } from "../language-detect.js";
+import { countLinesWcStyle, execFileSafe } from "./_subprocess-utils.js";
 export const MAPPER_VERSION = 1;
-
-const execAsync = promisify(exec);
 
 // Cache ctags availability check
 let ctagsAvailable: boolean | null = null;
@@ -98,8 +95,9 @@ export async function isCtagsAvailable(): Promise<boolean> {
   }
 
   try {
-    const { stdout } = await execAsync("ctags --version 2>&1", {
+    const { stdout } = await execFileSafe("ctags", ["--version"], {
       timeout: 2000,
+      maxBuffer: 1024 * 1024,
     });
     // Universal Ctags includes "Universal Ctags" in version output
     // Exuberant Ctags also works but is less feature-rich
@@ -179,15 +177,17 @@ export async function ctagsMapper(
     // Run ctags with JSON output and line numbers
     // --output-format=json requires Universal Ctags 5.9+
     // --fields=+n ensures line numbers are included in JSON output
-    const cmd = `ctags --output-format=json --fields=+n -f - "${filePath}" 2>/dev/null`;
-
     let stdout: string;
     try {
-      ({ stdout } = await execAsync(cmd, {
-        signal,
-        timeout: 10_000,
-        maxBuffer: 1024 * 1024,
-      }));
+      ({ stdout } = await execFileSafe(
+        "ctags",
+        ["--output-format=json", "--fields=+n", "-f", "-", filePath],
+        {
+          signal,
+          timeout: 10_000,
+          maxBuffer: 1024 * 1024,
+        }
+      ));
     } catch {
       // ctags might not support JSON output, try standard format
       return await ctagsMapperLegacy(filePath, signal);
@@ -198,10 +198,7 @@ export async function ctagsMapper(
     }
 
     // Count lines
-    const { stdout: wcOutput } = await execAsync(`wc -l < "${filePath}"`, {
-      signal,
-    });
-    const totalLines = Number.parseInt(wcOutput.trim(), 10) || 0;
+    const totalLines = await countLinesWcStyle(filePath, signal);
 
     // Parse output
     const entries = parseCtagsOutput(stdout);
@@ -261,23 +258,22 @@ async function ctagsMapperLegacy(
     const totalBytes = stats.size;
 
     // Run ctags with line numbers
-    const cmd = `ctags --excmd=number -f - "${filePath}" 2>/dev/null`;
-
-    const { stdout } = await execAsync(cmd, {
-      signal,
-      timeout: 10_000,
-      maxBuffer: 1024 * 1024,
-    });
+    const { stdout } = await execFileSafe(
+      "ctags",
+      ["--excmd=number", "-f", "-", filePath],
+      {
+        signal,
+        timeout: 10_000,
+        maxBuffer: 1024 * 1024,
+      }
+    );
 
     if (signal?.aborted) {
       return null;
     }
 
     // Count lines
-    const { stdout: wcOutput } = await execAsync(`wc -l < "${filePath}"`, {
-      signal,
-    });
-    const totalLines = Number.parseInt(wcOutput.trim(), 10) || 0;
+    const totalLines = await countLinesWcStyle(filePath, signal);
 
     // Parse traditional format
     const entries: CtagsEntry[] = [];

--- a/src/readmap/mappers/fallback.ts
+++ b/src/readmap/mappers/fallback.ts
@@ -1,14 +1,11 @@
-import { exec } from "node:child_process";
-import { stat } from "node:fs/promises";
-import { promisify } from "node:util";
+import { readFile, stat } from "node:fs/promises";
 
 import type { FileMap, FileSymbol } from "../types.js";
 
 import { DetailLevel, SymbolKind } from "../enums.js";
 import { detectLanguage } from "../language-detect.js";
+import { countLinesWcStyle } from "./_subprocess-utils.js";
 export const MAPPER_VERSION = 1;
-
-const execAsync = promisify(exec);
 
 /**
  * Patterns to grep for common structural elements.
@@ -66,6 +63,48 @@ function extractName(line: string): string {
   return cleaned.split(/\s|[({<:]/)[0] || "unknown";
 }
 
+async function scanMatches(filePath: string, signal?: AbortSignal): Promise<GrepMatch[]> {
+  const content = await readFile(filePath, { encoding: "utf8", signal });
+  const lines = content.split("\n");
+  const matches: GrepMatch[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (signal?.aborted) {
+      return matches;
+    }
+
+    const rawLine = lines[index];
+    const trimmedContent = rawLine.trim();
+    if (!trimmedContent) {
+      continue;
+    }
+
+    let matchedKind: SymbolKind | null = null;
+    for (const p of PATTERNS) {
+      if (new RegExp(p.pattern, "i").test(rawLine)) {
+        matchedKind = p.kind;
+        break;
+      }
+    }
+
+    if (matchedKind === null) {
+      continue;
+    }
+
+    matches.push({
+      lineNumber: index + 1,
+      content: trimmedContent,
+      kind: matchedKind,
+    });
+
+    if (matches.length >= 500) {
+      break;
+    }
+  }
+
+  return matches;
+}
+
 
 /**
  * Fallback mapper using grep for basic structure extraction.
@@ -81,51 +120,10 @@ export async function fallbackMapper(
     const totalBytes = stats.size;
 
     // Count lines
-    const { stdout: wcOutput } = await execAsync(`wc -l < "${filePath}"`, {
-      signal,
-    });
-    const totalLines = Number.parseInt(wcOutput.trim(), 10) || 0;
+    const totalLines = await countLinesWcStyle(filePath, signal);
 
-    // Build grep pattern
-    const combinedPattern = PATTERNS.map((p) => p.pattern).join("\\|");
-
-    // Run grep
-    let matches: GrepMatch[] = [];
-    try {
-      const { stdout } = await execAsync(
-        `grep -n "${combinedPattern}" "${filePath}" | head -500`,
-        { signal, timeout: 5000 }
-      );
-
-      // Parse grep output
-      for (const line of stdout.split("\n")) {
-        if (!line.trim()) {
-          continue;
-        }
-
-        const colonIndex = line.indexOf(":");
-        if (colonIndex === -1) {
-          continue;
-        }
-
-        const lineNumber = Number.parseInt(line.slice(0, colonIndex), 10);
-        const content = line.slice(colonIndex + 1).trim();
-
-        // Determine kind from pattern match
-        let matchedKind: SymbolKind = SymbolKind.Unknown;
-        for (const p of PATTERNS) {
-          if (new RegExp(p.pattern, "i").test(content)) {
-            matchedKind = p.kind;
-            break;
-          }
-        }
-
-        matches.push({ lineNumber, content, kind: matchedKind });
-      }
-    } catch {
-      // grep returns exit code 1 when no matches, which throws
-      matches = [];
-    }
+    // Scan for structural patterns, preserving the old grep/head behavior.
+    const matches = await scanMatches(filePath, signal);
 
     // Convert to symbols
     const symbols: FileSymbol[] = matches.map((m, i) => {

--- a/src/readmap/mappers/go.ts
+++ b/src/readmap/mappers/go.ts
@@ -1,16 +1,13 @@
-import { exec } from "node:child_process";
 import { existsSync } from "node:fs";
 import { stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
 
 import type { FileMap, FileSymbol } from "../types.js";
 
 import { DetailLevel, SymbolKind } from "../enums.js";
+import { countLinesWcStyle, execFileSafe } from "./_subprocess-utils.js";
 export const MAPPER_VERSION = 1;
-
-const execAsync = promisify(exec);
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCRIPTS_DIR = join(__dirname, "../../scripts");
@@ -45,7 +42,7 @@ let binaryAvailable = false;
  */
 async function hasGo(): Promise<boolean> {
   try {
-    await execAsync("go version", { timeout: 5000 });
+    await execFileSafe("go", ["version"], { timeout: 5000 });
     return true;
   } catch {
     return false;
@@ -83,7 +80,7 @@ async function ensureBinary(): Promise<boolean> {
 
   try {
     // Compile the binary
-    await execAsync(`go build -o "${GO_BINARY}" "${GO_SOURCE}"`, {
+    await execFileSafe("go", ["build", "-o", GO_BINARY, GO_SOURCE], {
       timeout: 30_000,
       cwd: SCRIPTS_DIR,
     });
@@ -182,13 +179,10 @@ export async function goMapper(
     const totalBytes = stats.size;
 
     // Count lines
-    const { stdout: wcOutput } = await execAsync(`wc -l < "${filePath}"`, {
-      signal,
-    });
-    const totalLines = Number.parseInt(wcOutput.trim(), 10) || 0;
+    const totalLines = await countLinesWcStyle(filePath, signal);
 
     // Run Go outline script
-    const { stdout, stderr } = await execAsync(`"${GO_BINARY}" "${filePath}"`, {
+    const { stdout, stderr } = await execFileSafe(GO_BINARY, [filePath], {
       signal,
       timeout: 10_000,
     });

--- a/src/readmap/mappers/json.ts
+++ b/src/readmap/mappers/json.ts
@@ -1,13 +1,10 @@
-import { exec } from "node:child_process";
 import { stat } from "node:fs/promises";
-import { promisify } from "node:util";
 
 import type { FileMap, FileSymbol } from "../types.js";
 
 import { DetailLevel, SymbolKind } from "../enums.js";
+import { countLinesWcStyle, execFileSafe } from "./_subprocess-utils.js";
 export const MAPPER_VERSION = 1;
-
-const execAsync = promisify(exec);
 
 /**
  * jq script to extract JSON schema structure.
@@ -116,7 +113,7 @@ function schemaToSymbols(
  */
 async function hasJq(): Promise<boolean> {
   try {
-    await execAsync("jq --version", { timeout: 5000 });
+    await execFileSafe("jq", ["--version"], { timeout: 5000 });
     return true;
   } catch {
     return false;
@@ -141,14 +138,12 @@ export async function jsonMapper(
     const totalBytes = stats.size;
 
     // Count lines
-    const { stdout: wcOutput } = await execAsync(`wc -l < "${filePath}"`, {
-      signal,
-    });
-    const totalLines = Number.parseInt(wcOutput.trim(), 10) || 1;
+    const totalLines = (await countLinesWcStyle(filePath, signal)) || 1;
 
     // Run jq to extract schema
-    const { stdout, stderr } = await execAsync(
-      `jq '${JQ_SCHEMA_SCRIPT.replaceAll("'", "'\\''")}' "${filePath}"`,
+    const { stdout, stderr } = await execFileSafe(
+      "jq",
+      [JQ_SCHEMA_SCRIPT, filePath],
       {
         signal,
         timeout: 10_000,

--- a/src/readmap/mappers/python.ts
+++ b/src/readmap/mappers/python.ts
@@ -1,15 +1,12 @@
-import { exec } from "node:child_process";
 import { stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
 
 import type { FileMap, FileSymbol } from "../types.js";
 
 import { DetailLevel, SymbolKind } from "../enums.js";
+import { countLinesWcStyle, execFileSafe } from "./_subprocess-utils.js";
 export const MAPPER_VERSION = 1;
-
-const execAsync = promisify(exec);
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCRIPT_PATH = join(__dirname, "../../scripts/python_outline.py");
@@ -99,14 +96,12 @@ export async function pythonMapper(
     const totalBytes = stats.size;
 
     // Count lines
-    const { stdout: wcOutput } = await execAsync(`wc -l < "${filePath}"`, {
-      signal,
-    });
-    const totalLines = Number.parseInt(wcOutput.trim(), 10) || 0;
+    const totalLines = await countLinesWcStyle(filePath, signal);
 
     // Run Python script
-    const { stdout, stderr } = await execAsync(
-      `python3 "${SCRIPT_PATH}" "${filePath}"`,
+    const { stdout, stderr } = await execFileSafe(
+      "python3",
+      [SCRIPT_PATH, filePath],
       {
         signal,
         timeout: 10_000,

--- a/tests/readmap-fallback-scanner.test.ts
+++ b/tests/readmap-fallback-scanner.test.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { fallbackMapper } from "../src/readmap/mappers/fallback.js";
+
+describe("fallback readmap scanner", () => {
+  it("replaces the grep pipeline while preserving match order, raw-line anchoring, trimming, and the 500-match cap", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "readmap-fallback-scanner-"));
+
+    try {
+      const filePath = join(tempDir, "large.txt");
+      const sourcePath = join(process.cwd(), "src/readmap/mappers/fallback.ts");
+      const source = await readFile(sourcePath, "utf8");
+
+      const prefix = "x".repeat(11 * 1024 * 1024);
+      const matches = Array.from({ length: 550 }, (_, index) => `\nfunction fn${index}() {}`);
+      await writeFile(
+        filePath,
+        `${prefix}\n  function indented() {}${matches.join("")}`
+      );
+
+      const map = await fallbackMapper(filePath);
+
+      expect(source).not.toContain("grep -n");
+      expect(source).not.toContain("execAsync");
+      expect(map?.symbols).toHaveLength(500);
+      expect(map?.symbols.map((symbol) => symbol.name).slice(0, 3)).toEqual([
+        "fn0",
+        "fn1",
+        "fn2",
+      ]);
+      expect(map?.symbols[0]).toMatchObject({ name: "fn0", startLine: 3 });
+      expect(map?.symbols.at(-1)).toMatchObject({ name: "fn499" });
+      expect(map?.symbols.some((symbol) => symbol.name === "indented")).toBe(false);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/readmap-go-subprocess-guard.test.ts
+++ b/tests/readmap-go-subprocess-guard.test.ts
@@ -1,0 +1,17 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+describe("Go mapper subprocess usage", () => {
+  it("does not use shell command strings", async () => {
+    const source = await readFile("src/readmap/mappers/go.ts", "utf8");
+
+    expect(source).not.toContain('import { exec } from "node:child_process"');
+    expect(source).not.toContain("promisify(exec)");
+    expect(source).not.toContain("execAsync(");
+    expect(source).not.toContain('wc -l < "${filePath}"');
+    expect(source).not.toContain('"${GO_BINARY}" "${filePath}"');
+    expect(source).toContain("execFileSafe(");
+    expect(source).toContain("countLinesWcStyle(filePath, signal)");
+  });
+});

--- a/tests/readmap-json-subprocess-guard.test.ts
+++ b/tests/readmap-json-subprocess-guard.test.ts
@@ -1,0 +1,17 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+describe("JSON mapper subprocess usage", () => {
+  it("does not use shell command strings", async () => {
+    const source = await readFile("src/readmap/mappers/json.ts", "utf8");
+
+    expect(source).not.toContain('import { exec } from "node:child_process"');
+    expect(source).not.toContain("promisify(exec)");
+    expect(source).not.toContain("execAsync(");
+    expect(source).not.toContain('wc -l < "${filePath}"');
+    expect(source).not.toContain("`jq '");
+    expect(source).toContain("execFileSafe(");
+    expect(source).toContain("countLinesWcStyle(filePath, signal)");
+  });
+});

--- a/tests/readmap-mapper-adversarial-filenames.test.ts
+++ b/tests/readmap-mapper-adversarial-filenames.test.ts
@@ -1,0 +1,87 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ctagsMapper } from "../src/readmap/mappers/ctags.js";
+import { fallbackMapper } from "../src/readmap/mappers/fallback.js";
+import { goMapper } from "../src/readmap/mappers/go.js";
+import { jsonMapper } from "../src/readmap/mappers/json.js";
+import { pythonMapper } from "../src/readmap/mappers/python.js";
+
+type MapperCase = {
+  name: string;
+  extension: string;
+  content: string;
+  mapper: (filePath: string) => Promise<unknown>;
+};
+
+const mapperCases: MapperCase[] = [
+  {
+    name: "python",
+    extension: ".py",
+    content: "def hello():\n    return 'world'\n",
+    mapper: pythonMapper,
+  },
+  {
+    name: "go",
+    extension: ".go",
+    content: "package main\n\nfunc main() {}\n",
+    mapper: goMapper,
+  },
+  {
+    name: "json",
+    extension: ".json",
+    content: '{"hello":"world"}\n',
+    mapper: jsonMapper,
+  },
+  {
+    name: "fallback",
+    extension: ".txt",
+    content: "function hello() {}\n",
+    mapper: fallbackMapper,
+  },
+  {
+    name: "ctags",
+    extension: ".rb",
+    content: "def hello\nend\n",
+    mapper: ctagsMapper,
+  },
+];
+
+const hostileFragments = [
+  'double"quote',
+  "single'quote",
+  "semicolon;touch pwn",
+  "command$(touch pwn)",
+  "backtick`touch pwn`",
+  "newline\ntouch pwn",
+  "unicode\u00A0touch\u00A0pwn",
+];
+
+describe("readmap mapper adversarial filenames", () => {
+  it("does not execute shell syntax from hostile filenames across mapper entry points", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "readmap-adversarial-filenames-"));
+    const originalCwd = process.cwd();
+
+    try {
+      process.chdir(tempDir);
+
+      for (const mapperCase of mapperCases) {
+        for (const fragment of hostileFragments) {
+          const fileName = `${mapperCase.name}-${fragment}${mapperCase.extension}`;
+          await writeFile(fileName, mapperCase.content);
+
+          await mapperCase.mapper(fileName);
+
+          expect(existsSync("pwn"), `${mapperCase.name}: ${JSON.stringify(fragment)}`).toBe(false);
+        }
+      }
+    } finally {
+      process.chdir(originalCwd);
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/readmap-mapper-injection-repro.test.ts
+++ b/tests/readmap-mapper-injection-repro.test.ts
@@ -1,0 +1,28 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { pythonMapper } from "../src/readmap/mappers/python.js";
+
+describe("readmap mapper subprocess command injection reproduction", () => {
+  it("does not execute shell command substitution in Python filenames", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "readmap-injection-repro-"));
+    const originalCwd = process.cwd();
+
+    try {
+      process.chdir(tempDir);
+      const maliciousPath = "evil$(touch pwn).py";
+      await writeFile(maliciousPath, "def hello():\n    return 'world'\n");
+
+      await pythonMapper(maliciousPath);
+
+      expect(existsSync("pwn")).toBe(false);
+    } finally {
+      process.chdir(originalCwd);
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/readmap-mapper-subprocess-static-guard.test.ts
+++ b/tests/readmap-mapper-subprocess-static-guard.test.ts
@@ -1,0 +1,26 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const mapperFiles = [
+  "src/readmap/mappers/python.ts",
+  "src/readmap/mappers/go.ts",
+  "src/readmap/mappers/json.ts",
+  "src/readmap/mappers/fallback.ts",
+  "src/readmap/mappers/ctags.ts",
+];
+
+describe("readmap mapper subprocess static guard", () => {
+  it("keeps mapper files from using shell subprocess APIs", async () => {
+    for (const file of mapperFiles) {
+      const source = await readFile(file, "utf8");
+
+      expect(source, file).not.toContain('import { exec } from "node:child_process"');
+      expect(source, file).not.toContain('from "node:child_process"');
+      expect(source, file).not.toContain("promisify(exec)");
+      expect(source, file).not.toContain("execAsync(");
+      expect(source, file).not.toMatch(/spawn\([^\n]*shell:\s*true/s);
+      expect(source, file).not.toMatch(/`[^`]*\$\{filePath\}[^`]*`/);
+    }
+  });
+});

--- a/tests/readmap-mapper-subprocess-static-guard.test.ts
+++ b/tests/readmap-mapper-subprocess-static-guard.test.ts
@@ -1,26 +1,76 @@
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-const mapperFiles = [
-  "src/readmap/mappers/python.ts",
-  "src/readmap/mappers/go.ts",
-  "src/readmap/mappers/json.ts",
-  "src/readmap/mappers/fallback.ts",
-  "src/readmap/mappers/ctags.ts",
-];
+const MAPPER_DIR = "src/readmap/mappers";
+const ALLOWED_HELPER = "_subprocess-utils.ts";
+
+async function mapperFiles(): Promise<string[]> {
+  const entries = await readdir(MAPPER_DIR);
+  return entries
+    .filter((entry) => entry.endsWith(".ts"))
+    .filter((entry) => entry !== ALLOWED_HELPER)
+    .map((entry) => join(MAPPER_DIR, entry));
+}
+
+function shellSubprocessFindings(source: string): string[] {
+  const findings: string[] = [];
+
+  if (source.includes('import { exec } from "node:child_process"')) {
+    findings.push("direct exec import");
+  }
+  if (source.includes('from "node:child_process"')) {
+    findings.push("direct child_process import");
+  }
+  if (source.includes("promisify(exec)")) {
+    findings.push("promisify(exec)");
+  }
+  if (source.includes("execAsync(")) {
+    findings.push("execAsync call");
+  }
+  if (/spawn\([^\n]*shell:\s*true/s.test(source)) {
+    findings.push("spawn shell:true");
+  }
+  if (/`[^`]*\$\{filePath\}[^`]*`/.test(source)) {
+    findings.push("filePath template interpolation");
+  }
+
+  return findings;
+}
 
 describe("readmap mapper subprocess static guard", () => {
   it("keeps mapper files from using shell subprocess APIs", async () => {
-    for (const file of mapperFiles) {
+    for (const file of await mapperFiles()) {
       const source = await readFile(file, "utf8");
-
-      expect(source, file).not.toContain('import { exec } from "node:child_process"');
-      expect(source, file).not.toContain('from "node:child_process"');
-      expect(source, file).not.toContain("promisify(exec)");
-      expect(source, file).not.toContain("execAsync(");
-      expect(source, file).not.toMatch(/spawn\([^\n]*shell:\s*true/s);
-      expect(source, file).not.toMatch(/`[^`]*\$\{filePath\}[^`]*`/);
+      expect(shellSubprocessFindings(source), file).toEqual([]);
     }
   });
+
+  it("flags seeded vulnerable subprocess patterns", () => {
+    const vulnerable = String.raw`
+      import { exec } from "node:child_process";
+      const execAsync = promisify(exec);
+      await execAsync(` + "`wc -l < \"${filePath}\"`" + `);
+      spawn("grep", [filePath], { shell: true });
+    `;
+
+    expect(shellSubprocessFindings(vulnerable)).toEqual([
+      "direct exec import",
+      "direct child_process import",
+      "promisify(exec)",
+      "execAsync call",
+      "spawn shell:true",
+      "filePath template interpolation",
+    ]);
+  });
+
+  it("allows argv-only helper usage", () => {
+    const safe = `
+      import { execFileSafe } from "./_subprocess-utils.js";
+      await execFileSafe("python3", [SCRIPT_PATH, filePath], { timeout: 10_000 });
+    `;
+
+    expect(shellSubprocessFindings(safe)).toEqual([]);
+});
 });

--- a/tests/readmap-subprocess-utils.test.ts
+++ b/tests/readmap-subprocess-utils.test.ts
@@ -1,0 +1,32 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { countLinesWcStyle } from "../src/readmap/mappers/_subprocess-utils.js";
+
+describe("readmap mapper subprocess utilities", () => {
+  it("counts lines with wc -l newline semantics", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "readmap-line-count-"));
+
+    try {
+      const empty = join(tempDir, "empty.txt");
+      const noTrailingNewline = join(tempDir, "one-line-no-newline.txt");
+      const oneTrailingNewline = join(tempDir, "one-line-with-newline.txt");
+      const threeNewlines = join(tempDir, "three-newlines.txt");
+
+      await writeFile(empty, "");
+      await writeFile(noTrailingNewline, "one line");
+      await writeFile(oneTrailingNewline, "one line\n");
+      await writeFile(threeNewlines, "a\nb\nc\n");
+
+      await expect(countLinesWcStyle(empty)).resolves.toBe(0);
+      await expect(countLinesWcStyle(noTrailingNewline)).resolves.toBe(0);
+      await expect(countLinesWcStyle(oneTrailingNewline)).resolves.toBe(1);
+      await expect(countLinesWcStyle(threeNewlines)).resolves.toBe(3);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes SEC-001 by removing shell command interpretation from readmap mapper subprocess paths. Repository-controlled filenames are now passed as argv data through a shared `execFileSafe` helper, and shell-only utilities used by mappers are replaced with native code where needed.

## What changed

- Added `src/readmap/mappers/_subprocess-utils.ts` with:
  - `execFileSafe(...)` for argv-only subprocess execution
  - `countLinesWcStyle(...)` for native `wc -l` newline-byte semantics
- Updated Python, Go, JSON, ctags, and legacy ctags mapper subprocess calls to use argv arrays.
- Replaced fallback mapper's `grep -n ... | head -500` pipeline with native scanning while preserving ordering, 1-based line numbers, trimmed content, and the 500-match cap.
- Added regression/static guard tests for command substitution filenames, line counting, fallback behavior, and mapper subprocess API usage.
- Added adversarial filename coverage across affected mapper entry points for quotes, semicolons, command substitution, backticks, newlines, and unicode spaces.
- Strengthened the static mapper guard to scan every mapper `.ts` file except the intentional `_subprocess-utils.ts` helper, with seeded vulnerable/safe fixture assertions proving the guard itself works.

## Comparison with PR #105

This implements the same core SEC-001 remediation from #105: remove `exec()` shell strings and treat `filePath` as argv data. It is adapted to the current tree with a smaller helper surface.

Parity points with #105:

- Covers the same five mapper surfaces: Python, Go, JSON, fallback, and ctags.
- Removes path-interpolated shell command strings from mapper subprocess boundaries.
- Replaces `wc -l` with native newline-byte counting.
- Replaces fallback `grep -n ... | head -500` behavior with native scanning.
- Adds adversarial filename coverage for the same classes of shell metacharacters.
- Adds static guard coverage against reintroducing shell subprocess patterns.

Differences from #105:

- #105 used broader reusable helpers (`countLinesNative`, `scanForMatches`, richer options). This PR keeps only `execFileSafe` and `countLinesWcStyle`; fallback scanning remains local to `fallback.ts`.
- #105 changed `package-lock.json`; this PR does not.
- This PR's full current test suite passed cleanly in verification.

## Verification

- `npm run typecheck`
- `npm test` — 333 files / 1445 tests passed
- `npx vitest run tests/readmap-mapper-adversarial-filenames.test.ts tests/readmap-mapper-injection-repro.test.ts tests/readmap-subprocess-utils.test.ts tests/readmap-fallback-scanner.test.ts tests/readmap-mapper-subprocess-static-guard.test.ts tests/readmap-go-subprocess-guard.test.ts tests/readmap-json-subprocess-guard.test.ts` — 7 files / 9 tests passed
- `npx vitest run tests/readmap-mapper-injection-repro.test.ts --reporter verbose`
