### PR TITLE
chore(release): bundle npm-managed sg and nu CLIs (#185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It also reduces extension conflict risk by replacing several overlapping tool pa
 ### Requirements
 
 - [pi](https://github.com/mariozechner/pi-coding-agent) with extension support
-- Node.js **>= 20** for local development in this repository
+- Node.js **>= 22** for installation/runtime and local development (the bundled `nushell` package declares this engine floor)
 
 ### From npm
 
@@ -51,13 +51,18 @@ pi install .
 
 Start a new pi session after installation. Running sessions do not hot-reload extension code or tool registrations.
 
-### Optional local tools
+### CLI dependencies and optional local tools
 
-These tools are not required for the extension to load, but they unlock more capability or better output quality:
+Normal npm installs of `pi-hashline-readmap` include npm-managed CLI packages for the tools this extension wraps:
+
+- `@ast-grep/cli` provides the `sg` binary used by `ast_search`.
+- `nushell` provides the `nu` binary used by the optional `nu` tool.
+
+The extension resolves those bundled binaries first and falls back to `sg` or `nu` on `PATH` when the npm-provided package or bin entry is unavailable. If troubleshooting a broken platform package, a system install can still be useful after repairing/removing the broken npm package or as a fallback in environments without the bundled binary:
 
 ```bash
-brew install nushell           # required for the nu tool
-brew install ast-grep          # required for ast_search
+brew install ast-grep          # fallback for ast_search if @ast-grep/cli cannot run
+brew install nushell           # fallback for the nu tool if the npm nushell package cannot run
 brew install fd                # optional, speeds up find
 brew install universal-ctags   # optional, symbol maps for languages without a dedicated mapper
 brew install difftastic        # optional, improves semantic edit summaries

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.8.9",
+      "version": "0.8.10",
       "license": "MIT",
       "dependencies": {
+        "@ast-grep/cli": "0.42.2",
         "diff": "^8.0.3",
         "ignore": "^7.0.5",
+        "nushell": "0.112.2",
         "picomatch": "^4.0.4",
         "tree-sitter": "0.22.4",
         "tree-sitter-clojure": "github:ghoseb/tree-sitter-clojure#78928e6",
@@ -29,10 +31,157 @@
         "typescript": "^5.9.3",
         "vitest": "^4.1.0"
       },
+      "engines": {
+        "node": ">=22.0.0"
+      },
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": "*",
         "@earendil-works/pi-tui": "*",
         "@sinclair/typebox": "*"
+      }
+    },
+    "node_modules/@ast-grep/cli": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli/-/cli-0.42.2.tgz",
+      "integrity": "sha512-TojScwpaM40UQyvV5n5oa8PfOPFfHSD8Xf0WppPXn1+lq73u/jwvDmP8M2Oxj5YgebIpgkDUPoMixThtqwpNBA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
+      "bin": {
+        "ast-grep": "ast-grep",
+        "sg": "sg"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "optionalDependencies": {
+        "@ast-grep/cli-darwin-arm64": "0.42.2",
+        "@ast-grep/cli-darwin-x64": "0.42.2",
+        "@ast-grep/cli-linux-arm64-gnu": "0.42.2",
+        "@ast-grep/cli-linux-x64-gnu": "0.42.2",
+        "@ast-grep/cli-win32-arm64-msvc": "0.42.2",
+        "@ast-grep/cli-win32-ia32-msvc": "0.42.2",
+        "@ast-grep/cli-win32-x64-msvc": "0.42.2"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-arm64": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-arm64/-/cli-darwin-arm64-0.42.2.tgz",
+      "integrity": "sha512-li1RsB2fO5/qchdZHny+meg1I03xD+A5rug8axxOdqull8hdFUqxymZ5hg/tKh+/C04gyccEBgqcuJAsghuPXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-x64": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-x64/-/cli-darwin-x64-0.42.2.tgz",
+      "integrity": "sha512-oKR1bRYsmc0G287q9Xj29m3SrxohEXhArKt647MswDYbG751LHG3aaEf6TtYjcxq+jKB4XaVJ5+q1jlIgKbVWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-arm64-gnu": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-0.42.2.tgz",
+      "integrity": "sha512-dfgQcTR2SI47J1yz/MMQuA3cFu/pzsum07aLgv+QcouCJY+AJcgjZTNUd26vZ/352wTXfJ/wpfziwbbI/Z4EEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-x64-gnu": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-x64-gnu/-/cli-linux-x64-gnu-0.42.2.tgz",
+      "integrity": "sha512-ygkLM/RLEKw8btFgFIl/BrU2ji2sH79YnxIzjVIC5np9NMWWvqZ/jy2++s0YYI8Y9XLmfa1+Pi8F5zFK+3qDww==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-arm64-msvc": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-0.42.2.tgz",
+      "integrity": "sha512-fThbaAvwUFfW1kAYw7xAzX/VvWMcyfeyyKyHfwQWHbkT5bjqdbnb5yFPLu0Q2Qo3bHUudYYP4WLakegkRyHSkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-ia32-msvc": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-0.42.2.tgz",
+      "integrity": "sha512-W7S+Hao/FMsXc8ZZny7YqA16J5C9O9b6UvT+0xpiWda6nNhOv0ebQHzjhtuSC/+SlV7S29uwjr+jT/T6+XmV0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-x64-msvc": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-x64-msvc/-/cli-win32-x64-msvc-0.42.2.tgz",
+      "integrity": "sha512-EPMQyUIvl4P3wqOAs9V+2LIUaLZNUQyHkLXqP+PKtGT+tS/c+IBv+/FiQ2psMHs2u4PM8tg2rnQBQ8sU0Nr+Gw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1332,6 +1481,110 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@nushell/darwin-arm64": {
+      "version": "0.112.2",
+      "resolved": "https://registry.npmjs.org/@nushell/darwin-arm64/-/darwin-arm64-0.112.2.tgz",
+      "integrity": "sha512-jeTxJ4cbF0wI/XF2qxAu4uwv24IAoArhoxI0DqQjVZjrXeSJQ0OVUVntugwXvgKiSJR5IlfPvj2IZiMaPelAhw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@nushell/darwin-x64": {
+      "version": "0.112.2",
+      "resolved": "https://registry.npmjs.org/@nushell/darwin-x64/-/darwin-x64-0.112.2.tgz",
+      "integrity": "sha512-G1nQqaRwWJECc/XZ1Uw6PzQts0exM7dtCwXSxZA7Y5Yune9mCjem51bt7iSqwSztGDSsJHMScQ7yUUMLGWbYrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@nushell/linux-arm": {
+      "version": "0.112.2",
+      "resolved": "https://registry.npmjs.org/@nushell/linux-arm/-/linux-arm-0.112.2.tgz",
+      "integrity": "sha512-UOACFdXMBRB6je2X1aKf1Tp34l8KB9WeiY8+933Mbf07oTAm7YUHwlJqdBvFIX2oGLtqtQoofKDHaQuOD0RWkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nushell/linux-arm64": {
+      "version": "0.112.2",
+      "resolved": "https://registry.npmjs.org/@nushell/linux-arm64/-/linux-arm64-0.112.2.tgz",
+      "integrity": "sha512-syosu1u4xb+bqO5KNKxr0qgau8Lyh2SGx7ZZ67UVz5bWjPRd4axRHP4YDBucSI+tg0fsoCtcyN7e0iKWI8OVkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nushell/linux-riscv64": {
+      "version": "0.112.2",
+      "resolved": "https://registry.npmjs.org/@nushell/linux-riscv64/-/linux-riscv64-0.112.2.tgz",
+      "integrity": "sha512-MQvgV1A8RXvb2H7j2BkuxnfUawFSTYgkUKsORO3yK4Wkg1pSxPqfglh9HgOM32JCjeoSKAjrJmyqcZvpKynjAQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nushell/linux-x64": {
+      "version": "0.112.2",
+      "resolved": "https://registry.npmjs.org/@nushell/linux-x64/-/linux-x64-0.112.2.tgz",
+      "integrity": "sha512-atMC9KpsLFC/MH1uH4qQvtIH+tomxtEvD5A1Q7fgsTbaBYhlYHm03Qs24sK+kdqOHcQ23ase/FUtRxqAFBwlDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nushell/windows-arm64": {
+      "version": "0.112.2",
+      "resolved": "https://registry.npmjs.org/@nushell/windows-arm64/-/windows-arm64-0.112.2.tgz",
+      "integrity": "sha512-jdq/PaLLe45xwRPQvykT31pZ5sqXSSoQvvHzspPpxhIJVeHLa+i0GpBj3Ftu+4jfO9QGK8UlDbnofPwOro/rBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@nushell/windows-x64": {
+      "version": "0.112.2",
+      "resolved": "https://registry.npmjs.org/@nushell/windows-x64/-/windows-x64-0.112.2.tgz",
+      "integrity": "sha512-FIC3Zp9sBrogWA6pFuWPNL9YWj2+eYgsWC8qy3XfxSe/K35gnfjCC5Je2KPaE6OrgbketLtPjuujpauo5TD1Ug==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@oxc-project/types": {
       "version": "0.129.0",
@@ -2935,7 +3188,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -4033,6 +4285,29 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nushell": {
+      "version": "0.112.2",
+      "resolved": "https://registry.npmjs.org/nushell/-/nushell-0.112.2.tgz",
+      "integrity": "sha512-CL1Uww/g+PCmO9eHCb1Z73D73VLsa7dXYzX5qbvfNRtQyx3LCU5ofHQ23vQi8SRcB9Tblbj364JzJRMdlE2fUg==",
+      "license": "MIT",
+      "bin": {
+        "nu": "lib/index.js"
+      },
+      "engines": {
+        "node": ">=22.0.0",
+        "pnpm": ">=10"
+      },
+      "optionalDependencies": {
+        "@nushell/darwin-arm64": "0.112.2",
+        "@nushell/darwin-x64": "0.112.2",
+        "@nushell/linux-arm": "0.112.2",
+        "@nushell/linux-arm64": "0.112.2",
+        "@nushell/linux-riscv64": "0.112.2",
+        "@nushell/linux-x64": "0.112.2",
+        "@nushell/windows-arm64": "0.112.2",
+        "@nushell/windows-x64": "0.112.2"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {
@@ -36,9 +36,14 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "dependencies": {
+    "@ast-grep/cli": "0.42.2",
     "diff": "^8.0.3",
     "ignore": "^7.0.5",
+    "nushell": "0.112.2",
     "picomatch": "^4.0.4",
     "tree-sitter": "0.22.4",
     "tree-sitter-clojure": "github:ghoseb/tree-sitter-clojure#78928e6",

--- a/src/binary-resolution.ts
+++ b/src/binary-resolution.ts
@@ -1,0 +1,77 @@
+import { existsSync as defaultExistsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+
+export interface ResolveBundledBinDeps {
+  resolvePackageJson?: (specifier: string) => string;
+  readPackageJson?: (packageJsonPath: string) => string;
+  existsSync?: (candidate: string) => boolean;
+  platform?: NodeJS.Platform;
+}
+
+function defaultResolvePackageJson(specifier: string): string {
+  return require.resolve(specifier);
+}
+
+function defaultReadPackageJson(packageJsonPath: string): string {
+  return readFileSync(packageJsonPath, "utf8");
+}
+
+function binEntryFor(packageJsonText: string, binName: string): string | undefined {
+  const parsed = JSON.parse(packageJsonText) as { bin?: string | Record<string, string> };
+  if (typeof parsed.bin === "string") return parsed.bin;
+  return parsed.bin?.[binName];
+}
+
+function commandCandidates(basePath: string, platform: NodeJS.Platform): string[] {
+  if (platform !== "win32") return [basePath];
+  return [`${basePath}.exe`, basePath];
+}
+
+function firstExisting(candidates: string[], existsSync: (candidate: string) => boolean): string | undefined {
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+export interface ExecutableCommand {
+  command: string;
+  argsPrefix: string[];
+}
+
+export function executableCommand(binaryPath: string, platform: NodeJS.Platform = process.platform): ExecutableCommand {
+  if (platform === "win32" && /\.js$/i.test(binaryPath)) {
+    return { command: process.execPath, argsPrefix: [binaryPath] };
+  }
+  return { command: binaryPath, argsPrefix: [] };
+}
+
+export function resolveBundledBin(
+  packageName: string,
+  binName: string,
+  fallbackCommand: string,
+  deps: ResolveBundledBinDeps = {},
+): string {
+  const resolvePackageJson = deps.resolvePackageJson ?? defaultResolvePackageJson;
+  const readPackageJson = deps.readPackageJson ?? defaultReadPackageJson;
+  const existsSync = deps.existsSync ?? defaultExistsSync;
+  const platform = deps.platform ?? process.platform;
+
+  try {
+    const packageJsonPath = resolvePackageJson(`${packageName}/package.json`);
+    const packageDir = dirname(packageJsonPath);
+    const binEntry = binEntryFor(readPackageJson(packageJsonPath), binName);
+    if (!binEntry) return fallbackCommand;
+
+
+    const packageBinCandidate = firstExisting(
+      commandCandidates(resolve(packageDir, binEntry), platform),
+      existsSync,
+    );
+    if (packageBinCandidate) return packageBinCandidate;
+  } catch {
+    // Fall through to PATH fallback.
+  }
+
+  return fallbackCommand;
+}

--- a/src/nu.ts
+++ b/src/nu.ts
@@ -10,6 +10,7 @@ import { buildPtcError } from "./ptc-value.js";
 import { stripAnsi } from "./rtk/ansi.js";
 import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine } from "./tui-render-utils.js";
+import { executableCommand, resolveBundledBin } from "./binary-resolution.js";
 
 const MAX_LINES = 2000;
 const MAX_BYTES = 50 * 1024; // 50 KB
@@ -18,9 +19,14 @@ const MAX_BYTES = 50 * 1024; // 50 KB
  * Check if the `nu` (Nushell) binary is available in PATH.
  * Runs `nu --version` synchronously with a 3-second timeout.
  */
+export function resolveNuBinary(): string {
+  return resolveBundledBin("nushell", "nu", "nu");
+}
+
 export function isNuAvailable(): boolean {
   try {
-    execFileSync("nu", ["--version"], { timeout: 3000, stdio: "pipe" });
+    const binary = executableCommand(resolveNuBinary());
+    execFileSync(binary.command, [...binary.argsPrefix, "--version"], { timeout: 3000, stdio: "pipe" });
     return true;
   } catch {
     return false;
@@ -155,7 +161,8 @@ export async function executeNuScript(opts: NuExecuteOptions): Promise<NuExecute
     // Wrap spawn in try/catch for sync failures (e.g. invalid cwd)
     let proc;
     try {
-      proc = spawn("nu", args, {
+      const binary = executableCommand(resolveNuBinary());
+      proc = spawn(binary.command, [...binary.argsPrefix, ...args], {
         cwd,
         env: { ...process.env },
         detached: process.platform !== "win32",
@@ -213,7 +220,7 @@ export async function executeNuScript(opts: NuExecuteOptions): Promise<NuExecute
     proc.on("error", (err: NodeJS.ErrnoException) => {
       const hint =
         err.code === "ENOENT"
-          ? "\n\nHint: 'nu' was not found in PATH. Install nushell: https://www.nushell.sh/"
+          ? "\n\nHint: bundled npm package 'nushell' was unavailable or unusable. Run npm install, or install Nushell on PATH as a fallback: https://www.nushell.sh/"
           : "";
       settle({
         output: `Error spawning nushell: ${err.message}${hint}`,
@@ -361,7 +368,7 @@ export function registerNuTool(pi: ExtensionAPI): NuToolDefinition | false {
           error: buildPtcError(
             "nu-spawn-error",
             text,
-            "Install nushell: https://www.nushell.sh/",
+            "Run npm install to install the nushell package, or install Nushell on PATH as a fallback: https://www.nushell.sh/",
             { exitCode: result.exitCode, timedOut: false },
           ),
         };

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -13,6 +13,7 @@ import type { FileSymbol } from "./readmap/types.js";
 import { buildSgOutput } from "./sg-output.js";
 import { buildAstSearchRehydrateDescriptor, isContextHygieneDebugEnabled } from "./context-hygiene.js";
 import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine } from "./tui-render-utils.js";
+import { executableCommand, resolveBundledBin } from "./binary-resolution.js";
 
 type SgParams = { pattern: string; lang?: string; path?: string };
 const CONTEXT_HYGIENE_SG_SYMBOL_FILE_CAP = 20;
@@ -122,9 +123,14 @@ function execFileText(
  * Check if the `sg` (ast-grep) binary is available in PATH.
  * Runs `sg --version` synchronously with a 3-second timeout.
  */
+export function resolveSgBinary(): string {
+  return resolveBundledBin("@ast-grep/cli", "sg", "sg");
+}
+
 export function isSgAvailable(): boolean {
   try {
-    cp.execFileSync("sg", ["--version"], { timeout: 3000, stdio: "pipe" });
+    const binary = executableCommand(resolveSgBinary());
+    cp.execFileSync(binary.command, [...binary.argsPrefix, "--version"], { timeout: 3000, stdio: "pipe" });
     return true;
   } catch {
     return false;
@@ -237,7 +243,8 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
       args.push(searchPath);
 
       try {
-        const { stdout } = await execFileText("sg", args, {
+        const binary = executableCommand(resolveSgBinary());
+        const { stdout } = await execFileText(binary.command, [...binary.argsPrefix, ...args], {
           cwd: ctx.cwd,
           signal,
           maxBuffer: 10 * 1024 * 1024,
@@ -352,7 +359,7 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
         };
       } catch (err: any) {
         if (err?.code === "ENOENT") {
-          const message = "ast-grep (sg) is not installed. Run: brew install ast-grep";
+          const message = "ast-grep (sg) could not be resolved or executed. pi-hashline-readmap includes @ast-grep/cli for normal npm installs; run npm install, or install ast-grep on PATH as a fallback (for example: brew install ast-grep).";
           return {
             content: [{ type: "text", text: message }],
             isError: true,
@@ -363,7 +370,7 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
                 error: buildPtcError(
                   "sg-not-installed",
                   message,
-                  "Install with: brew install ast-grep (or see https://ast-grep.github.io)",
+                  "Run npm install to install @ast-grep/cli, or install ast-grep on PATH as a fallback: brew install ast-grep.",
                 ),
               },
             },

--- a/tests/binary-resolution.test.ts
+++ b/tests/binary-resolution.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { executableCommand, resolveBundledBin } from "../src/binary-resolution.js";
+
+describe("resolveBundledBin", () => {
+  it("uses the direct package bin on non-Windows even when an npm .bin shim exists", () => {
+    const resolved = resolveBundledBin("nushell", "nu", "nu", {
+      resolvePackageJson: () => "/repo/node_modules/nushell/package.json",
+      readPackageJson: () => JSON.stringify({ bin: "lib/index.js" }),
+      existsSync: (candidate) => candidate === "/repo/node_modules/.bin/nu" || candidate === "/repo/node_modules/nushell/lib/index.js",
+      platform: "darwin",
+    });
+
+    expect(resolved).toBe("/repo/node_modules/nushell/lib/index.js");
+  });
+
+  it("resolves Windows JavaScript package bins and prepares them for node execution", () => {
+    const resolved = resolveBundledBin("nushell", "nu", "nu", {
+      resolvePackageJson: () => "/repo/node_modules/nushell/package.json",
+      readPackageJson: () => JSON.stringify({ bin: "lib/index.js" }),
+      existsSync: (candidate) => candidate === "/repo/node_modules/nushell/lib/index.js",
+      platform: "win32",
+    });
+
+    expect(resolved).toBe("/repo/node_modules/nushell/lib/index.js");
+    const command = executableCommand(resolved, "win32");
+    expect(command.command).toBe(process.execPath);
+    expect(command.argsPrefix).toEqual(["/repo/node_modules/nushell/lib/index.js"]);
+  });
+
+  it("resolves Windows package executables when no npm .bin shim exists", () => {
+    const resolved = resolveBundledBin("@ast-grep/cli", "sg", "sg", {
+      resolvePackageJson: () => "/repo/node_modules/@ast-grep/cli/package.json",
+      readPackageJson: () => JSON.stringify({ bin: { sg: "sg" } }),
+      existsSync: (candidate) => candidate === "/repo/node_modules/@ast-grep/cli/sg.exe",
+      platform: "win32",
+    });
+
+    expect(resolved).toBe("/repo/node_modules/@ast-grep/cli/sg.exe");
+  });
+
+  it("leaves native executables and non-Windows scripts as direct commands", () => {
+    expect(executableCommand("/repo/node_modules/@ast-grep/cli/sg.exe", "win32")).toEqual({ command: "/repo/node_modules/@ast-grep/cli/sg.exe", argsPrefix: [] });
+    expect(executableCommand("/repo/node_modules/nushell/lib/index.js", "darwin")).toEqual({ command: "/repo/node_modules/nushell/lib/index.js", argsPrefix: [] });
+  });
+  it("returns an existing bin path from an npm package.json bin map before falling back to PATH", () => {
+    const resolved = resolveBundledBin("@ast-grep/cli", "sg", "sg", {
+      resolvePackageJson: (specifier) => {
+        expect(specifier).toBe("@ast-grep/cli/package.json");
+        return "/repo/node_modules/@ast-grep/cli/package.json";
+      },
+      readPackageJson: () => JSON.stringify({ bin: { sg: "bin/sg" } }),
+      existsSync: (candidate) => candidate === "/repo/node_modules/@ast-grep/cli/bin/sg",
+    });
+
+    expect(resolved).toBe("/repo/node_modules/@ast-grep/cli/bin/sg");
+  });
+
+  it("returns an existing bin path from a string package.json bin entry", () => {
+    const resolved = resolveBundledBin("nushell", "nu", "nu", {
+      resolvePackageJson: () => "/repo/node_modules/nushell/package.json",
+      readPackageJson: () => JSON.stringify({ bin: "nu" }),
+      existsSync: (candidate) => candidate === "/repo/node_modules/nushell/nu",
+    });
+
+    expect(resolved).toBe("/repo/node_modules/nushell/nu");
+  });
+
+  it("returns the PATH fallback command when the npm package cannot be resolved", () => {
+    const resolved = resolveBundledBin("nushell", "nu", "nu", {
+      resolvePackageJson: () => {
+        throw Object.assign(new Error("Cannot find module 'nushell/package.json'"), { code: "MODULE_NOT_FOUND" });
+      },
+      readPackageJson: () => {
+        throw new Error("should not read package.json after resolution failed");
+      },
+      existsSync: () => false,
+    });
+
+    expect(resolved).toBe("nu");
+  });
+
+  it("returns the PATH fallback command when the package bin entry is missing", () => {
+    const resolved = resolveBundledBin("@ast-grep/cli", "sg", "sg", {
+      resolvePackageJson: () => "/repo/node_modules/@ast-grep/cli/package.json",
+      readPackageJson: () => JSON.stringify({ bin: { "ast-grep": "bin/ast-grep" } }),
+      existsSync: () => false,
+    });
+
+    expect(resolved).toBe("sg");
+  });
+});

--- a/tests/nu-binary-resolution.test.ts
+++ b/tests/nu-binary-resolution.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as cp from "node:child_process";
+import { EventEmitter } from "node:events";
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<any>("node:child_process");
+  return {
+    ...actual,
+    execFileSync: vi.fn(() => Buffer.from("0.112.2\n")),
+    spawn: vi.fn(),
+  };
+});
+
+function mockSpawnClose(stdout = "ok\n", exitCode = 0) {
+  vi.mocked(cp.spawn).mockImplementation((_cmd: any, _args: any, _opts: any) => {
+    const proc = new EventEmitter() as any;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = vi.fn();
+    queueMicrotask(() => {
+      proc.stdout.emit("data", Buffer.from(stdout));
+      proc.emit("close", exitCode);
+    });
+    return proc;
+  });
+}
+
+async function captureNuTool() {
+  const { registerNuTool } = await import("../src/nu.js");
+  const pi = { registerTool: vi.fn() };
+  const tool = registerNuTool(pi as any);
+  if (!tool) throw new Error("nu tool was not registered");
+  return tool;
+}
+
+describe("nu binary resolution", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../src/binary-resolution.js");
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../src/binary-resolution.js");
+    vi.clearAllMocks();
+  });
+
+  it("checks availability and executes with the npm-provided nu binary when it resolves", async () => {
+    const resolveBundledBin = vi.fn(() => "/mock/node_modules/nushell/nu");
+    vi.doMock("../src/binary-resolution.js", () => ({ resolveBundledBin, executableCommand: (command: string) => ({ command, argsPrefix: [] }) }));
+    mockSpawnClose("ok\n", 0);
+
+    const tool = await captureNuTool();
+    await tool.execute("tc", { command: "echo ok" }, undefined, undefined, { cwd: process.cwd() } as any);
+
+    expect(resolveBundledBin).toHaveBeenCalledWith("nushell", "nu", "nu");
+    expect(vi.mocked(cp.execFileSync).mock.calls[0][0]).toBe("/mock/node_modules/nushell/nu");
+    expect(vi.mocked(cp.spawn).mock.calls[0][0]).toBe("/mock/node_modules/nushell/nu");
+  });
+
+  it("checks availability and executes with PATH nu when the npm-provided binary is unavailable", async () => {
+    const resolveBundledBin = vi.fn((_packageName: string, _binName: string, fallbackCommand: string) => fallbackCommand);
+    vi.doMock("../src/binary-resolution.js", () => ({ resolveBundledBin, executableCommand: (command: string) => ({ command, argsPrefix: [] }) }));
+    mockSpawnClose("ok\n", 0);
+
+    const tool = await captureNuTool();
+    await tool.execute("tc", { command: "echo ok" }, undefined, undefined, { cwd: process.cwd() } as any);
+
+    expect(resolveBundledBin).toHaveBeenCalledWith("nushell", "nu", "nu");
+    expect(vi.mocked(cp.execFileSync).mock.calls[0][0]).toBe("nu");
+    expect(vi.mocked(cp.spawn).mock.calls[0][0]).toBe("nu");
+  });
+});

--- a/tests/nu-spawn-error-guidance.test.ts
+++ b/tests/nu-spawn-error-guidance.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as cp from "node:child_process";
+import { EventEmitter } from "node:events";
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<any>("node:child_process");
+  return {
+    ...actual,
+    execFileSync: vi.fn(() => Buffer.from("0.112.2\n")),
+    spawn: vi.fn(),
+  };
+});
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  vi.doUnmock("node:child_process");
+});
+
+describe("nu spawn error guidance", () => {
+  it("keeps nu-spawn-error while mentioning the npm nushell dependency and PATH fallback", async () => {
+    vi.mocked(cp.spawn).mockImplementation(() => {
+      const proc = new EventEmitter() as any;
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      proc.kill = vi.fn();
+      queueMicrotask(() => {
+        const err = Object.assign(new Error("spawn nu ENOENT"), { code: "ENOENT" });
+        proc.emit("error", err);
+      });
+      return proc;
+    });
+
+    const { registerNuTool } = await import("../src/nu.js");
+    const pi = { registerTool: vi.fn() };
+    const tool = registerNuTool(pi as any);
+    if (!tool) throw new Error("nu tool was not registered");
+
+    const result = await tool.execute("tc", { command: "echo ok" }, undefined, undefined, { cwd: process.cwd() } as any);
+    const text = (result.content[0] as { text: string }).text;
+    const ptc = (result.details as any).ptcValue;
+
+    expect(text).toContain("bundled npm package 'nushell'");
+    expect(text).toContain("install Nushell on PATH as a fallback");
+    expect(ptc.error.code).toBe("nu-spawn-error");
+    expect(ptc.error.hint).toContain("nushell");
+    expect(ptc.error.hint).toContain("PATH");
+  });
+});

--- a/tests/package-version.test.ts
+++ b/tests/package-version.test.ts
@@ -6,8 +6,8 @@ const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
 
 describe("package version", () => {
   it("is bumped for the compact provider-visible metadata release", () => {
-    expect(packageJson.version).toBe("0.8.9");
-    expect(packageLock.version).toBe("0.8.9");
-    expect(packageLock.packages[""].version).toBe("0.8.9");
+    expect(packageJson.version).toBe("0.8.10");
+    expect(packageLock.version).toBe("0.8.10");
+    expect(packageLock.packages[""].version).toBe("0.8.10");
   });
 });

--- a/tests/ptc-error-contract.test.ts
+++ b/tests/ptc-error-contract.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { ensureHashInit } from "../src/hashline.js";
-import { isNuAvailable } from "../src/nu.js";
 import { PTC_ERROR_CODES } from "../src/ptc-error-codes.js";
 
+let nuAvailable = false;
 async function callTool(
   registerName:
     | "registerReadTool"
@@ -49,6 +49,15 @@ function assertContract(r: any, tool: string, expectedCode: string) {
 describe("ptc-error contract — every tool emits ptcValue.error on representative failure", () => {
   beforeAll(async () => {
     await ensureHashInit();
+    const nu = await import("../src/nu.js");
+    nuAvailable = nu.isNuAvailable();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../src/binary-resolution.js");
+    vi.doUnmock("node:child_process");
+    vi.resetModules();
   });
 
   it("read → file-not-found", async () => {
@@ -75,7 +84,19 @@ describe("ptc-error contract — every tool emits ptcValue.error on representati
     assertContract(r, "grep", "invalid-limit");
   });
 
-  it("ast_search → sg-not-installed (PATH stripped)", async () => {
+  it("ast_search → sg-not-installed", async () => {
+    vi.doMock("../src/binary-resolution.js", () => ({
+      resolveBundledBin: (_packageName: string, _binName: string, fallbackCommand: string) => fallbackCommand,
+      executableCommand: (command: string) => ({ command, argsPrefix: [] }),
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFile: vi.fn((_cmd: any, _args: any, _opts: any, cb: any) => {
+        const err: any = new Error("command not found: sg");
+        err.code = "ENOENT";
+        cb(err, "", "");
+        return {} as any;
+      }),
+    }));
     const orig = process.env.PATH;
     process.env.PATH = "/nonexistent";
     try {
@@ -106,7 +127,8 @@ describe("ptc-error contract — every tool emits ptcValue.error on representati
     expect(r!.isError).toBe(true);
   });
 
-  (isNuAvailable() ? it : it.skip)("nu → nu-non-zero-exit (AC 15)", async () => {
+  it("nu → nu-non-zero-exit (AC 15)", async () => {
+    if (!nuAvailable) return;
     const r = await callTool("registerNuTool", "../src/nu.js", { command: "exit 1" });
     assertContract(r, "nu", "nu-non-zero-exit");
     expect(r!.isError).toBeFalsy();

--- a/tests/ptc-error-sg.test.ts
+++ b/tests/ptc-error-sg.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import * as cp from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
 
 async function callSgTool(params: Record<string, unknown>) {
   const { registerSgTool } = await import("../src/sg.js");
@@ -12,19 +17,21 @@ const getPtc = (r: any) => r.details?.ptcValue;
 
 describe("ast_search ptcValue.error", () => {
   it("sg-not-installed when ENOENT", async () => {
-    const origPath = process.env.PATH;
-    process.env.PATH = "/nonexistent";
-    try {
-      const r = await callSgTool({ pattern: "$X", lang: "ts" });
-      expect(r.isError).toBe(true);
-      const ptc = getPtc(r);
-      expect(ptc?.tool).toBe("ast_search");
-      expect(ptc?.ok).toBe(false);
-      expect(ptc?.error?.code).toBe("sg-not-installed");
-      expect(typeof ptc?.error?.message).toBe("string");
-      expect(ptc?.error?.hint).toMatch(/brew install ast-grep/i);
-    } finally {
-      process.env.PATH = origPath;
-    }
+    vi.mocked(cp.execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      const err: any = new Error("command not found: sg");
+      err.code = "ENOENT";
+      cb(err, "", "");
+      return {} as any;
+    });
+
+    const r = await callSgTool({ pattern: "$X", lang: "ts" });
+    expect(r.isError).toBe(true);
+    const ptc = getPtc(r);
+    expect(ptc?.tool).toBe("ast_search");
+    expect(ptc?.ok).toBe(false);
+    expect(ptc?.error?.code).toBe("sg-not-installed");
+    expect(typeof ptc?.error?.message).toBe("string");
+    expect(ptc?.error?.hint).toMatch(/@ast-grep\/cli/i);
+    expect(ptc?.error?.hint).toMatch(/brew install ast-grep/i);
   });
 });

--- a/tests/sg-binary-resolution.test.ts
+++ b/tests/sg-binary-resolution.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as cp from "node:child_process";
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<any>("node:child_process");
+  return {
+    ...actual,
+    execFile: vi.fn(),
+    execFileSync: vi.fn(() => Buffer.from("ast-grep 0.42.2\n")),
+  };
+});
+
+async function captureSgTool() {
+  const { registerSgTool } = await import("../src/sg.js");
+  let captured: any = null;
+  registerSgTool({ registerTool(def: any) { captured = def; } } as any);
+  if (!captured) throw new Error("sg tool was not registered");
+  return captured;
+}
+
+describe("ast_search binary resolution", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../src/binary-resolution.js");
+    vi.clearAllMocks();
+  });
+
+  it("executes the npm-provided sg binary when it resolves", async () => {
+    const resolveBundledBin = vi.fn(() => "/mock/node_modules/@ast-grep/cli/bin/sg");
+    vi.doMock("../src/binary-resolution.js", () => ({ resolveBundledBin, executableCommand: (command: string) => ({ command, argsPrefix: [] }) }));
+
+    const tool = await captureSgTool();
+    vi.mocked(cp.execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, "[]", "");
+      return {} as any;
+    });
+
+    await tool.execute("tc", { pattern: "console.log($$$ARGS)" }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+
+    expect(resolveBundledBin).toHaveBeenCalledWith("@ast-grep/cli", "sg", "sg");
+    expect(vi.mocked(cp.execFile).mock.calls[0][0]).toBe("/mock/node_modules/@ast-grep/cli/bin/sg");
+  });
+
+  it("executes PATH sg when the npm-provided binary is unavailable", async () => {
+    const resolveBundledBin = vi.fn((_packageName: string, _binName: string, fallbackCommand: string) => fallbackCommand);
+    vi.doMock("../src/binary-resolution.js", () => ({ resolveBundledBin, executableCommand: (command: string) => ({ command, argsPrefix: [] }) }));
+
+    const tool = await captureSgTool();
+    vi.mocked(cp.execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, "[]", "");
+      return {} as any;
+    });
+
+    await tool.execute("tc", { pattern: "console.log($$$ARGS)" }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+
+    expect(resolveBundledBin).toHaveBeenCalledWith("@ast-grep/cli", "sg", "sg");
+    expect(vi.mocked(cp.execFile).mock.calls[0][0]).toBe("sg");
+  });
+});

--- a/tests/sg.execute-errors.test.ts
+++ b/tests/sg.execute-errors.test.ts
@@ -40,7 +40,9 @@ describe("sg execute errors", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(text(result)).toBe("ast-grep (sg) is not installed. Run: brew install ast-grep");
+    expect(text(result)).toBe(
+      "ast-grep (sg) could not be resolved or executed. pi-hashline-readmap includes @ast-grep/cli for normal npm installs; run npm install, or install ast-grep on PATH as a fallback (for example: brew install ast-grep).",
+    );
   });
 
   it("returns stderr when sg exits non-zero", async () => {


### PR DESCRIPTION
Closes #185.

## Summary

Bundles the CLI dependencies used by `ast_search` and `nu` so normal npm installs of `pi-hashline-readmap` can run both tools without separate Homebrew installs.

This also bumps the package version from `0.8.9` to `0.8.10` in both `package.json` and `package-lock.json`.

## What changed

- Added `@ast-grep/cli@0.42.2` and `nushell@0.112.2` as runtime dependencies.
- Added a small shared binary resolver for npm package `bin` entries.
- Updated `ast_search` to resolve the bundled `sg` binary first, with `sg` on `PATH` as fallback when the package/bin entry is unavailable.
- Updated `nu` registration and execution to resolve the bundled `nu` binary first, with `nu` on `PATH` as fallback when unavailable.
- Added Windows-aware execution handling: native `.exe` bins are preferred, and JavaScript package bins run through `process.execPath` instead of shell shims.
- Refreshed missing-binary guidance while preserving existing `ptcValue` error codes (`sg-not-installed`, `nu-spawn-error`).
- Updated README docs to describe `@ast-grep/cli` and `nushell` as npm-managed dependencies, with Homebrew retained as fallback troubleshooting guidance.
- Declared Node `>=22.0.0` because `nushell@0.112.2` requires that engine floor.

## Acceptance Criteria

- [x] AC1-4 — `package.json` and `package-lock.json` include the new runtime dependencies and `0.8.10` package version.
- [x] AC5-8 — `ast_search` and `nu` resolve npm-provided binaries first and preserve PATH fallback when unavailable.
- [x] AC9 — Binary resolution is small, shared, and directly unit tested.
- [x] AC10-11 — Missing-binary guidance is actionable while preserving existing error taxonomy.
- [x] AC12-13 — Existing `ast_search` and `nu` execution/output behavior is preserved.
- [x] AC14-15 — README documents npm-managed CLIs and fallback Homebrew guidance.
- [x] AC16-19 — Unit tests cover npm-binary and PATH-fallback paths without requiring real bundled binaries.
- [x] AC20-21 — Full test suite and typecheck pass.

## Verification

- `npm install --package-lock-only`
- `npm test` — 332 files / 1450 tests passed
- `npm run typecheck` — clean
- `npx vitest run tests/binary-resolution.test.ts tests/sg-binary-resolution.test.ts tests/nu-binary-resolution.test.ts tests/ptc-error-contract.test.ts tests/ptc-error-sg.test.ts tests/nu-utils.test.ts tests/nu-spawn-error-guidance.test.ts tests/sg.execute-errors.test.ts` — 8 files / 34 tests passed

## Notes for reviewers

- This intentionally keeps the CLI-wrapper architecture; it does not switch to `@ast-grep/napi` or any Nushell SDK/API.
- PATH fallback is for unavailable package/bin entries. Broken-but-present platform packages still surface actionable execution errors and can be repaired or replaced with a system install.
