### PR TITLE
fix: prefer ast-grep binary for ast_search

### DIFF
--- a/src/sg.ts
+++ b/src/sg.ts
@@ -119,12 +119,23 @@ function execFileText(
 }
 
 /**
- * Check if the `sg` (ast-grep) binary is available in PATH.
- * Runs `sg --version` synchronously with a 3-second timeout.
+ * Prefer `ast-grep`; `sg` is the setgid command on many Linux systems.
+ */
+function resolveSgCommand(): "ast-grep" | "sg" {
+  try {
+    cp.execFileSync("ast-grep", ["--version"], { timeout: 3000, stdio: "pipe" });
+    return "ast-grep";
+  } catch {
+    return "sg";
+  }
+}
+
+/**
+ * Check if an ast-grep-compatible binary is available in PATH.
  */
 export function isSgAvailable(): boolean {
   try {
-    cp.execFileSync("sg", ["--version"], { timeout: 3000, stdio: "pipe" });
+    cp.execFileSync(resolveSgCommand(), ["--version"], { timeout: 3000, stdio: "pipe" });
     return true;
   } catch {
     return false;
@@ -237,7 +248,7 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
       args.push(searchPath);
 
       try {
-        const { stdout } = await execFileText("sg", args, {
+        const { stdout } = await execFileText(resolveSgCommand(), args, {
           cwd: ctx.cwd,
           signal,
           maxBuffer: 10 * 1024 * 1024,

--- a/tests/sg-binary-resolution.test.ts
+++ b/tests/sg-binary-resolution.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as cp from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
+}));
+
+async function getSgTool() {
+  const { registerSgTool } = await import("../src/sg.js");
+  let captured: any = null;
+  const mockPi = { registerTool(def: any) { captured = def; } };
+  registerSgTool(mockPi as any);
+  if (!captured) throw new Error("sg tool was not registered");
+  return captured;
+}
+
+describe("ast_search binary resolution", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("reports available when ast-grep is on PATH even if sg is not", async () => {
+    const { isSgAvailable } = await import("../src/sg.js");
+    vi.mocked(cp.execFileSync).mockImplementation((cmd: any) => {
+      if (cmd === "ast-grep") return Buffer.from("ast-grep 0.42.1");
+      throw Object.assign(new Error("not found"), { code: "ENOENT" });
+    });
+
+    expect(isSgAvailable()).toBe(true);
+  });
+
+  it("executes ast-grep when ast-grep is on PATH", async () => {
+    const tool = await getSgTool();
+    vi.mocked(cp.execFileSync).mockImplementation((cmd: any) => {
+      if (cmd === "ast-grep") return Buffer.from("ast-grep 0.42.1");
+      throw Object.assign(new Error("not found"), { code: "ENOENT" });
+    });
+
+    let command = "";
+    vi.mocked(cp.execFile).mockImplementation((cmd: any, _args: any, _opts: any, cb: any) => {
+      command = cmd;
+      cb(null, "[]", "");
+      return {} as any;
+    });
+
+    await tool.execute("tc", { pattern: "console.log($$$ARGS)" }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+
+    expect(command).toBe("ast-grep");
+  });
+
+  it("falls back to sg when ast-grep is not on PATH", async () => {
+    const tool = await getSgTool();
+    vi.mocked(cp.execFileSync).mockImplementation((cmd: any) => {
+      if (cmd === "ast-grep") throw Object.assign(new Error("not found"), { code: "ENOENT" });
+      return Buffer.from("ast-grep 0.42.1");
+    });
+
+    let command = "";
+    vi.mocked(cp.execFile).mockImplementation((cmd: any, _args: any, _opts: any, cb: any) => {
+      command = cmd;
+      cb(null, "[]", "");
+      return {} as any;
+    });
+
+    await tool.execute("tc", { pattern: "console.log($$$ARGS)" }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+
+    expect(command).toBe("sg");
+  });
+});


### PR DESCRIPTION
Prefer ast-grep for ast_search and fall back to sg when ast-grep is unavailable.

fixes #112 