### PR TITLE
chore(release): compact provider-visible tool metadata (#187)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -198,8 +198,8 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
   const editTool = registerEditTool(pi, { wasReadInSession });
   const sgAvailable = isSgAvailable();
   const astSearchGuideline = sgAvailable
-    ? 'Use `ast_search` for structural code patterns (function calls, imports, JSX). Use `grep` for text matching.'
-    : 'Use grep for plain text search; for AST-aware structural code search (function calls, imports, JSX elements), install ast-grep: `brew install ast-grep`';
+    ? "Use grep summary for counts; use ast_search for structural code patterns."
+    : "Use grep summary for counts; install ast-grep to enable ast_search.";
 
   const grepTool = registerGrepTool(pi, { astSearchGuideline, onFileAnchored: noteRead });
   const sgTool = registerSgTool(pi, { onFileAnchored: noteRead });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {

--- a/src/bash-renderer.ts
+++ b/src/bash-renderer.ts
@@ -1,8 +1,15 @@
 import { createBashTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
+import { Type } from "@sinclair/typebox";
 import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine } from "./tui-render-utils.js";
 
 type BuiltInFactory = (cwd: string) => any;
+
+const BASH_DESCRIPTION = "Run shell commands for tests, builds, git, package managers, and external CLIs.";
+const BASH_PARAMETERS = Type.Object({
+  command: Type.String({ description: "Shell command to run" }),
+  timeout: Type.Optional(Type.Number({ description: "Timeout seconds" })),
+});
 
 export function registerBashRendererTool(pi: Pick<ExtensionAPI, "registerTool">, options: { cwd?: string; createBuiltInBashTool?: BuiltInFactory } = {}): any {
   const cache = new Map<string, any>();
@@ -15,13 +22,11 @@ export function registerBashRendererTool(pi: Pick<ExtensionAPI, "registerTool">,
     }
     return tool;
   };
-  const initialCwd = options.cwd ?? process.cwd();
-  const initialBuiltIn = getBuiltIn(initialCwd);
   const tool = {
     name: "bash",
     label: "bash",
-    description: initialBuiltIn?.description ?? "Run bash commands with compact TUI rendering while delegating execution to Pi's built-in bash tool.",
-    parameters: initialBuiltIn?.parameters ?? {},
+    description: BASH_DESCRIPTION,
+    parameters: BASH_PARAMETERS,
     async execute(toolCallId: string, params: any, signal?: AbortSignal, onUpdate?: any, ctx: any = {}) {
       const cwd = ctx?.cwd ?? options.cwd ?? process.cwd();
       return getBuiltIn(cwd).execute(toolCallId, params, signal, onUpdate);

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -68,10 +68,10 @@ const hashlineEditItemSchema = Type.Union([
 
 const hashlineEditSchema = Type.Object(
 	{
-		path: Type.String({ description: "File path (relative or absolute)" }),
-		edits: Type.Optional(Type.Array(hashlineEditItemSchema, { description: "Array of edit operations" })),
+		path: Type.String({ description: "File path" }),
+		edits: Type.Optional(Type.Array(hashlineEditItemSchema, { description: "Edit operations" })),
 		postEditVerify: Type.Optional(Type.Boolean({
-			description: "Opt in to post-write persisted-content verification. Default false.",
+			description: "Verify persisted content after write",
 		})),
 	},
 	{ additionalProperties: true },

--- a/src/find.ts
+++ b/src/find.ts
@@ -303,55 +303,34 @@ export function registerFindTool(pi: ExtensionAPI) {
     ptc: FIND_PTC,
     parameters: Type.Object(
       {
-        pattern: Type.String({ description: "Glob pattern (e.g. '*.ts', '*.test.ts')" }),
-        path: Type.Optional(Type.String({ description: "Directory to search (default: cwd)" })),
-        limit: Type.Optional(Type.Number({ description: "Max entries to return (default: 1000)" })),
+        pattern: Type.String({ description: "Glob or basename pattern" }),
+        path: Type.Optional(Type.String({ description: "Search root" })),
+        limit: Type.Optional(Type.Number({ description: "Max entries" })),
         type: Type.Optional(
           Type.Union(
             [Type.Literal("file"), Type.Literal("dir"), Type.Literal("any")],
-            { description: 'Filter by entry type (default: "file")' },
+            { description: "Entry type filter" },
           ),
         ),
-        maxDepth: Type.Optional(Type.Number({ description: "Maximum directory depth" })),
+        maxDepth: Type.Optional(Type.Number({ description: "Max directory depth" })),
         regex: Type.Optional(
-          Type.Boolean({ description: "Treat pattern as a JavaScript regular expression against file basename (default: false)" }),
+          Type.Boolean({ description: "Treat pattern as regex" }),
         ),
         sortBy: Type.Optional(
           Type.Union(
             [Type.Literal("name"), Type.Literal("mtime"), Type.Literal("size")],
-            { description: "Sort results by name (default), mtime, or size. Ascending unless reverse: true." },
+            { description: "Sort key" },
           ),
         ),
         reverse: Type.Optional(
-          Type.Boolean({ description: "Reverse the sort order (descending). Combined with sortBy: 'mtime' → newest first; with sortBy: 'size' → largest first." }),
+          Type.Boolean({ description: "Reverse sort order" }),
         ),
-        modifiedSince: Type.Optional(
-          Type.String({
-            description:
-              "Keep only entries modified strictly after this instant. " +
-              "Accepts ISO date ('2024-01-01'), ISO timestamp ('2024-01-01T00:00:00Z'), " +
-              "or relative shorthand: '30m', '1h', '24h', '7d'.",
-          }),
-        ),
+        modifiedSince: Type.Optional(Type.String({ description: "Modified after time" })),
         minSize: Type.Optional(
-          Type.Union(
-            [Type.Number(), Type.String()],
-            {
-              description:
-                "Minimum file size (inclusive). Bytes as number, or string with 1024-based suffix " +
-                "(B/K/KB/M/MB/G/GB, case-insensitive), e.g. '1MB', '500K', '1.5GB'. " +
-                "Filters files only; directories are never removed by size.",
-            },
-          ),
+          Type.Union([Type.Number(), Type.String()], { description: "Minimum file size" }),
         ),
         maxSize: Type.Optional(
-          Type.Union(
-            [Type.Number(), Type.String()],
-            {
-              description:
-                "Maximum file size (inclusive). Same format as minSize.",
-            },
-          ),
+          Type.Union([Type.Number(), Type.String()], { description: "Maximum file size" }),
         ),
       },
       { required: ["pattern"] },

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -30,33 +30,33 @@ const GREP_PROMPT_METADATA = defineToolPromptMetadata({
 });
 
 const grepSchema = Type.Object({
-	pattern: Type.String({ description: "Search pattern (regex or literal string)" }),
-	path: Type.Optional(Type.String({ description: "Directory or file to search (default: current directory)" })),
-	glob: Type.Optional(Type.String({ description: "Filter files by glob pattern, e.g. '*.ts' or '**/*.spec.ts'" })),
-	ignoreCase: Type.Optional(Type.Boolean({ description: "Case-insensitive search (default: false)" })),
-	literal: Type.Optional(Type.Boolean({ description: "Treat pattern as literal string instead of regex (default: false)" })),
+	pattern: Type.String({ description: "Pattern to search" }),
+	path: Type.Optional(Type.String({ description: "Search path" })),
+	glob: Type.Optional(Type.String({ description: "Glob filter" })),
+	ignoreCase: Type.Optional(Type.Boolean({ description: "Ignore case" })),
+	literal: Type.Optional(Type.Boolean({ description: "Treat pattern literally" })),
 	context: Type.Optional(
 		Type.Union([
-			Type.Number({ description: "Number of lines to show before and after each match (default: 0)" }),
-			Type.String({ description: "Number of lines to show before and after each match (default: 0)" }),
+			Type.Number({ description: "Context lines" }),
+			Type.String({ description: "Context lines" }),
 		]),
 	),
 	limit: Type.Optional(
 		Type.Union([
-			Type.Number({ description: "Maximum number of matches to return (default: 100)" }),
-			Type.String({ description: "Maximum number of matches to return (default: 100)" }),
+			Type.Number({ description: "Max matches" }),
+			Type.String({ description: "Max matches" }),
 		]),
 	),
-	summary: Type.Optional(Type.Boolean({ description: "Return per-file match counts only (no hashline anchors)" })),
+	summary: Type.Optional(Type.Boolean({ description: "Return per-file counts" })),
 	scope: Type.Optional(
 		Type.Literal("symbol", {
-			description: 'Scope matches to enclosing symbol blocks. Only "symbol" is defined, and it is ignored when summary: true.',
+			description: "Scope matches to symbols",
 		}),
 	),
 	scopeContext: Type.Optional(
 		Type.Union([
-			Type.Number({ description: "Context lines within symbol scope (requires scope: \"symbol\"). 0 = match lines only." }),
-			Type.String({ description: "Context lines within symbol scope (requires scope: \"symbol\"). 0 = match lines only." }),
+			Type.Number({ description: "Symbol context lines" }),
+			Type.String({ description: "Symbol context lines" }),
 		]),
 	),
 });
@@ -307,7 +307,7 @@ export function registerGrepTool(pi: ExtensionAPI, options: GrepToolOptions = {}
 		ptc,
 		promptSnippet: GREP_PROMPT_METADATA.promptSnippet,
 		promptGuidelines: options.astSearchGuideline
-			? [...GREP_PROMPT_METADATA.promptGuidelines, options.astSearchGuideline]
+			? [GREP_PROMPT_METADATA.promptGuidelines[0], options.astSearchGuideline]
 			: GREP_PROMPT_METADATA.promptGuidelines,
 		async execute(toolCallId, params, signal, onUpdate, ctx) {
 			await ensureHashInit();

--- a/src/ls.ts
+++ b/src/ls.ts
@@ -108,14 +108,14 @@ export function registerLsTool(pi: ExtensionAPI) {
     promptGuidelines: LS_PROMPT_METADATA.promptGuidelines,
     ptc: LS_PTC,
     parameters: Type.Object({
-      path: Type.Optional(Type.String({ description: "Directory to list (default: cwd)" })),
+      path: Type.Optional(Type.String({ description: "Directory path" })),
       limit: Type.Optional(
         Type.Union(
           [Type.Number(), Type.String()],
-          { description: "Max entries to return (default: 500)" },
+          { description: "Max entries" },
         ),
       ),
-      glob: Type.Optional(Type.String({ description: "Filter entries by glob pattern (e.g. '*.ts')" })),
+      glob: Type.Optional(Type.String({ description: "Glob filter" })),
     }),
     async execute(
       _toolCallId: string,

--- a/src/nu.ts
+++ b/src/nu.ts
@@ -270,24 +270,8 @@ export function augmentNuOutput(result: NuExecuteResult): string {
 const NU_SNIPPET =
   "Structured exploration shell — file inspection, data wrangling, system queries via Nushell pipelines. Use bash for project commands.";
 
-export const NU_GUIDELINES: string[] = [
-  `Use \`nu\` for exploring, inspecting, and analyzing. Use \`bash\` for executing project commands.
-
-| Task | Tool |
-|------|------|
-| Find large files in src/ | nu |
-| Run tests | bash |
-| Read fields from package.json | nu |
-| Install dependencies | bash |
-| Parse and filter a CSV | nu |
-| Run git diff | bash |
-| Check disk space or memory | nu |
-| Build Docker image | bash |
-| Explore an API response | nu |
-| Run a Makefile target | bash |`,
-  `nu primer: ls | where size > 10kb | first 5 · open package.json | get scripts · http get URL | get results · where / sort-by / first / length / math sum / group-by · strings in filters must be quoted.`,
-
-  `Optional plugins if installed: gstat, query, formats, semver, file. Run \`plugin list\` inside nu to check availability.`,
+export const NU_GUIDELINES = [
+  "Use nu for structured data, filesystem metadata, and system inspection.",
 ];
 
 const NU_PROMPT_METADATA = defineToolPromptMetadata({
@@ -322,9 +306,9 @@ export function registerNuTool(pi: ExtensionAPI): NuToolDefinition | false {
     promptGuidelines: NU_PROMPT_METADATA.promptGuidelines,
     ptc: NU_PTC,
     parameters: Type.Object({
-      command: Type.String({ description: "Nushell script to run. May be multi-line." }),
+      command: Type.String({ description: "Nushell script" }),
       timeout: Type.Optional(
-        Type.Number({ description: "Maximum run time in seconds. Defaults to 30." }),
+        Type.Number({ description: "Timeout seconds" }),
       ),
     }),
     async execute(_toolCallId, params: { command: string; timeout?: number }, signal, onUpdate, ctx) {

--- a/src/read.ts
+++ b/src/read.ts
@@ -67,24 +67,24 @@ export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}
 		promptSnippet: READ_PROMPT_METADATA.promptSnippet,
 		promptGuidelines: READ_PROMPT_METADATA.promptGuidelines,
 		parameters: Type.Object({
-			path: Type.String({ description: "Path to the file to read (relative or absolute)" }),
+			path: Type.String({ description: "File path" }),
 			offset: Type.Optional(
 				Type.Union([
-					Type.Number({ description: "Line number to start reading from (1-indexed)" }),
-					Type.String({ description: "Line number to start reading from (1-indexed)" }),
+					Type.Number({ description: "Start line (1-indexed)" }),
+					Type.String({ description: "Start line (1-indexed)" }),
 				]),
 			),
 			limit: Type.Optional(
 				Type.Union([
-					Type.Number({ description: "Maximum number of lines to read" }),
-					Type.String({ description: "Maximum number of lines to read" }),
+					Type.Number({ description: "Max lines" }),
+					Type.String({ description: "Max lines" }),
 				]),
 			),
-			symbol: Type.Optional(Type.String({ description: "Symbol to read (e.g., functionName or ClassName.methodName)" })),
-			map: Type.Optional(Type.Boolean({ description: "Append structural map to output (cannot combine with symbol)" })),
+			symbol: Type.Optional(Type.String({ description: "Symbol name to read" })),
+			map: Type.Optional(Type.Boolean({ description: "Append structural map" })),
 			bundle: Type.Optional(
 				Type.Literal("local", {
-					description: 'Include the requested symbol plus direct same-file local support. Only "local" is defined.',
+					description: "Include same-file local support",
 				}),
 			),
 		}),

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -152,9 +152,9 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
     promptSnippet: SG_PROMPT_METADATA.promptSnippet,
     promptGuidelines: SG_PROMPT_METADATA.promptGuidelines,
     parameters: Type.Object({
-      pattern: Type.String({ description: "AST pattern to search for" }),
-      lang: Type.Optional(Type.String({ description: "Language hint for ast-grep (e.g. 'typescript')" })),
-      path: Type.Optional(Type.String({ description: "Directory or file to search (default: cwd)" })),
+      pattern: Type.String({ description: "AST pattern" }),
+      lang: Type.Optional(Type.String({ description: "Language hint" })),
+      path: Type.Optional(Type.String({ description: "Search path" })),
     }),
     ptc,
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {

--- a/src/tool-prompt-metadata.ts
+++ b/src/tool-prompt-metadata.ts
@@ -1,6 +1,50 @@
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@earendil-works/pi-coding-agent";
 import { readFileSync } from "node:fs";
 
+
+const COMPACT_DESCRIPTIONS: Record<string, string> = {
+  "read.md": "Read file contents by path, range, or symbol; returns LINE:HASH anchors for edits.",
+  "edit.md": "Edit existing text files using fresh LINE:HASH anchors from read, grep, ast_search, or write.",
+  "grep.md": "Search file contents; non-summary results include LINE:HASH anchors for edits.",
+  "find.md": "Find files by glob, respecting .gitignore.",
+  "ls.md": "List one directory.",
+  "write.md": "Create or overwrite a file and return anchors.",
+  "sg.md": "Search code by AST pattern and return anchored matches.",
+  "nu.md": "Run Nushell for structured data, filesystem metadata, and system inspection.",
+};
+
+
+const COMPACT_GUIDELINES: Record<string, string[]> = {
+  "read.md": [
+    "Use read for file contents, ranges, symbols, and edit anchors.",
+    "Use read map or symbol options to keep reads focused.",
+  ],
+  "edit.md": [
+    "Use edit with fresh LINE:HASH anchors for existing files.",
+    "Use edit replace only when anchored edits are impractical.",
+  ],
+  "grep.md": [
+    "Use grep for text search and edit-ready matching anchors.",
+    "Use grep summary mode when only file counts are needed.",
+  ],
+  "find.md": [
+    "Use find for recursive file discovery by glob.",
+  ],
+  "ls.md": [
+    "Use ls to list one directory, optionally with a glob filter.",
+  ],
+  "write.md": [
+    "Use write to create files or intentionally overwrite whole files.",
+    "Use edit rather than write for small changes to existing files.",
+  ],
+  "sg.md": [
+    "Use ast_search for AST-shaped code patterns.",
+  ],
+  "nu.md": [
+    "Use nu for structured data, filesystem metadata, and system inspection.",
+  ],
+};
+
 export interface ToolPromptMetadata {
   description: string;
   promptSnippet: string;
@@ -18,15 +62,22 @@ export function firstPromptParagraph(prompt: string): string {
   return prompt.split(/\n\s*\n/, 1)[0]?.trim() ?? prompt;
 }
 
+
+function promptFileName(promptUrl: URL): string {
+  return promptUrl.pathname.split("/").pop() ?? "";
+}
+
 export function defineToolPromptMetadata(options: {
   promptUrl: URL;
   promptSnippet: string;
   promptGuidelines: string[];
 }): ToolPromptMetadata {
   const prompt = loadPrompt(options.promptUrl);
+  const fileName = promptFileName(options.promptUrl);
+  const compactDescription = COMPACT_DESCRIPTIONS[fileName];
   return {
-    description: firstPromptParagraph(prompt),
+    description: compactDescription ?? firstPromptParagraph(prompt),
     promptSnippet: options.promptSnippet,
-    promptGuidelines: options.promptGuidelines,
+    promptGuidelines: COMPACT_GUIDELINES[fileName] ?? options.promptGuidelines,
   };
 }

--- a/src/write.ts
+++ b/src/write.ts
@@ -288,9 +288,9 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
     promptSnippet: WRITE_PROMPT_METADATA.promptSnippet,
     promptGuidelines: WRITE_PROMPT_METADATA.promptGuidelines,
     parameters: Type.Object({
-      path: Type.String({ description: "Path to the file to write (relative or absolute)" }),
-      content: Type.String({ description: "Content to write to the file" }),
-      map: Type.Optional(Type.Boolean({ description: "Append structural map to output" })),
+      path: Type.String({ description: "File path" }),
+      content: Type.String({ description: "File content" }),
+      map: Type.Optional(Type.Boolean({ description: "Append structural map" })),
     }),
     async execute(_toolCallId: string, params: { path: string; content: string; map?: boolean }, _signal: AbortSignal | undefined, _onUpdate: any, ctx: any): Promise<any> {
       const cwd = ctx?.cwd ?? process.cwd();

--- a/tests/bash-renderer-metadata.test.ts
+++ b/tests/bash-renderer-metadata.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerBashRendererTool } from "../src/bash-renderer.js";
+
+function capturePi() {
+  let registered: any;
+  return {
+    pi: {
+      registerTool: vi.fn((tool: any) => {
+        registered = tool;
+      }),
+    },
+    get tool() {
+      return registered;
+    },
+  };
+}
+
+describe("bash renderer provider-visible metadata", () => {
+  it("uses compact local metadata and still delegates execution", async () => {
+    const execute = vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] }));
+    const createBuiltInBashTool = vi.fn(() => ({
+      description: "VERBOSE BUILTIN BASH DESCRIPTION THAT SHOULD NOT BE PROVIDER VISIBLE",
+      parameters: {
+        type: "object",
+        properties: {
+          command: { type: "string", description: "VERBOSE BUILTIN COMMAND PARAMETER DESCRIPTION" },
+        },
+      },
+      execute,
+    }));
+    const captured = capturePi();
+
+    const tool = registerBashRendererTool(captured.pi as any, {
+      cwd: "/tmp/project",
+      createBuiltInBashTool,
+    });
+
+    expect(captured.tool).toBe(tool);
+    expect(tool.description).toBe("Run shell commands for tests, builds, git, package managers, and external CLIs.");
+    expect(tool.parameters.properties.command.description).toBe("Shell command to run");
+    expect(tool.parameters.properties.timeout.description).toBe("Timeout seconds");
+
+    await tool.execute("call-1", { command: "npm test", timeout: 30 }, undefined, undefined, { cwd: "/tmp/project" });
+    expect(execute).toHaveBeenCalledWith("call-1", { command: "npm test", timeout: 30 }, undefined, undefined);
+  });
+});

--- a/tests/bash-renderer-wrapper.test.ts
+++ b/tests/bash-renderer-wrapper.test.ts
@@ -25,12 +25,12 @@ describe("bash renderer wrapper", () => {
     expect(source).not.toContain("renderResult(result: any, optionsArg: any, theme: any");
   });
 
-  it("forwards the built-in bash description and parameters so the model sees the real schema", () => {
+  it("uses compact local metadata instead of forwarding verbose built-in metadata", () => {
     const params = { type: "object", properties: { command: { type: "string" } }, required: ["command"] };
     const builtIn = { name: "bash", label: "bash", description: "real bash description", parameters: params, execute: async () => ({ content: [{ type: "text", text: "" }] }) };
     let registered: any;
     registerBashRendererTool({ registerTool(def: any) { registered = def; } } as any, { createBuiltInBashTool: () => builtIn, cwd: "/tmp/work" });
-    expect(registered.description).toBe("real bash description");
-    expect(registered.parameters).toBe(params);
+    expect(registered.description).toBe("Run shell commands for tests, builds, git, package managers, and external CLIs.");
+    expect(registered.parameters.properties.command.description).toBe("Shell command to run");
   });
 });

--- a/tests/find.prompt-loading.test.ts
+++ b/tests/find.prompt-loading.test.ts
@@ -19,9 +19,10 @@ function captureTool(register: (pi: any) => void) {
 }
 
 describe("find prompt loading", () => {
-  it("uses the first paragraph of prompts/find.md as the tool description", () => {
+  it("uses compact provider-visible metadata and keeps prompt details in prompts/find.md", () => {
     const tool = captureTool(registerFindTool);
-    expect(tool.description).toBe(firstParagraph(resolve("prompts/find.md")));
+    expect(tool.description).toBe("Find files by glob, respecting .gitignore.");
+    expect(firstParagraph(resolve("prompts/find.md"))).toContain("nested `.gitignore`");
   });
 
   it("documents basename matching, filters, sorting, and limit order", () => {

--- a/tests/ls.prompt-loading.test.ts
+++ b/tests/ls.prompt-loading.test.ts
@@ -19,9 +19,10 @@ function captureTool(register: (pi: any) => void) {
 }
 
 describe("ls prompt loading", () => {
-  it("uses the first paragraph of prompts/ls.md as the tool description", () => {
+  it("uses compact provider-visible metadata and keeps prompt details in prompts/ls.md", () => {
     const tool = captureTool(registerLsTool);
-    expect(tool.description).toBe(firstParagraph(resolve("prompts/ls.md")));
+    expect(tool.description).toBe("List one directory.");
+    expect(firstParagraph(resolve("prompts/ls.md"))).toContain("dotfiles are included");
   });
 
   it("documents single-directory output and routing to find/read", () => {

--- a/tests/nu-prompt-size.test.ts
+++ b/tests/nu-prompt-size.test.ts
@@ -1,27 +1,23 @@
 import { describe, it, expect } from "vitest";
 import { NU_GUIDELINES } from "../src/nu.js";
+import { readFileSync } from "node:fs";
+
+const nuPrompt = readFileSync("prompts/nu.md", "utf8");
 
 describe("NU_GUIDELINES prompt-size budget", () => {
   const serialized = NU_GUIDELINES.join("\n\n");
 
-  it("is at most 25 lines when serialized", () => {
+  it("is at most 8 lines when serialized", () => {
     const lineCount = serialized.split("\n").length;
-    expect(lineCount).toBeLessThanOrEqual(25);
+    expect(lineCount).toBeLessThanOrEqual(8);
   });
 
-  it("is at most 1500 characters when serialized", () => {
-    expect(serialized.length).toBeLessThanOrEqual(1500);
+  it("is at most 500 characters when serialized", () => {
+    expect(serialized.length).toBeLessThanOrEqual(500);
   });
 
-  it("preserves the nu-vs-bash routing table sentinel", () => {
-    expect(serialized).toContain("| Task | Tool |");
-  });
-
-  it("preserves the primer's parse-structured example sentinel", () => {
-    expect(serialized).toContain("open package.json | get scripts");
-  });
-
-  it("preserves the plugin pointer sentinel", () => {
-    expect(serialized).toContain("plugin list");
+  it("keeps detailed nu examples in the markdown prompt", () => {
+    expect(nuPrompt).toContain("open package.json | get scripts");
+    expect(nuPrompt).toContain("plugin list");
   });
 });

--- a/tests/nu-register.test.ts
+++ b/tests/nu-register.test.ts
@@ -8,40 +8,28 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe("NU_GUIDELINES", () => {
   const allText = NU_GUIDELINES.join("\n");
+  const nuPrompt = readFileSync(resolve(__dirname, "../prompts/nu.md"), "utf-8");
 
-  it("contains routing guidance for both nu and bash", () => {
-    expect(allText).toContain("bash");
+  it("keeps provider-visible guidance compact and nu-specific", () => {
     expect(allText).toContain("nu");
+    expect(allText.length).toBeLessThanOrEqual(500);
   });
 
-  it("includes file exploration patterns", () => {
-    expect(allText).toContain("ls");
-    expect(allText).toContain("where");
-    expect(allText).toContain("sort-by");
-  });
-
-  it("includes structured data access patterns", () => {
-    expect(allText).toContain("open");
-    expect(allText).toContain("get");
-  });
-
-  it("includes a plugin pointer block", () => {
-    expect(allText).toContain("plugin list");
-    expect(allText).toContain("gstat");
-    expect(allText).toContain("query");
-    expect(allText).toContain("formats");
-  });
-
-  it("includes key syntax reference", () => {
-    expect(allText).toContain("length");
-    expect(allText).toContain("math sum");
-    expect(allText).toContain("group-by");
-    expect(allText).toContain("first");
-  });
-
-  it("includes routing table with task-to-tool mappings", () => {
-    expect(allText).toContain("Run tests");
-    expect(allText).toContain("package.json");
+  it("keeps detailed routing and syntax examples in prompts/nu.md", () => {
+    expect(nuPrompt).toContain("bash");
+    expect(nuPrompt).toContain("ls");
+    expect(nuPrompt).toContain("where");
+    expect(nuPrompt).toContain("sort-by");
+    expect(nuPrompt).toContain("open");
+    expect(nuPrompt).toContain("get");
+    expect(nuPrompt).toContain("plugin list");
+    expect(nuPrompt).toContain("plugins");
+    expect(nuPrompt).toContain("length");
+    expect(nuPrompt).toContain("math sum");
+    expect(nuPrompt).toContain("group-by");
+    expect(nuPrompt).toContain("first");
+    expect(nuPrompt).toContain("tests");
+    expect(nuPrompt).toContain("package.json");
   });
 });
 

--- a/tests/package-version.test.ts
+++ b/tests/package-version.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
+
+describe("package version", () => {
+  it("is bumped for the compact provider-visible metadata release", () => {
+    expect(packageJson.version).toBe("0.8.9");
+    expect(packageLock.version).toBe("0.8.9");
+    expect(packageLock.packages[""].version).toBe("0.8.9");
+  });
+});

--- a/tests/repro-109-prompt-docs.test.ts
+++ b/tests/repro-109-prompt-docs.test.ts
@@ -21,7 +21,7 @@ function captureTool(register: (pi: any) => void) {
 }
 
 describe("repro 109 — prompt docs alignment", () => {
-  it("loads ls, find, and write descriptions from prompt files", () => {
+  it("uses compact descriptions while keeping ls, find, and write prompt docs", () => {
     const lsTool = captureTool(registerLsTool);
     const findTool = captureTool(registerFindTool);
     const writeTool = captureTool(registerWriteTool);
@@ -30,10 +30,13 @@ describe("repro 109 — prompt docs alignment", () => {
     const findPrompt = resolve("prompts/find.md");
     const writePrompt = resolve("prompts/write.md");
 
-    expect(lsTool.description).toBe(firstParagraph(lsPrompt));
-    expect(findTool.description).toBe(firstParagraph(findPrompt));
+    expect(lsTool.description).toBe("List one directory.");
+    expect(findTool.description).toBe("Find files by glob, respecting .gitignore.");
     expect(existsSync(writePrompt)).toBe(true);
-    expect(writeTool.description).toBe(firstParagraph(writePrompt));
+    expect(writeTool.description).toBe("Create or overwrite a file and return anchors.");
+    expect(firstParagraph(lsPrompt)).toContain("dotfiles are included");
+    expect(firstParagraph(findPrompt)).toContain("nested `.gitignore`");
+    expect(firstParagraph(writePrompt)).toContain("overwrites existing files");
   });
 
   it("documents hash mismatch recovery and all valid anchor sources in prompts/edit.md", () => {

--- a/tests/sg.prompt-loading.test.ts
+++ b/tests/sg.prompt-loading.test.ts
@@ -16,11 +16,11 @@ async function getSgTool() {
 }
 
 describe("sg prompt loading", () => {
-  it("uses the first prompt paragraph as the exact ast_search description", async () => {
+  it("uses compact provider-visible metadata and keeps prompt details in prompts/sg.md", async () => {
     const tool = await getSgTool();
-    expect(tool.description).toBe(
-      "AST-aware structural code search. Use when text search is too broad or brittle and you need code shape, such as calls, imports, declarations, or JSX. Returns matches grouped by file with edit-ready hashline anchors.",
-    );
+    expect(tool.description).toBe("Search code by AST pattern and return anchored matches.");
+    const content = readFileSync(resolve(root, "prompts/sg.md"), "utf8");
+    expect(content).toContain("AST-aware structural code search");
   });
 
   it("keeps structural-search contract details in prompts/sg.md", () => {

--- a/tests/tool-prompt-metadata.test.ts
+++ b/tests/tool-prompt-metadata.test.ts
@@ -28,8 +28,10 @@ function firstParagraph(promptPath: string): string {
 }
 
 function assertPromptMetadata(tool: ToolDefinition, promptPath: string, toolName: string) {
-  expect(tool.description).toBe(firstParagraph(promptPath));
+  expect(typeof tool.description).toBe("string");
+  expect((tool.description as string).length).toBeGreaterThan(0);
   expect(tool.description).not.toContain("\n\n");
+  expect(firstParagraph(promptPath).length).toBeGreaterThan(0);
 
   expect(typeof tool.promptSnippet).toBe("string");
   expect((tool.promptSnippet as string).length).toBeGreaterThan(0);
@@ -92,5 +94,209 @@ describe("stock pi prompt metadata", () => {
 
     expect(tool).not.toBe(false);
     assertPromptMetadata(tool as ToolDefinition, "prompts/nu.md", "nu");
+  });
+});
+
+
+describe("compact provider-visible descriptions", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("node:child_process");
+  });
+
+  it("uses compact registered descriptions for scoped hashline tools", async () => {
+    vi.doMock("node:child_process", async () => {
+      const actual = await vi.importActual<any>("node:child_process");
+      return {
+        ...actual,
+        execFileSync: vi.fn(() => Buffer.from("0.111.0\n")),
+      };
+    });
+
+    const pi = createMockPi();
+    const { registerReadTool } = await import("../src/read.js");
+    const { registerEditTool } = await import("../src/edit.js");
+    const { registerGrepTool } = await import("../src/grep.js");
+    const { registerFindTool } = await import("../src/find.js");
+    const { registerLsTool } = await import("../src/ls.js");
+    const { registerWriteTool } = await import("../src/write.js");
+    const { registerSgTool } = await import("../src/sg.js");
+    const { registerNuTool } = await import("../src/nu.js");
+
+    const tools = {
+      read: registerReadTool(pi as any),
+      edit: registerEditTool(pi as any),
+      grep: registerGrepTool(pi as any),
+      find: registerFindTool(pi as any),
+      ls: registerLsTool(pi as any),
+      write: registerWriteTool(pi as any),
+      ast_search: registerSgTool(pi as any),
+      nu: registerNuTool(pi as any),
+    };
+
+    expect(tools.read.description).toBe("Read file contents by path, range, or symbol; returns LINE:HASH anchors for edits.");
+    expect(tools.edit.description).toBe("Edit existing text files using fresh LINE:HASH anchors from read, grep, ast_search, or write.");
+    expect(tools.grep.description).toBe("Search file contents; non-summary results include LINE:HASH anchors for edits.");
+    expect(tools.find.description).toBe("Find files by glob, respecting .gitignore.");
+    expect(tools.ls.description).toBe("List one directory.");
+    expect(tools.write.description).toBe("Create or overwrite a file and return anchors.");
+    expect(tools.ast_search.description).toBe("Search code by AST pattern and return anchored matches.");
+    expect((tools.nu as ToolDefinition).description).toBe("Run Nushell for structured data, filesystem metadata, and system inspection.");
+
+    for (const [name, tool] of Object.entries(tools)) {
+      expect(typeof (tool as ToolDefinition).description, name).toBe("string");
+      expect(((tool as ToolDefinition).description as string).length, name).toBeLessThanOrEqual(100);
+    }
+  });
+});
+
+
+function collectSchemaDescriptions(schema: any): string[] {
+  if (!schema || typeof schema !== "object") return [];
+  const descriptions: string[] = [];
+  if (typeof schema.description === "string") descriptions.push(schema.description);
+  for (const value of Object.values(schema)) {
+    if (Array.isArray(value)) {
+      for (const item of value) descriptions.push(...collectSchemaDescriptions(item));
+    } else if (value && typeof value === "object") {
+      descriptions.push(...collectSchemaDescriptions(value));
+    }
+  }
+  return descriptions;
+}
+
+describe("compact read and mutation parameter metadata", () => {
+  it("uses short provider-visible parameter descriptions for read, edit, and write", async () => {
+    const pi = createMockPi();
+    const { registerReadTool } = await import("../src/read.js");
+    const { registerEditTool } = await import("../src/edit.js");
+    const { registerWriteTool } = await import("../src/write.js");
+
+    const tools = [
+      registerReadTool(pi as any),
+      registerEditTool(pi as any),
+      registerWriteTool(pi as any),
+    ];
+
+    for (const tool of tools) {
+      const descriptions = collectSchemaDescriptions((tool as any).parameters);
+      expect(descriptions.length, tool.name).toBeGreaterThan(0);
+      for (const description of descriptions) {
+        expect(description.length, `${tool.name}: ${description}`).toBeLessThanOrEqual(58);
+        expect(description, `${tool.name}: ${description}`).not.toMatch(/e\.g\.|example|Default false|relative or absolute/i);
+      }
+    }
+  });
+});
+
+
+describe("compact discovery and search parameter metadata", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("node:child_process");
+  });
+
+  it("uses short provider-visible parameter descriptions for grep, find, ls, ast_search, and nu", async () => {
+    vi.doMock("node:child_process", async () => {
+      const actual = await vi.importActual<any>("node:child_process");
+      return {
+        ...actual,
+        execFileSync: vi.fn(() => Buffer.from("0.111.0\n")),
+      };
+    });
+
+    const pi = createMockPi();
+    const { registerGrepTool } = await import("../src/grep.js");
+    const { registerFindTool } = await import("../src/find.js");
+    const { registerLsTool } = await import("../src/ls.js");
+    const { registerSgTool } = await import("../src/sg.js");
+    const { registerNuTool } = await import("../src/nu.js");
+
+    const tools = [
+      registerGrepTool(pi as any),
+      registerFindTool(pi as any),
+      registerLsTool(pi as any),
+      registerSgTool(pi as any),
+      registerNuTool(pi as any),
+    ];
+
+    for (const tool of tools) {
+      const toolDefinition = tool as ToolDefinition;
+      const descriptions = collectSchemaDescriptions((toolDefinition as any).parameters);
+      expect(descriptions.length, toolDefinition.name).toBeGreaterThan(0);
+      for (const description of descriptions) {
+        expect(description.length, `${toolDefinition.name}: ${description}`).toBeLessThanOrEqual(58);
+        expect(description, `${toolDefinition.name}: ${description}`).not.toMatch(/e\.g\.|example|Combined with|JavaScript regular expression|Defaults to/i);
+      }
+    }
+  });
+});
+
+
+describe("compact provider-visible prompt guidelines", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("node:child_process");
+  });
+
+  it("exposes only short tool-specific provider-visible guidelines", async () => {
+    vi.doMock("node:child_process", async () => {
+      const actual = await vi.importActual<any>("node:child_process");
+      return {
+        ...actual,
+        execFileSync: vi.fn(() => Buffer.from("0.111.0\n")),
+      };
+    });
+
+    const pi = createMockPi();
+    const { registerReadTool } = await import("../src/read.js");
+    const { registerEditTool } = await import("../src/edit.js");
+    const { registerGrepTool } = await import("../src/grep.js");
+    const { registerFindTool } = await import("../src/find.js");
+    const { registerLsTool } = await import("../src/ls.js");
+    const { registerWriteTool } = await import("../src/write.js");
+    const { registerSgTool } = await import("../src/sg.js");
+    const { registerNuTool } = await import("../src/nu.js");
+
+    const tools = [
+      registerReadTool(pi as any),
+      registerEditTool(pi as any),
+      registerGrepTool(pi as any),
+      registerFindTool(pi as any),
+      registerLsTool(pi as any),
+      registerWriteTool(pi as any),
+      registerSgTool(pi as any),
+      registerNuTool(pi as any),
+    ];
+
+    for (const tool of tools) {
+      const toolDefinition = tool as ToolDefinition;
+      const guidelines = toolDefinition.promptGuidelines as string[];
+      expect(guidelines.length, toolDefinition.name).toBeGreaterThan(0);
+      expect(guidelines.length, toolDefinition.name).toBeLessThanOrEqual(2);
+      for (const guideline of guidelines) {
+        expect(guideline.length, `${toolDefinition.name}: ${guideline}`).toBeLessThanOrEqual(96);
+        expect(guideline.toLowerCase(), `${toolDefinition.name}: ${guideline}`).toContain(toolDefinition.name.toLowerCase());
+        expect(guideline, `${toolDefinition.name}: ${guideline}`).not.toMatch(/\| Task \| Tool \||graph tools|NOT this|Do NOT|examples?|instead of bash grep or rg/i);
+      }
+    }
+  });
+
+
+  it("keeps dynamic grep AST guidance compact", async () => {
+    const pi = createMockPi();
+    const { registerGrepTool } = await import("../src/grep.js");
+
+    const tool = registerGrepTool(pi as any, {
+      astSearchGuideline: "Use grep summary for counts; use ast_search for structural code patterns.",
+    }) as ToolDefinition;
+    const guidelines = tool.promptGuidelines as string[];
+
+    expect(guidelines.join("\n").toLowerCase()).toContain("summary");
+    expect(guidelines.length).toBeLessThanOrEqual(2);
+    for (const guideline of guidelines) {
+      expect(guideline.length, guideline).toBeLessThanOrEqual(96);
+      expect(guideline.toLowerCase(), guideline).toContain("grep");
+    }
   });
 });

--- a/tests/write.prompt-loading.test.ts
+++ b/tests/write.prompt-loading.test.ts
@@ -19,12 +19,13 @@ function captureTool(register: (pi: any) => void) {
 }
 
 describe("prompt loading — write", () => {
-  it("creates prompts/write.md and uses its first paragraph as the tool description", () => {
+  it("uses compact provider-visible metadata and keeps prompt details in prompts/write.md", () => {
     const promptPath = resolve("prompts/write.md");
     expect(existsSync(promptPath)).toBe(true);
 
     const tool = captureTool(registerWriteTool);
-    expect(tool.description).toBe(firstParagraph(promptPath));
+    expect(tool.description).toBe("Create or overwrite a file and return anchors.");
+    expect(firstParagraph(promptPath)).toContain("overwrites existing files");
   });
 
   it("documents overwrite, binary no-anchor behavior, safe display escaping, and best-effort map appends", () => {


### PR DESCRIPTION
Closes #187.

## Summary

Compacts the provider-visible Pi tool metadata for scoped hashline tools so live tool namespace prompts are shorter while runtime behavior, public PTC policy exports, and detailed markdown docs remain intact.

This also bumps the package version from `0.8.8` to `0.8.9` in both `package.json` and `package-lock.json`.

## What changed

- Added compact registered descriptions for `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`, `ast_search`, and `nu`.
- Centralized compact prompt metadata in `src/tool-prompt-metadata.ts` while preserving long-form details in `prompts/*.md`.
- Shortened provider-visible TypeBox parameter descriptions for read/mutation and discovery/search tools without changing accepted schemas or execution behavior.
- Reduced provider-visible `promptGuidelines` arrays to short tool-specific guidance.
- Kept dynamic `grep` AST routing guidance compact while preserving summary-mode guidance.
- Updated `src/bash-renderer.ts` to expose compact local bash wrapper metadata instead of forwarding verbose built-in metadata, while still delegating execution to Pi's built-in bash tool.
- Reduced `NU_GUIDELINES` provider-visible size while keeping detailed Nu examples in `prompts/nu.md`.
- Added regression coverage for compact descriptions, parameter metadata, prompt guidelines, bash wrapper metadata/delegation, prompt-doc discoverability, and the `0.8.9` package version.

## Acceptance Criteria

- [x] AC1-10 — Scoped registered tool descriptions are compact and match the required text.
- [x] AC11 — Inline TypeBox parameter descriptions are concise; schemas and runtime behavior unchanged.
- [x] AC12 — Provider-visible prompt guidelines are short and tool-specific.
- [x] AC13 — Detailed help, examples, and output-contract notes remain in markdown prompts/docs.
- [x] AC14 — Bash wrapper exposes compact local metadata and continues delegating execution.
- [x] AC15 — Runtime behavior/output/edit/PTC semantics unchanged.
- [x] AC16 — Public PTC policy exports remain available and compatible.
- [x] AC17 — Tests cover descriptions, parameter metadata, guidelines, and bash wrapper metadata behavior.
- [x] AC18 — Relevant focused tests and full suite pass.
- [x] AC19 — Package version bumped to `0.8.9` in `package.json` and `package-lock.json`.

## Verification

- `npm test -- tests/tool-prompt-metadata.test.ts` — 7 tests passed
- `npm test` — 328 files / 1437 tests passed
- `npm run typecheck` — clean

## Notes for reviewers

- This PR intentionally changes provider-visible metadata only; detailed prompts remain the source for nuanced usage and output contracts.
- The package bump is included on the PR branch: `package.json`, root `package-lock.json.version`, and `package-lock.json.packages[""].version` are all `0.8.9`.
