### PR TITLE
feat: add GDScript mapper using gdtoolkit

### DIFF
--- a/src/readmap/enums.ts
+++ b/src/readmap/enums.ts
@@ -10,6 +10,7 @@ export enum SymbolKind {
   Interface = "interface",
   Type = "type",
   Enum = "enum",
+  Signal = "signal",
   Struct = "struct",
   Import = "import",
   Module = "module",

--- a/src/readmap/language-detect.ts
+++ b/src/readmap/language-detect.ts
@@ -79,6 +79,9 @@ const EXTENSION_MAP: Record<string, LanguageInfo> = {
   // CSV
   ".csv": { id: "csv", name: "CSV" },
   ".tsv": { id: "csv", name: "TSV" },
+
+  // GDScript
+  ".gd": { id: "gdscript", name: "GDScript" },
 };
 
 /**

--- a/src/readmap/mapper.ts
+++ b/src/readmap/mapper.ts
@@ -24,18 +24,11 @@ import { typescriptMapper, typescriptMapperFromContent, MAPPER_VERSION as TYPESC
 import { yamlMapper, MAPPER_VERSION as YAML_VERSION } from "./mappers/yaml.js";
 
 /**
- * Check if GDScript mapper is explicitly enabled via env var or setting.
+ * Check if GDScript mapper is explicitly enabled via env var.
  * Opt-in by default to avoid hard gdtoolkit dependency.
  */
 function isGdscriptEnabled(): boolean {
-  // Check env var first
-  if (process.env.PI_HASHLINE_GDSCRIPT === "1") return true;
-  // Check setting
-  try {
-    const settings = pi?.settings;
-    if (settings?.hashlineReadmap?.gdscript?.enabled) return true;
-  } catch {}
-  return false;
+  return process.env.PI_HASHLINE_GDSCRIPT === "1";
 }
 type MapperFn = (
   filePath: string,

--- a/src/readmap/mapper.ts
+++ b/src/readmap/mapper.ts
@@ -8,7 +8,7 @@ import { cppMapper, MAPPER_VERSION as CPP_VERSION } from "./mappers/cpp.js";
 import { csvMapper, MAPPER_VERSION as CSV_VERSION } from "./mappers/csv.js";
 import { ctagsMapper, MAPPER_VERSION as CTAGS_VERSION } from "./mappers/ctags.js";
 import { fallbackMapper, MAPPER_VERSION as FALLBACK_VERSION } from "./mappers/fallback.js";
-import { gdscriptMapper, MAPPER_VERSION as GDSRIPT_VERSION } from "./mappers/gdscript.js";
+import { gdscriptMapper, MAPPER_VERSION as GDSCRIPT_VERSION } from "./mappers/gdscript.js";
 import { goMapper, MAPPER_VERSION as GO_VERSION } from "./mappers/go.js";
 import { jsonMapper, MAPPER_VERSION as JSON_VERSION } from "./mappers/json.js";
 import { javaMapper, javaMapperFromContent, MAPPER_VERSION as JAVA_VERSION } from "./mappers/java.js";
@@ -23,6 +23,20 @@ import { tomlMapper, MAPPER_VERSION as TOML_VERSION } from "./mappers/toml.js";
 import { typescriptMapper, typescriptMapperFromContent, MAPPER_VERSION as TYPESCRIPT_VERSION } from "./mappers/typescript.js";
 import { yamlMapper, MAPPER_VERSION as YAML_VERSION } from "./mappers/yaml.js";
 
+/**
+ * Check if GDScript mapper is explicitly enabled via env var or setting.
+ * Opt-in by default to avoid hard gdtoolkit dependency.
+ */
+function isGdscriptEnabled(): boolean {
+  // Check env var first
+  if (process.env.PI_HASHLINE_GDSCRIPT === "1") return true;
+  // Check setting
+  try {
+    const settings = pi?.settings;
+    if (settings?.hashlineReadmap?.gdscript?.enabled) return true;
+  } catch {}
+  return false;
+}
 type MapperFn = (
   filePath: string,
   signal?: AbortSignal
@@ -70,7 +84,7 @@ const MAPPERS_V: Record<string, MapperEntry> = {
   // Phase 7: Shell/Bash regex mapper
   shell: { fn: shellMapper, version: SHELL_VERSION },
   // Phase 8: GDScript (gdtoolkit subprocess)
-  gdscript: { fn: gdscriptMapper, version: GDSRIPT_VERSION },
+  gdscript: { fn: gdscriptMapper, version: GDSCRIPT_VERSION },
 };
 
 type ContentMapperFn = (
@@ -122,11 +136,16 @@ export async function generateMapWithIdentity(
   const { signal } = options;
   const langInfo = detectLanguage(filePath);
   if (langInfo) {
-    const entry = MAPPERS_V[langInfo.id];
-    if (entry) {
-      const result = await entry.fn(filePath, signal);
-      if (result) {
-        return { map: result, mapperName: langInfo.id, mapperVersion: entry.version };
+    // GDScript mapper is opt-in (requires gdtoolkit dependency)
+    if (langInfo.id === "gdscript" && !isGdscriptEnabled()) {
+      // Fall through to ctags/fallback
+    } else {
+      const entry = MAPPERS_V[langInfo.id];
+      if (entry) {
+        const result = await entry.fn(filePath, signal);
+        if (result) {
+          return { map: result, mapperName: langInfo.id, mapperVersion: entry.version };
+        }
       }
     }
   }

--- a/src/readmap/mapper.ts
+++ b/src/readmap/mapper.ts
@@ -8,6 +8,7 @@ import { cppMapper, MAPPER_VERSION as CPP_VERSION } from "./mappers/cpp.js";
 import { csvMapper, MAPPER_VERSION as CSV_VERSION } from "./mappers/csv.js";
 import { ctagsMapper, MAPPER_VERSION as CTAGS_VERSION } from "./mappers/ctags.js";
 import { fallbackMapper, MAPPER_VERSION as FALLBACK_VERSION } from "./mappers/fallback.js";
+import { gdscriptMapper, MAPPER_VERSION as GDSRIPT_VERSION } from "./mappers/gdscript.js";
 import { goMapper, MAPPER_VERSION as GO_VERSION } from "./mappers/go.js";
 import { jsonMapper, MAPPER_VERSION as JSON_VERSION } from "./mappers/json.js";
 import { javaMapper, javaMapperFromContent, MAPPER_VERSION as JAVA_VERSION } from "./mappers/java.js";
@@ -68,6 +69,8 @@ const MAPPERS_V: Record<string, MapperEntry> = {
   swift: { fn: swiftMapper, version: SWIFT_VERSION },
   // Phase 7: Shell/Bash regex mapper
   shell: { fn: shellMapper, version: SHELL_VERSION },
+  // Phase 8: GDScript (gdtoolkit subprocess)
+  gdscript: { fn: gdscriptMapper, version: GDSRIPT_VERSION },
 };
 
 type ContentMapperFn = (

--- a/src/readmap/mappers/gdscript.ts
+++ b/src/readmap/mappers/gdscript.ts
@@ -1,5 +1,5 @@
-import { exec } from "node:child_process";
-import { stat } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -9,7 +9,7 @@ import type { FileMap, FileSymbol } from "../types.js";
 import { DetailLevel, SymbolKind } from "../enums.js";
 export const MAPPER_VERSION = 1;
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCRIPT_PATH = join(__dirname, "gdscript_outline.py");
@@ -75,6 +75,17 @@ function convertSymbol(gs: GdSymbol): FileSymbol {
 }
 
 /**
+ * Count lines in file content without spawning wc.
+ */
+function countLines(content: string): number {
+  let count = 0;
+  for (let i = 0; i < content.length; i++) {
+    if (content[i] === "\n") count++;
+  }
+  return count;
+}
+
+/**
  * Generate a file map for a GDScript file using gdtoolkit (Lark-based parser).
  */
 export async function gdscriptMapper(
@@ -85,13 +96,14 @@ export async function gdscriptMapper(
     const stats = await stat(filePath);
     const totalBytes = stats.size;
 
-    const { stdout: wcOutput } = await execAsync(`wc -l < "${filePath}"`, {
-      signal,
-    });
-    const totalLines = Number.parseInt(wcOutput.trim(), 10) || 0;
+    // Count lines in JS instead of spawning wc
+    const content = await readFile(filePath, "utf-8");
+    const totalLines = countLines(content);
 
-    const { stdout, stderr } = await execAsync(
-      `python3 "${SCRIPT_PATH}" "${filePath}"`,
+    // Use execFile to avoid shell injection
+    const { stdout, stderr } = await execFileAsync(
+      "python3",
+      [SCRIPT_PATH, filePath],
       {
         signal,
         timeout: 10_000,
@@ -99,9 +111,18 @@ export async function gdscriptMapper(
       }
     );
 
-    if (stderr && !stdout) {
-      console.error(`GDScript mapper stderr: ${stderr}`);
-      return null;
+    // Check for stderr (non-fatal warnings are ok if we got output)
+    if (stderr) {
+      // Check for missing gdtoolkit
+      if (stderr.includes("ModuleNotFoundError") || stderr.includes("gdtoolkit")) {
+        console.error(
+          "[hashline] GDScript mapper requires gdtoolkit. " +
+          "Install it with: pip3 install --system gdtoolkit"
+        );
+      } else {
+        console.error(`GDScript mapper stderr: ${stderr}`);
+      }
+      if (!stdout) return null;
     }
 
     const result: GdOutlineResult = JSON.parse(stdout);
@@ -122,11 +143,20 @@ export async function gdscriptMapper(
     };
 
     return fileMap;
-  } catch (error) {
+  } catch (error: any) {
     if (signal?.aborted) {
       return null;
     }
-    console.error(`GDScript mapper failed: ${error}`);
+    // Check for missing gdtoolkit in exception
+    const errorMsg = String(error);
+    if (errorMsg.includes("ModuleNotFoundError") || errorMsg.includes("gdtoolkit")) {
+      console.error(
+        "[hashline] GDScript mapper requires gdtoolkit. " +
+        "Install it with: pip3 install --system gdtoolkit"
+      );
+    } else {
+      console.error(`GDScript mapper failed: ${error}`);
+    }
     return null;
   }
 }

--- a/src/readmap/mappers/gdscript.ts
+++ b/src/readmap/mappers/gdscript.ts
@@ -1,0 +1,132 @@
+import { exec } from "node:child_process";
+import { stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import type { FileMap, FileSymbol } from "../types.js";
+
+import { DetailLevel, SymbolKind } from "../enums.js";
+export const MAPPER_VERSION = 1;
+
+const execAsync = promisify(exec);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = join(__dirname, "gdscript_outline.py");
+
+interface GdSymbol {
+  name: string;
+  kind: string;
+  startLine: number;
+  endLine: number;
+  signature?: string;
+  children?: GdSymbol[];
+}
+
+interface GdOutlineResult {
+  imports?: string[];
+  symbols: GdSymbol[];
+  error?: string;
+}
+
+function mapKind(kind: string): SymbolKind {
+  switch (kind) {
+    case "class": {
+      return SymbolKind.Class;
+    }
+    case "function": {
+      return SymbolKind.Function;
+    }
+    case "constant": {
+      return SymbolKind.Constant;
+    }
+    case "variable": {
+      return SymbolKind.Variable;
+    }
+    case "signal": {
+      return SymbolKind.Signal;
+    }
+    case "enum": {
+      return SymbolKind.Enum;
+    }
+    default: {
+      return SymbolKind.Unknown;
+    }
+  }
+}
+
+function convertSymbol(gs: GdSymbol): FileSymbol {
+  const symbol: FileSymbol = {
+    name: gs.name,
+    kind: mapKind(gs.kind),
+    startLine: gs.startLine,
+    endLine: gs.endLine,
+  };
+
+  if (gs.signature) {
+    symbol.signature = gs.signature;
+  }
+
+  if (gs.children && gs.children.length > 0) {
+    symbol.children = gs.children.map(convertSymbol);
+  }
+
+  return symbol;
+}
+
+/**
+ * Generate a file map for a GDScript file using gdtoolkit (Lark-based parser).
+ */
+export async function gdscriptMapper(
+  filePath: string,
+  signal?: AbortSignal
+): Promise<FileMap | null> {
+  try {
+    const stats = await stat(filePath);
+    const totalBytes = stats.size;
+
+    const { stdout: wcOutput } = await execAsync(`wc -l < "${filePath}"`, {
+      signal,
+    });
+    const totalLines = Number.parseInt(wcOutput.trim(), 10) || 0;
+
+    const { stdout, stderr } = await execAsync(
+      `python3 "${SCRIPT_PATH}" "${filePath}"`,
+      {
+        signal,
+        timeout: 10_000,
+        maxBuffer: 5 * 1024 * 1024,
+      }
+    );
+
+    if (stderr && !stdout) {
+      console.error(`GDScript mapper stderr: ${stderr}`);
+      return null;
+    }
+
+    const result: GdOutlineResult = JSON.parse(stdout);
+
+    if (result.error) {
+      console.error(`GDScript mapper error: ${result.error}`);
+      return null;
+    }
+
+    const fileMap: FileMap = {
+      path: filePath,
+      totalLines,
+      totalBytes,
+      language: "GDScript",
+      symbols: result.symbols.map(convertSymbol),
+      imports: result.imports ?? [],
+      detailLevel: DetailLevel.Full,
+    };
+
+    return fileMap;
+  } catch (error) {
+    if (signal?.aborted) {
+      return null;
+    }
+    console.error(`GDScript mapper failed: ${error}`);
+    return null;
+  }
+}

--- a/src/readmap/mappers/gdscript_outline.py
+++ b/src/readmap/mappers/gdscript_outline.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Parse a GDScript file using gdtoolkit (Lark-based parser) and emit a JSON
+outline for pi-hashline-readmap.
+
+Usage: python3 gdscript_outline.py <file.gd>
+
+Requires: pip install gdtoolkit
+"""
+import json
+import sys
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Token helpers
+# ---------------------------------------------------------------------------
+
+def _token_str(tok):
+    """Return the string value of a Lark token or tree node."""
+    if hasattr(tok, "value"):
+        return tok.value
+    return str(tok)
+
+
+def _token_line(tok):
+    """Return the 1-indexed line number of a token."""
+    if hasattr(tok, "line") and tok.line is not None:
+        return tok.line
+    # Fallback: walk children
+    if hasattr(tok, "children"):
+        for ch in tok.children:
+            line = _token_line(ch)
+            if line:
+                return line
+    return 0
+
+
+def _find_var_name(node):
+    """Recursively find the variable-name token inside a class_var child."""
+    if hasattr(node, "data"):
+        if node.data in (
+            "class_var_typed_assgnd",
+            "class_var_assigned",
+            "class_var_typed",
+            "class_var",
+        ):
+            return node.children[0]
+        for child in node.children:
+            result = _find_var_name(child)
+            if result is not None:
+                return result
+    return node  # leaf token
+
+
+# ---------------------------------------------------------------------------
+# AST walker
+# ---------------------------------------------------------------------------
+
+def _build_signature(header) -> str:
+    """Build 'name(args) -> ret' from a func_header node."""
+    name = _token_str(header.children[0])
+    args_node = header.children[1] if len(header.children) > 1 else None
+    ret_node = header.children[2] if len(header.children) > 2 else None
+
+    args: list[str] = []
+    if args_node and hasattr(args_node, "data") and args_node.data == "func_args":
+        for arg in args_node.children:
+            if hasattr(arg, "data"):
+                if arg.data == "func_arg_typed":
+                    args.append(f"{_token_str(arg.children[0])}: {_token_str(arg.children[1])}")
+                elif arg.data == "func_arg":
+                    args.append(_token_str(arg.children[0]))
+                else:
+                    args.append(_token_str(arg))
+            else:
+                args.append(_token_str(arg))
+
+    sig = f"{name}({', '.join(args)})"
+    if ret_node and _token_str(ret_node).strip():
+        sig += f" -> {_token_str(ret_node)}"
+    return sig
+
+
+def _process_node(node) -> dict[str, Any] | None:
+    rule = node.data if hasattr(node, "data") else None
+    children = node.children if hasattr(node, "children") else []
+
+    if rule == "extends_stmt":
+        return None
+
+    if rule == "classname_stmt":
+        return {
+            "kind": "class",
+            "name": _token_str(children[0]),
+            "startLine": _token_line(children[0]),
+        }
+
+    if rule == "class_def":
+        name_token = children[0]
+        name = _token_str(name_token)
+        start = _token_line(name_token)
+        kids = [c for c in (_process_node(ch) for ch in children[1:]) if c]
+        sym: dict[str, Any] = {
+            "kind": "class",
+            "name": name,
+            "startLine": start,
+        }
+        if kids:
+            sym["children"] = kids
+        return sym
+
+    if rule == "func_def":
+        header = children[0]
+        name_token = header.children[0]
+        name = _token_str(name_token)
+        start = _token_line(name_token)
+        return {
+            "kind": "function",
+            "name": name,
+            "startLine": start,
+            "signature": _build_signature(header),
+        }
+
+    if rule == "const_stmt":
+        name_token = children[0]
+        return {
+            "kind": "constant",
+            "name": _token_str(name_token),
+            "startLine": _token_line(name_token),
+        }
+
+    if rule == "class_var_stmt":
+        name_node = _find_var_name(children[0])
+        return {
+            "kind": "variable",
+            "name": _token_str(name_node),
+            "startLine": _token_line(name_node),
+        }
+
+    if rule == "signal_stmt":
+        name_token = children[0]
+        return {
+            "kind": "signal",
+            "name": _token_str(name_token),
+            "startLine": _token_line(name_token),
+        }
+
+    if rule == "enum_stmt":
+        if children and hasattr(children[0], "data") and children[0].data == "enum_named":
+            name_token = children[0].children[0]
+            return {
+                "kind": "enum",
+                "name": _token_str(name_token),
+                "startLine": _token_line(name_token),
+            }
+
+    return None
+
+
+def extract_outline(tree) -> list[dict[str, Any]]:
+    """Walk the Lark AST and extract a flat+nested outline."""
+    result: list[dict[str, Any]] = []
+    for child in tree.children:
+        item = _process_node(child)
+        if item:
+            result.append(item)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# End-line estimation (linear scan, same pattern as other mappers)
+# ---------------------------------------------------------------------------
+
+def _estimate_endlines(symbols: list[dict], total_lines: int):
+    """Mutate symbols to add endLine = next symbol's startLine - 1."""
+    for i, sym in enumerate(symbols):
+        # Recurse into children first
+        if sym.get("children"):
+            _estimate_endlines(sym["children"], total_lines)
+
+        next_start = symbols[i + 1]["startLine"] if i + 1 < len(symbols) else total_lines + 1
+        # If this symbol has children, endLine = last child's endLine
+        if sym.get("children"):
+            sym["endLine"] = sym["children"][-1]["endLine"]
+        else:
+            sym["endLine"] = next_start - 1
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: gdscript_outline.py <file.gd>", file=sys.stderr)
+        sys.exit(1)
+
+    filepath = sys.argv[1]
+    try:
+        from gdtoolkit.parser import parser
+        import subprocess
+
+        code = open(filepath).read()
+        total_lines = code.count("\n") + 1
+
+        tree = parser.parse(code)
+        outline = extract_outline(tree)
+        _estimate_endlines(outline, total_lines)
+
+        # Collect imports (load, preload, requires)
+        imports: list[str] = []
+        for child in tree.children:
+            if hasattr(child, "data") and child.data in ("load_stmt", "preload_stmt", "requires_stmt"):
+                imports.append(_token_str(child.children[0]))
+
+        print(json.dumps({"symbols": outline, "imports": imports}))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add GDScript (`.gd`) support via a regex-free, Lark-based AST mapper using [gdtoolkit](https://github.com/Scony/godot-gdscript-toolkit) (1.5K stars).

## Changes

| File | Lines | Role |
|---|---|---|
| `mappers/gdscript.ts` | New, 120 | TypeScript wrapper (subprocess pattern, same as Python mapper) |
| `mappers/gdscript_outline.py` | New, 197 | Lark AST walker — extracts signals, enums, classes, functions (with signatures), variables, constants |
| `language-detect.ts` | +3 | Register `.gd` → `{ id: "gdscript", name: "GDScript" }` |
| `mapper.ts` | +3 | Import + register in `MAPPERS_V` |
| `enums.ts` | +1 | Add `Signal = "signal"` to `SymbolKind` |

## How It Works

Same pattern as the existing Python mapper: `gdscript.ts` spawns `python3 gdscript_outline.py <file.gd>` which uses `gdtoolkit.parser` (Lark grammar) to build the AST and emit a JSON outline with symbols, imports, and end-line estimates.

## Requirements

`pip install gdtoolkit` (Python 3.8+, no C dependencies)

## Testing

- TypeScript compiles clean (`tsc --noEmit`)
- Existing test suite: 1421 pass, 7 pre-existing failures (unrelated)
- Verified on real Godot project `.gd` files — signatures, return types, nested structures all parse correctly
