### PR TITLE
chore: clarify bash tool usage metadata

### DIFF
--- a/src/bash-renderer.ts
+++ b/src/bash-renderer.ts
@@ -5,9 +5,15 @@ import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabe
 
 type BuiltInFactory = (cwd: string) => any;
 
-const BASH_DESCRIPTION = "Run shell commands for tests, builds, git, package managers, and external CLIs.";
+const BASH_DESCRIPTION = "Run tests, builds, git, package managers, and external CLIs; do not use for repo file reading/searching/listing/editing (use read, grep, find, ls, edit, or write).";
+const BASH_PROMPT_SNIPPET = "Bash only for tests/builds/git/pkg/external CLIs. Don't use cat/head/tail, grep/rg, find/ls/tree, sed/awk/perl/python rewrites, or > heredocs/tee for repo files; use read/grep/find/ls/edit/write.";
+const BASH_PROMPT_GUIDELINES = [
+  "Use bash for tests, builds, git, package managers, and external CLIs.",
+  "Do not use bash cat/head/tail/grep/rg/find/ls/tree/sed/awk for repo files.",
+  "Use read/grep/find/ls/edit/write for repo file operations.",
+];
 const BASH_PARAMETERS = Type.Object({
-  command: Type.String({ description: "Shell command to run" }),
+  command: Type.String({ description: "Test/build/git/pkg/external command; not repo file read/search/list/edit." }),
   timeout: Type.Optional(Type.Number({ description: "Timeout seconds" })),
 });
 
@@ -26,6 +32,8 @@ export function registerBashRendererTool(pi: Pick<ExtensionAPI, "registerTool">,
     name: "bash",
     label: "bash",
     description: BASH_DESCRIPTION,
+    promptSnippet: BASH_PROMPT_SNIPPET,
+    promptGuidelines: BASH_PROMPT_GUIDELINES,
     parameters: BASH_PARAMETERS,
     async execute(toolCallId: string, params: any, signal?: AbortSignal, onUpdate?: any, ctx: any = {}) {
       const cwd = ctx?.cwd ?? options.cwd ?? process.cwd();

--- a/tests/bash-renderer-metadata.test.ts
+++ b/tests/bash-renderer-metadata.test.ts
@@ -36,8 +36,14 @@ describe("bash renderer provider-visible metadata", () => {
     });
 
     expect(captured.tool).toBe(tool);
-    expect(tool.description).toBe("Run shell commands for tests, builds, git, package managers, and external CLIs.");
-    expect(tool.parameters.properties.command.description).toBe("Shell command to run");
+    expect(tool.description).toBe("Run tests, builds, git, package managers, and external CLIs; do not use for repo file reading/searching/listing/editing (use read, grep, find, ls, edit, or write).");
+    expect(tool.promptSnippet).toBe("Bash only for tests/builds/git/pkg/external CLIs. Don't use cat/head/tail, grep/rg, find/ls/tree, sed/awk/perl/python rewrites, or > heredocs/tee for repo files; use read/grep/find/ls/edit/write.");
+    expect(tool.promptGuidelines).toEqual([
+      "Use bash for tests, builds, git, package managers, and external CLIs.",
+      "Do not use bash cat/head/tail/grep/rg/find/ls/tree/sed/awk for repo files.",
+      "Use read/grep/find/ls/edit/write for repo file operations.",
+    ]);
+    expect(tool.parameters.properties.command.description).toBe("Test/build/git/pkg/external command; not repo file read/search/list/edit.");
     expect(tool.parameters.properties.timeout.description).toBe("Timeout seconds");
 
     await tool.execute("call-1", { command: "npm test", timeout: 30 }, undefined, undefined, { cwd: "/tmp/project" });

--- a/tests/bash-renderer-wrapper.test.ts
+++ b/tests/bash-renderer-wrapper.test.ts
@@ -30,7 +30,13 @@ describe("bash renderer wrapper", () => {
     const builtIn = { name: "bash", label: "bash", description: "real bash description", parameters: params, execute: async () => ({ content: [{ type: "text", text: "" }] }) };
     let registered: any;
     registerBashRendererTool({ registerTool(def: any) { registered = def; } } as any, { createBuiltInBashTool: () => builtIn, cwd: "/tmp/work" });
-    expect(registered.description).toBe("Run shell commands for tests, builds, git, package managers, and external CLIs.");
-    expect(registered.parameters.properties.command.description).toBe("Shell command to run");
+    expect(registered.description).toBe("Run tests, builds, git, package managers, and external CLIs; do not use for repo file reading/searching/listing/editing (use read, grep, find, ls, edit, or write).");
+    expect(registered.promptSnippet).toBe("Bash only for tests/builds/git/pkg/external CLIs. Don't use cat/head/tail, grep/rg, find/ls/tree, sed/awk/perl/python rewrites, or > heredocs/tee for repo files; use read/grep/find/ls/edit/write.");
+    expect(registered.promptGuidelines).toEqual([
+      "Use bash for tests, builds, git, package managers, and external CLIs.",
+      "Do not use bash cat/head/tail/grep/rg/find/ls/tree/sed/awk for repo files.",
+      "Use read/grep/find/ls/edit/write for repo file operations.",
+    ]);
+    expect(registered.parameters.properties.command.description).toBe("Test/build/git/pkg/external command; not repo file read/search/list/edit.");
   });
 });


### PR DESCRIPTION
## Summary

Clarifies provider-visible bash metadata so agents use bash for command execution, not repository file operations.

## What changed

- Expanded `bash.description` to say repo file read/search/list/edit operations should use native tools.
- Added a compact `promptSnippet` listing common bash anti-patterns (`cat`, `head`/`tail`, `grep`/`rg`, `find`/`ls`/`tree`, `sed`/`awk`, Python/Perl rewrites, heredocs/tee).
- Added `promptGuidelines` for bash usage.
- Tightened the `command` parameter description.
- Updated metadata regression tests.

## Verification

- `npx vitest run tests/bash-renderer-metadata.test.ts tests/bash-renderer-wrapper.test.ts` — 2 files / 4 tests passed
- `npm run typecheck` — clean

## Notes for reviewers

- Runtime execution behavior is unchanged; this only changes provider-visible metadata on the local bash wrapper.
- The intent is to steer repo file operations toward `read`, `grep`, `find`, `ls`, `edit`, and `write` while keeping bash for tests, builds, git, package managers, and external CLIs.
