### PR TITLE
fix: harden ast_search fallback, mapper subprocesses, and diff gutters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+- `ast_search`: when the bundled `@ast-grep/cli` binary cannot be resolved, the PATH fallback now prefers `ast-grep` over `sg`, avoiding the `sg: group 'run' does not exist` error caused by util-linux's setgid `sg` on Linux. Thanks to @Ramblurr for the original investigation in [GH #112](https://github.com/coctostan/pi-hashline-readmap/issues/112) and PR #113.
+- `readmap` mappers (`python`, `go`, `fallback`, `json`, `ctags`) now invoke subprocesses via `execFile` or in-process scanning instead of shell `exec`, so paths containing shell metacharacters (`"`, `` ` ``, `$`, `;`, `|`, `&`, newline) no longer break quoting or produce null maps ([GH #116](https://github.com/coctostan/pi-hashline-readmap/issues/116)). Each migrated mapper now carries a comment forbidding `exec`-with-template to prevent regressions.
+- TUI diff renderer: pending `write`/`edit` previews now include `+`/`-`/space textual markers in the gutter (`▌+ `, `▌- `, `▌  `) in addition to color, so add/remove rows are distinguishable in plain-text transcripts, screenshots, and screen readers ([GH #190](https://github.com/coctostan/pi-hashline-readmap/issues/190)).
+
 ## [0.8.2] - 2026-04-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ It also reduces extension conflict risk by replacing several overlapping tool pa
 - Navigate large files with structural maps and direct symbol reads.
 - Turn search results into edit anchors without an extra read step.
 - Search code structurally with `ast_search` when text search is too brittle.
+- Keep readmap subprocesses safe for paths containing shell metacharacters such as `"` and `$`.
+- Read pending write/edit diffs without color thanks to textual `+`/`-`/space gutter markers.
 - Explore files with agent-oriented `ls`, `find`, and optional `nu` tools.
 - Compress noisy test, build, Git, Docker, linter, package-manager, HTTP, transfer, and generic command output.
 - Use one extension instead of stacking overlapping `read`, `grep`, `edit`, and Bash-output packages.
@@ -58,7 +60,7 @@ Normal npm installs of `pi-hashline-readmap` include npm-managed CLI packages fo
 - `@ast-grep/cli` provides the `sg` binary used by `ast_search`.
 - `nushell` provides the `nu` binary used by the optional `nu` tool.
 
-The extension resolves those bundled binaries first and falls back to `sg` or `nu` on `PATH` when the npm-provided package or bin entry is unavailable. If troubleshooting a broken platform package, a system install can still be useful after repairing/removing the broken npm package or as a fallback in environments without the bundled binary:
+The extension resolves those bundled binaries first. If `@ast-grep/cli` cannot be resolved, `ast_search` falls back to `ast-grep` on `PATH` rather than `sg`, avoiding Linux util-linux `sg` collisions. The optional `nu` tool falls back to `nu` on `PATH` when the bundled `nushell` package or bin entry is unavailable. If troubleshooting a broken platform package, a system install can still be useful after repairing/removing the broken npm package or as a fallback in environments without the bundled binary:
 
 ```bash
 brew install ast-grep          # fallback for ast_search if @ast-grep/cli cannot run

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/cli": "0.42.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {

--- a/src/readmap/mappers/ctags.ts
+++ b/src/readmap/mappers/ctags.ts
@@ -4,8 +4,11 @@
  * Uses universal-ctags when installed to extract symbols.
  * Falls back gracefully when ctags is not available.
  */
-import { exec } from "node:child_process";
-import { stat } from "node:fs/promises";
+// NOTE: This mapper invokes ctags as a subprocess. Use `execFile` (no shell)
+// with argv arrays — never `exec` with template interpolation or shell
+// redirection — so user file paths are not parsed by `/bin/sh`. See GH #116.
+import { execFile } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
 import { promisify } from "node:util";
 
 import type { FileMap, FileSymbol } from "../types.js";
@@ -14,7 +17,7 @@ import { DetailLevel, SymbolKind } from "../enums.js";
 import { detectLanguage } from "../language-detect.js";
 export const MAPPER_VERSION = 1;
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 // Cache ctags availability check
 let ctagsAvailable: boolean | null = null;
@@ -98,13 +101,14 @@ export async function isCtagsAvailable(): Promise<boolean> {
   }
 
   try {
-    const { stdout } = await execAsync("ctags --version 2>&1", {
+    const { stdout, stderr } = await execFileAsync("ctags", ["--version"], {
       timeout: 2000,
     });
+    const banner = `${stdout}\n${stderr}`;
     // Universal Ctags includes "Universal Ctags" in version output
     // Exuberant Ctags also works but is less feature-rich
     ctagsAvailable =
-      stdout.includes("Universal Ctags") || stdout.includes("Exuberant Ctags");
+      banner.includes("Universal Ctags") || banner.includes("Exuberant Ctags");
     return ctagsAvailable;
   } catch {
     ctagsAvailable = false;
@@ -171,6 +175,8 @@ export async function ctagsMapper(
 
     const stats = await stat(filePath);
     const totalBytes = stats.size;
+    const fileText = await readFile(filePath, "utf8");
+    const totalLines = fileText.split("\n").length - 1;
 
     if (signal?.aborted) {
       return null;
@@ -179,11 +185,9 @@ export async function ctagsMapper(
     // Run ctags with JSON output and line numbers
     // --output-format=json requires Universal Ctags 5.9+
     // --fields=+n ensures line numbers are included in JSON output
-    const cmd = `ctags --output-format=json --fields=+n -f - "${filePath}" 2>/dev/null`;
-
     let stdout: string;
     try {
-      ({ stdout } = await execAsync(cmd, {
+      ({ stdout } = await execFileAsync("ctags", ["--output-format=json", "--fields=+n", "-f", "-", filePath], {
         signal,
         timeout: 10_000,
         maxBuffer: 1024 * 1024,
@@ -197,11 +201,6 @@ export async function ctagsMapper(
       return null;
     }
 
-    // Count lines
-    const { stdout: wcOutput } = await execAsync(`wc -l < "${filePath}"`, {
-      signal,
-    });
-    const totalLines = Number.parseInt(wcOutput.trim(), 10) || 0;
 
     // Parse output
     const entries = parseCtagsOutput(stdout);
@@ -259,11 +258,11 @@ async function ctagsMapperLegacy(
   try {
     const stats = await stat(filePath);
     const totalBytes = stats.size;
+    const fileText = await readFile(filePath, "utf8");
+    const totalLines = fileText.split("\n").length - 1;
 
     // Run ctags with line numbers
-    const cmd = `ctags --excmd=number -f - "${filePath}" 2>/dev/null`;
-
-    const { stdout } = await execAsync(cmd, {
+    const { stdout } = await execFileAsync("ctags", ["--excmd=number", "-f", "-", filePath], {
       signal,
       timeout: 10_000,
       maxBuffer: 1024 * 1024,
@@ -273,11 +272,6 @@ async function ctagsMapperLegacy(
       return null;
     }
 
-    // Count lines
-    const { stdout: wcOutput } = await execAsync(`wc -l < "${filePath}"`, {
-      signal,
-    });
-    const totalLines = Number.parseInt(wcOutput.trim(), 10) || 0;
 
     // Parse traditional format
     const entries: CtagsEntry[] = [];

--- a/src/readmap/mappers/fallback.ts
+++ b/src/readmap/mappers/fallback.ts
@@ -1,14 +1,13 @@
-import { exec } from "node:child_process";
-import { stat } from "node:fs/promises";
-import { promisify } from "node:util";
+// NOTE: This mapper scans user-provided file paths. Keep the implementation
+// in-process; do not use `exec` with template interpolation for grep/wc because
+// shell metacharacters in paths would be parsed by `/bin/sh`. See GH #116.
+import { readFile, stat } from "node:fs/promises";
 
 import type { FileMap, FileSymbol } from "../types.js";
 
 import { DetailLevel, SymbolKind } from "../enums.js";
 import { detectLanguage } from "../language-detect.js";
 export const MAPPER_VERSION = 1;
-
-const execAsync = promisify(exec);
 
 /**
  * Patterns to grep for common structural elements.
@@ -80,51 +79,29 @@ export async function fallbackMapper(
     const stats = await stat(filePath);
     const totalBytes = stats.size;
 
-    // Count lines
-    const { stdout: wcOutput } = await execAsync(`wc -l < "${filePath}"`, {
-      signal,
-    });
-    const totalLines = Number.parseInt(wcOutput.trim(), 10) || 0;
+    // Count lines in JS (matches `wc -l` semantics).
+    const fileText = await readFile(filePath, "utf8");
+    const lines = fileText.split("\n");
+    const totalLines = lines.length - 1;
 
-    // Build grep pattern
-    const combinedPattern = PATTERNS.map((p) => p.pattern).join("\\|");
+    const matches: GrepMatch[] = [];
+    for (const [index, rawLine] of lines.entries()) {
+      if (signal?.aborted) return null;
+      const content = rawLine.trim();
+      if (!content) continue;
 
-    // Run grep
-    let matches: GrepMatch[] = [];
-    try {
-      const { stdout } = await execAsync(
-        `grep -n "${combinedPattern}" "${filePath}" | head -500`,
-        { signal, timeout: 5000 }
-      );
-
-      // Parse grep output
-      for (const line of stdout.split("\n")) {
-        if (!line.trim()) {
-          continue;
+      let matchedKind: SymbolKind | null = null;
+      for (const p of PATTERNS) {
+        if (new RegExp(p.pattern, "i").test(content)) {
+          matchedKind = p.kind;
+          break;
         }
-
-        const colonIndex = line.indexOf(":");
-        if (colonIndex === -1) {
-          continue;
-        }
-
-        const lineNumber = Number.parseInt(line.slice(0, colonIndex), 10);
-        const content = line.slice(colonIndex + 1).trim();
-
-        // Determine kind from pattern match
-        let matchedKind: SymbolKind = SymbolKind.Unknown;
-        for (const p of PATTERNS) {
-          if (new RegExp(p.pattern, "i").test(content)) {
-            matchedKind = p.kind;
-            break;
-          }
-        }
-
-        matches.push({ lineNumber, content, kind: matchedKind });
       }
-    } catch {
-      // grep returns exit code 1 when no matches, which throws
-      matches = [];
+
+      if (matchedKind !== null) {
+        matches.push({ lineNumber: index + 1, content, kind: matchedKind });
+        if (matches.length >= 500) break;
+      }
     }
 
     // Convert to symbols

--- a/src/readmap/mappers/go.ts
+++ b/src/readmap/mappers/go.ts
@@ -1,6 +1,10 @@
-import { exec } from "node:child_process";
+// NOTE: This mapper invokes a Go helper binary as a subprocess. Use
+// `execFile` (no shell) with an args array — never `exec` with template
+// interpolation — so paths containing shell metacharacters are passed safely as
+// argv entries instead of being parsed by `/bin/sh`. See GH #116.
+import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
-import { stat } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -10,10 +14,10 @@ import type { FileMap, FileSymbol } from "../types.js";
 import { DetailLevel, SymbolKind } from "../enums.js";
 export const MAPPER_VERSION = 1;
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const SCRIPTS_DIR = join(__dirname, "../../scripts");
+const SCRIPTS_DIR = join(__dirname, "../../../scripts");
 const GO_SOURCE = join(SCRIPTS_DIR, "go_outline.go");
 const GO_BINARY = join(SCRIPTS_DIR, "go_outline");
 
@@ -45,7 +49,7 @@ let binaryAvailable = false;
  */
 async function hasGo(): Promise<boolean> {
   try {
-    await execAsync("go version", { timeout: 5000 });
+    await execFileAsync("go", ["version"], { timeout: 5000 });
     return true;
   } catch {
     return false;
@@ -83,7 +87,7 @@ async function ensureBinary(): Promise<boolean> {
 
   try {
     // Compile the binary
-    await execAsync(`go build -o "${GO_BINARY}" "${GO_SOURCE}"`, {
+    await execFileAsync("go", ["build", "-o", GO_BINARY, GO_SOURCE], {
       timeout: 30_000,
       cwd: SCRIPTS_DIR,
     });
@@ -181,14 +185,12 @@ export async function goMapper(
     const stats = await stat(filePath);
     const totalBytes = stats.size;
 
-    // Count lines
-    const { stdout: wcOutput } = await execAsync(`wc -l < "${filePath}"`, {
-      signal,
-    });
-    const totalLines = Number.parseInt(wcOutput.trim(), 10) || 0;
+    // Count lines in JS (matches `wc -l` semantics).
+    const fileText = await readFile(filePath, "utf8");
+    const totalLines = fileText.split("\n").length - 1;
 
-    // Run Go outline script
-    const { stdout, stderr } = await execAsync(`"${GO_BINARY}" "${filePath}"`, {
+    // Run Go outline script via execFile (no shell).
+    const { stdout, stderr } = await execFileAsync(GO_BINARY, [filePath], {
       signal,
       timeout: 10_000,
     });

--- a/src/readmap/mappers/json.ts
+++ b/src/readmap/mappers/json.ts
@@ -1,5 +1,8 @@
-import { exec } from "node:child_process";
-import { stat } from "node:fs/promises";
+// NOTE: This mapper invokes jq as a subprocess. Use `execFile` (no shell) with
+// an args array — never `exec` with template interpolation — so paths containing
+// shell metacharacters are passed safely as argv entries. See GH #116.
+import { execFile } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
 import { promisify } from "node:util";
 
 import type { FileMap, FileSymbol } from "../types.js";
@@ -7,7 +10,7 @@ import type { FileMap, FileSymbol } from "../types.js";
 import { DetailLevel, SymbolKind } from "../enums.js";
 export const MAPPER_VERSION = 1;
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 /**
  * jq script to extract JSON schema structure.
@@ -116,7 +119,7 @@ function schemaToSymbols(
  */
 async function hasJq(): Promise<boolean> {
   try {
-    await execAsync("jq --version", { timeout: 5000 });
+    await execFileAsync("jq", ["--version"], { timeout: 5000 });
     return true;
   } catch {
     return false;
@@ -140,21 +143,15 @@ export async function jsonMapper(
     const stats = await stat(filePath);
     const totalBytes = stats.size;
 
-    // Count lines
-    const { stdout: wcOutput } = await execAsync(`wc -l < "${filePath}"`, {
-      signal,
-    });
-    const totalLines = Number.parseInt(wcOutput.trim(), 10) || 1;
+    // Preserve the previous minimum-one-line behavior.
+    const fileText = await readFile(filePath, "utf8");
+    const totalLines = Math.max(1, fileText.split("\n").length - 1);
 
-    // Run jq to extract schema
-    const { stdout, stderr } = await execAsync(
-      `jq '${JQ_SCHEMA_SCRIPT.replaceAll("'", "'\\''")}' "${filePath}"`,
-      {
-        signal,
-        timeout: 10_000,
-        maxBuffer: 1024 * 1024, // 1MB
-      }
-    );
+    const { stdout, stderr } = await execFileAsync("jq", [JQ_SCHEMA_SCRIPT, filePath], {
+      signal,
+      timeout: 10_000,
+      maxBuffer: 1024 * 1024,
+    });
 
     if (!stdout) {
       if (stderr) {

--- a/src/readmap/mappers/python.ts
+++ b/src/readmap/mappers/python.ts
@@ -1,5 +1,9 @@
-import { exec } from "node:child_process";
-import { stat } from "node:fs/promises";
+// NOTE: This mapper invokes a Python helper script as a subprocess. Use
+// `execFile` (no shell) with an args array — never `exec` with template
+// interpolation — so paths containing shell metacharacters are passed safely as
+// argv entries instead of being parsed by `/bin/sh`. See GH #116.
+import { execFile } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -9,10 +13,10 @@ import type { FileMap, FileSymbol } from "../types.js";
 import { DetailLevel, SymbolKind } from "../enums.js";
 export const MAPPER_VERSION = 1;
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const SCRIPT_PATH = join(__dirname, "../../scripts/python_outline.py");
+const SCRIPT_PATH = join(__dirname, "../../../scripts/python_outline.py");
 
 interface PythonSymbol {
   name: string;
@@ -98,21 +102,17 @@ export async function pythonMapper(
     const stats = await stat(filePath);
     const totalBytes = stats.size;
 
-    // Count lines
-    const { stdout: wcOutput } = await execAsync(`wc -l < "${filePath}"`, {
-      signal,
-    });
-    const totalLines = Number.parseInt(wcOutput.trim(), 10) || 0;
+    // Count lines in JS — matches `wc -l` semantics for newline-terminated and
+    // unterminated tails.
+    const fileText = await readFile(filePath, "utf8");
+    const totalLines = fileText.split("\n").length - 1;
 
-    // Run Python script
-    const { stdout, stderr } = await execAsync(
-      `python3 "${SCRIPT_PATH}" "${filePath}"`,
-      {
-        signal,
-        timeout: 10_000,
-        maxBuffer: 5 * 1024 * 1024, // 5MB
-      }
-    );
+    // Run Python script via execFile (no shell).
+    const { stdout, stderr } = await execFileAsync("python3", [SCRIPT_PATH, filePath], {
+      signal,
+      timeout: 10_000,
+      maxBuffer: 5 * 1024 * 1024,
+    });
 
     if (stderr && !stdout) {
       console.error(`Python mapper stderr: ${stderr}`);

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -124,7 +124,11 @@ function execFileText(
  * Runs `sg --version` synchronously with a 3-second timeout.
  */
 export function resolveSgBinary(): string {
-  return resolveBundledBin("@ast-grep/cli", "sg", "sg");
+  // PATH fallback name. We intentionally prefer `ast-grep` over `sg` because on
+  // Linux `sg` collides with util-linux's setgid helper (see GH #112). The
+  // bundled `@ast-grep/cli` package still resolves by its `sg` bin entry above;
+  // only the PATH fallback string changes.
+  return resolveBundledBin("@ast-grep/cli", "sg", "ast-grep");
 }
 
 export function isSgAvailable(): boolean {

--- a/src/tui-diff-renderer.ts
+++ b/src/tui-diff-renderer.ts
@@ -15,6 +15,7 @@ function header(data: DiffData, mode: TuiDiffMode, width: number): string {
   return visibleWidth(full) <= width ? full : clampLineToWidth(compactHeader(data), width);
 }
 function lineNo(entry: DiffEntry): string { return String(entry.kind === "add" ? entry.newLine : entry.kind === "remove" ? entry.oldLine : entry.kind === "context" ? entry.newLine : ""); }
+function gutterMarker(entry: DiffEntry): string { return entry.kind === "add" ? "+" : entry.kind === "remove" ? "-" : " "; }
 function textOf(entry: DiffEntry): string { return "text" in entry ? entry.text : ""; }
 function tint(theme: RendererTheme, entry: DiffEntry, text: string): string { return entry.kind === "add" ? theme.fg("success", text) : entry.kind === "remove" ? theme.fg("error", text) : theme.fg("toolOutput", text); }
 function spans(theme: RendererTheme, spans: DiffSpan[] | undefined, fallback: string): string { return spans?.map((s) => s.kind === "add" ? theme.fg("success", s.text) : s.kind === "remove" ? theme.fg("error", s.text) : s.text).join("") ?? fallback; }
@@ -23,15 +24,15 @@ function inlineText(input: RenderTuiDiffInput, index: number, entry: DiffEntry):
   if (!pair) return textOf(entry);
   return entry.kind === "remove" ? spans(input.theme, pair.removeSpans, textOf(entry)) : entry.kind === "add" ? spans(input.theme, pair.addSpans, textOf(entry)) : textOf(entry);
 }
-function unifiedRows(input: RenderTuiDiffInput): string[] { return input.diffData.entries.map((e, i) => e.kind === "meta" ? null : tint(input.theme, e, `▌ ${lineNo(e)} │ ${inlineText(input, i, e)}`)).filter((row): row is string => row !== null); }
-function compactRows(input: RenderTuiDiffInput): string[] { return input.diffData.entries.map((e, i) => e.kind === "add" || e.kind === "remove" ? tint(input.theme, e, `▌ ${lineNo(e)} ${inlineText(input, i, e)}`) : null).filter((row): row is string => row !== null); }
+function unifiedRows(input: RenderTuiDiffInput): string[] { return input.diffData.entries.map((e, i) => e.kind === "meta" ? null : tint(input.theme, e, `▌${gutterMarker(e)} ${lineNo(e)} │ ${inlineText(input, i, e)}`)).filter((row): row is string => row !== null); }
+function compactRows(input: RenderTuiDiffInput): string[] { return input.diffData.entries.map((e, i) => e.kind === "add" || e.kind === "remove" ? tint(input.theme, e, `▌${gutterMarker(e)} ${lineNo(e)} ${inlineText(input, i, e)}`) : null).filter((row): row is string => row !== null); }
 function splitRows(input: RenderTuiDiffInput, width: number): string[] {
   const pane = Math.max(10, Math.floor((width - 3) / 2));
   const rows = [`${"old".padEnd(pane)} │ new`];
   for (const [i, e] of input.diffData.entries.entries()) {
-    if (e.kind === "remove") rows.push(`${clampLineToWidth(`▌ ${e.oldLine} │ ${inlineText(input, i, e)}`, pane)} │ ${""}`);
-    else if (e.kind === "add") rows.push(`${"".padEnd(pane)} │ ${clampLineToWidth(`▌ ${e.newLine} │ ${inlineText(input, i, e)}`, pane)}`);
-    else if (e.kind === "context") rows.push(`${clampLineToWidth(`  ${e.oldLine} │ ${e.text}`, pane)} │ ${clampLineToWidth(`  ${e.newLine} │ ${e.text}`, pane)}`);
+    if (e.kind === "remove") rows.push(`${clampLineToWidth(`▌- ${e.oldLine} │ ${inlineText(input, i, e)}`, pane)} │ ${""}`);
+    else if (e.kind === "add") rows.push(`${"".padEnd(pane)} │ ${clampLineToWidth(`▌+ ${e.newLine} │ ${inlineText(input, i, e)}`, pane)}`);
+    else if (e.kind === "context") rows.push(`${clampLineToWidth(`▌  ${e.oldLine} │ ${e.text}`, pane)} │ ${clampLineToWidth(`▌  ${e.newLine} │ ${e.text}`, pane)}`);
   }
   return rows;
 }

--- a/tests/edit-pending-diff-render-success.test.ts
+++ b/tests/edit-pending-diff-render-success.test.ts
@@ -36,6 +36,6 @@ describe("edit renderCall pending diff preview", () => {
 
 		expect(rendered).toContain("pending edit");
 		expect(rendered).toContain("↳ diff +1 -1");
-		expect(rendered).toContain("▌ 1 │ const unique = 2;");
+		expect(rendered).toContain("▌+ 1 │ const unique = 2;");
 	});
 });

--- a/tests/edit-render-tui.test.ts
+++ b/tests/edit-render-tui.test.ts
@@ -15,7 +15,7 @@ describe("edit TUI renderer", () => {
     const rendered = textOf(tool().renderResult(result, { expanded: true, width: 80 }, theme, { expanded: true, width: 80 }));
     expect(rendered.split("\n")[0]).toBe("↳ edited +1 -1 • semantic");
     expect(rendered).toContain("↳ diff +1 -1 • 1 hunk • 1 file • unified");
-    expect(rendered).toContain("▌ 2 │ TWO");
+    expect(rendered).toContain("▌+ 2 │ TWO");
     expect(JSON.stringify(result.details)).toBe(before);
   });
 

--- a/tests/package-version.test.ts
+++ b/tests/package-version.test.ts
@@ -5,9 +5,9 @@ const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
 const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
 
 describe("package version", () => {
-  it("is bumped for the compact provider-visible metadata release", () => {
-    expect(packageJson.version).toBe("0.8.10");
-    expect(packageLock.version).toBe("0.8.10");
-    expect(packageLock.packages[""].version).toBe("0.8.10");
+  it("is bumped for the triage cleanup bugfix release", () => {
+    expect(packageJson.version).toBe("0.8.11");
+    expect(packageLock.version).toBe("0.8.11");
+    expect(packageLock.packages[""].version).toBe("0.8.11");
   });
 });

--- a/tests/readmap-mappers-ctags-quoting.test.ts
+++ b/tests/readmap-mappers-ctags-quoting.test.ts
@@ -1,0 +1,59 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { readFile, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { ctagsMapper, resetCtagsCache } from "../src/readmap/mappers/ctags.js";
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function ctagsAvailable(): Promise<boolean> {
+  try {
+    await execFileAsync("ctags", ["--version"], { timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("ctagsMapper subprocess safety (GH #116)", () => {
+  let dir = "";
+  let filePath = "";
+  let available = false;
+
+  beforeAll(async () => {
+    available = await ctagsAvailable();
+    if (!available) return;
+    dir = await mkdtemp(join(tmpdir(), "ctagsmap-quoting-"));
+    filePath = join(dir, 'has"quote$dollar.ts');
+    await writeFile(filePath, "export function hello() {\n  return 1;\n}\n", "utf8");
+  });
+
+  afterAll(async () => {
+    resetCtagsCache();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  it("does not import shell exec", async () => {
+    const text = await readFile(resolve(__dirname, "../src/readmap/mappers/ctags.ts"), "utf8");
+    expect(text).not.toMatch(/import\s*\{[^}]*\bexec\b[^}]*\}\s*from\s*["']node:child_process["']/s);
+  });
+
+  it("does not contain shell redirection or wc shell commands", async () => {
+    const text = await readFile(resolve(__dirname, "../src/readmap/mappers/ctags.ts"), "utf8");
+    expect(text).not.toContain("2>/dev/null");
+    expect(text).not.toContain("wc -l <");
+  });
+
+  it("returns a non-null FileMap for quoted path when ctags is installed", async () => {
+    if (!available) return;
+    resetCtagsCache();
+    const fileMap = await ctagsMapper(filePath);
+    expect(fileMap).not.toBeNull();
+    const names = (fileMap?.symbols ?? []).map((s) => s.name);
+    expect(names).toContain("hello");
+  });
+});

--- a/tests/readmap-mappers-fallback-quoting.test.ts
+++ b/tests/readmap-mappers-fallback-quoting.test.ts
@@ -1,0 +1,27 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fallbackMapper } from "../src/readmap/mappers/fallback.js";
+
+describe("fallbackMapper with shell metacharacters in path (GH #116)", () => {
+  let dir: string;
+  let filePath: string;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), "fallback-quoting-"));
+    filePath = join(dir, 'has"quote$dollar.py');
+    await writeFile(filePath, "def hello():\n    return 1\n", "utf8");
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns a non-null FileMap with the hello symbol", async () => {
+    const fileMap = await fallbackMapper(filePath);
+    expect(fileMap).not.toBeNull();
+    const names = (fileMap?.symbols ?? []).map((s) => s.name);
+    expect(names).toContain("hello");
+  });
+});

--- a/tests/readmap-mappers-go-quoting.test.ts
+++ b/tests/readmap-mappers-go-quoting.test.ts
@@ -1,0 +1,51 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { readFile, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { goMapper } from "../src/readmap/mappers/go.js";
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function goAvailable(): Promise<boolean> {
+  try {
+    await execFileAsync("go", ["version"], { timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("goMapper subprocess safety (GH #116)", () => {
+  let dir = "";
+  let filePath = "";
+  let available = false;
+
+  beforeAll(async () => {
+    available = await goAvailable();
+    if (!available) return;
+    dir = await mkdtemp(join(tmpdir(), "gomap-quoting-"));
+    filePath = join(dir, 'has"quote$dollar.go');
+    await writeFile(filePath, "package main\n\nfunc Hello() int {\n\treturn 1\n}\n", "utf8");
+  });
+
+  afterAll(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  it("does not import shell exec", async () => {
+    const text = await readFile(resolve(__dirname, "../src/readmap/mappers/go.ts"), "utf8");
+    expect(text).not.toMatch(/import\s*\{[^}]*\bexec\b[^}]*\}\s*from\s*["']node:child_process["']/s);
+  });
+
+  it("returns a non-null FileMap with the Hello symbol when Go is installed", async () => {
+    if (!available) return;
+    const fileMap = await goMapper(filePath);
+    expect(fileMap).not.toBeNull();
+    const names = (fileMap?.symbols ?? []).map((s) => s.name);
+    expect(names).toContain("Hello");
+  });
+});

--- a/tests/readmap-mappers-json-quoting.test.ts
+++ b/tests/readmap-mappers-json-quoting.test.ts
@@ -1,0 +1,51 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { readFile, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { jsonMapper } from "../src/readmap/mappers/json.js";
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function jqAvailable(): Promise<boolean> {
+  try {
+    await execFileAsync("jq", ["--version"], { timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("jsonMapper subprocess safety (GH #116)", () => {
+  let dir = "";
+  let filePath = "";
+  let available = false;
+
+  beforeAll(async () => {
+    available = await jqAvailable();
+    if (!available) return;
+    dir = await mkdtemp(join(tmpdir(), "jsonmap-quoting-"));
+    filePath = join(dir, 'has"quote$dollar.json');
+    await writeFile(filePath, '{"hello": {"enabled": true}}\n', "utf8");
+  });
+
+  afterAll(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  it("does not import shell exec", async () => {
+    const text = await readFile(resolve(__dirname, "../src/readmap/mappers/json.ts"), "utf8");
+    expect(text).not.toMatch(/import\s*\{[^}]*\bexec\b[^}]*\}\s*from\s*["']node:child_process["']/s);
+  });
+
+  it("returns a non-null FileMap for quoted JSON path when jq is installed", async () => {
+    if (!available) return;
+    const fileMap = await jsonMapper(filePath);
+    expect(fileMap).not.toBeNull();
+    const names = (fileMap?.symbols ?? []).map((s) => s.name);
+    expect(names.some((name) => name.includes("hello"))).toBe(true);
+  });
+});

--- a/tests/readmap-mappers-python-quoting.test.ts
+++ b/tests/readmap-mappers-python-quoting.test.ts
@@ -1,0 +1,27 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pythonMapper } from "../src/readmap/mappers/python.js";
+
+describe("pythonMapper with shell metacharacters in path (GH #116)", () => {
+  let dir: string;
+  let filePath: string;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), "pymap-quoting-"));
+    filePath = join(dir, 'has"quote$dollar.py');
+    await writeFile(filePath, "def hello():\n    return 1\n", "utf8");
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns a non-null FileMap with the hello symbol", async () => {
+    const fileMap = await pythonMapper(filePath);
+    expect(fileMap).not.toBeNull();
+    const names = (fileMap?.symbols ?? []).map((s) => s.name);
+    expect(names).toContain("hello");
+  });
+});

--- a/tests/sg-binary-resolution.test.ts
+++ b/tests/sg-binary-resolution.test.ts
@@ -27,7 +27,10 @@ describe("ast_search binary resolution", () => {
 
   it("executes the npm-provided sg binary when it resolves", async () => {
     const resolveBundledBin = vi.fn(() => "/mock/node_modules/@ast-grep/cli/bin/sg");
-    vi.doMock("../src/binary-resolution.js", () => ({ resolveBundledBin, executableCommand: (command: string) => ({ command, argsPrefix: [] }) }));
+    vi.doMock("../src/binary-resolution.js", () => ({
+      resolveBundledBin,
+      executableCommand: (command: string) => ({ command, argsPrefix: [] }),
+    }));
 
     const tool = await captureSgTool();
     vi.mocked(cp.execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
@@ -37,13 +40,16 @@ describe("ast_search binary resolution", () => {
 
     await tool.execute("tc", { pattern: "console.log($$$ARGS)" }, new AbortController().signal, () => {}, { cwd: process.cwd() });
 
-    expect(resolveBundledBin).toHaveBeenCalledWith("@ast-grep/cli", "sg", "sg");
+    expect(resolveBundledBin).toHaveBeenCalledWith("@ast-grep/cli", "sg", "ast-grep");
     expect(vi.mocked(cp.execFile).mock.calls[0][0]).toBe("/mock/node_modules/@ast-grep/cli/bin/sg");
   });
 
-  it("executes PATH sg when the npm-provided binary is unavailable", async () => {
+  it("prefers PATH `ast-grep` over Linux `sg` when the bundled binary is unavailable", async () => {
     const resolveBundledBin = vi.fn((_packageName: string, _binName: string, fallbackCommand: string) => fallbackCommand);
-    vi.doMock("../src/binary-resolution.js", () => ({ resolveBundledBin, executableCommand: (command: string) => ({ command, argsPrefix: [] }) }));
+    vi.doMock("../src/binary-resolution.js", () => ({
+      resolveBundledBin,
+      executableCommand: (command: string) => ({ command, argsPrefix: [] }),
+    }));
 
     const tool = await captureSgTool();
     vi.mocked(cp.execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
@@ -53,7 +59,7 @@ describe("ast_search binary resolution", () => {
 
     await tool.execute("tc", { pattern: "console.log($$$ARGS)" }, new AbortController().signal, () => {}, { cwd: process.cwd() });
 
-    expect(resolveBundledBin).toHaveBeenCalledWith("@ast-grep/cli", "sg", "sg");
-    expect(vi.mocked(cp.execFile).mock.calls[0][0]).toBe("sg");
+    expect(resolveBundledBin).toHaveBeenCalledWith("@ast-grep/cli", "sg", "ast-grep");
+    expect(vi.mocked(cp.execFile).mock.calls[0][0]).toBe("ast-grep");
   });
 });

--- a/tests/tui-diff-renderer.test.ts
+++ b/tests/tui-diff-renderer.test.ts
@@ -11,6 +11,29 @@ const diffData: DiffData = { version: 1, stats: { added: 2, removed: 1, context:
   { kind: "add", newLine: 3, text: "three" },
 ], inlineDiffs: [{ removeLineIndex: 1, addLineIndex: 2, removeSpans: [{ kind: "remove", text: "two" }], addSpans: [{ kind: "add", text: "TWO" }] }] };
 
+const identityTheme = { fg: (_kind: string, text: string) => text } as any;
+
+const markerDiffData: DiffData = {
+  version: 1,
+  entries: [
+    { kind: "remove", oldLine: 1, text: "one" },
+    { kind: "add", newLine: 1, text: "ONE" },
+    { kind: "context", oldLine: 2, newLine: 2, text: "two" },
+  ],
+  stats: { added: 1, removed: 1, context: 1 },
+  blockRanges: [{ kind: "add", startLine: 1, endLine: 2 }],
+};
+
+const identicalSameLineDiffData: DiffData = {
+  version: 1,
+  entries: [
+    { kind: "remove", oldLine: 1, text: "same" },
+    { kind: "add", newLine: 1, text: "same" },
+  ],
+  stats: { added: 1, removed: 1, context: 0 },
+  blockRanges: [{ kind: "add", startLine: 1, endLine: 1 }],
+};
+
 describe("renderTuiDiff", () => {
   it("renders unified, compact, split, and summary modes within width", () => {
     const wide = renderTuiDiff({ diffData, width: 120, theme, expanded: true });
@@ -20,7 +43,7 @@ describe("renderTuiDiff", () => {
     const normal = renderTuiDiff({ diffData, width: 80, theme, expanded: true });
     expect(normal.mode).toBe("unified");
     expect(normal.lines[0]).toBe("↳ diff +2 -1 • 1 hunk • 1 file • unified");
-    expect(normal.lines.join("\n")).toContain("▌ 2 │ TWO");
+    expect(normal.lines.join("\n")).toContain("▌+ 2 │ TWO");
     const narrow = renderTuiDiff({ diffData, width: 28, theme, expanded: true });
     expect(narrow.mode).toBe("compact");
     expect(narrow.lines[0]).toBe("↳ diff +2 -1");
@@ -28,6 +51,37 @@ describe("renderTuiDiff", () => {
     expect(tiny.mode).toBe("summary");
     expect(tiny.lines).toEqual(["↳ diff +2"]);
     for (const rendered of [wide, normal, narrow, tiny]) expect(rendered.lines.every((line) => visibleWidth(line) <= rendered.width)).toBe(true);
+  });
+
+  it("emits textual gutter markers without relying on color", () => {
+    const normal = renderTuiDiff({ diffData: markerDiffData, width: 80, theme: identityTheme, expanded: true });
+    const text = normal.lines.join("\n");
+    expect(text).toContain("▌- 1 │ one");
+    expect(text).toContain("▌+ 1 │ ONE");
+    expect(text).toContain("▌  2 │ two");
+  });
+
+  it("same-line add and remove rows with identical text are distinct when color is stripped", () => {
+    const normal = renderTuiDiff({ diffData: identicalSameLineDiffData, width: 80, theme: identityTheme, expanded: true });
+    const bodyRows = normal.lines.filter((line) => line.includes("same"));
+    expect(bodyRows).toHaveLength(2);
+    expect(new Set(bodyRows).size).toBe(2);
+    expect(bodyRows[0]?.startsWith("▌- ")).toBe(true);
+    expect(bodyRows[1]?.startsWith("▌+ ")).toBe(true);
+  });
+
+  it("compact and split modes also emit textual gutter markers", () => {
+    const compact = renderTuiDiff({ diffData: markerDiffData, width: 28, theme: identityTheme, expanded: true });
+    expect(compact.mode).toBe("compact");
+    expect(compact.lines.join("\n")).toContain("▌- 1 one");
+    expect(compact.lines.join("\n")).toContain("▌+ 1 ONE");
+
+    const split = renderTuiDiff({ diffData: markerDiffData, width: 120, theme: identityTheme, expanded: true });
+    expect(split.mode).toBe("split");
+    const splitText = split.lines.join("\n");
+    expect(splitText).toContain("▌- 1 │ one");
+    expect(splitText).toContain("▌+ 1 │ ONE");
+    expect(splitText).toContain("▌  2 │ two");
   });
 
   it("renders collapsed progressive hidden-content hints", () => {

--- a/tests/write-pending-diff-render-success.test.ts
+++ b/tests/write-pending-diff-render-success.test.ts
@@ -32,7 +32,7 @@ describe("write renderCall pending diff preview", () => {
 
 		expect(text).toContain("↳ pending overwrite");
 		expect(text).toContain("↳ diff +1 -1");
-		expect(text).toContain("▌ 1 │ old value");
-		expect(text).toContain("▌ 1 │ new value");
+		expect(text).toContain("▌- 1 │ old value");
+		expect(text).toContain("▌+ 1 │ new value");
 	});
 });

--- a/tests/write-render-tui.test.ts
+++ b/tests/write-render-tui.test.ts
@@ -18,7 +18,7 @@ describe("write TUI renderer", () => {
     const rendered = textOf(t.renderResult(created, { expanded: true, width: 80 }, theme, { expanded: true, width: 80 }));
     expect(rendered.split("\n")[0]).toBe("↳ created");
     expect(rendered).toContain("↳ diff +3 -0 • 1 hunk • 1 file • unified");
-    expect(rendered).toContain("▌ 1 │ one");
+    expect(rendered).toContain("▌+ 1 │ one");
     expect(JSON.stringify(created.details)).toBe(before);
 
     const overwritten: any = { content: created.content, details: { ...created.details, writeState: "overwritten" } };


### PR DESCRIPTION
Closes #191.

## Summary

Fixes three triaged reliability/accessibility bugs:

- `ast_search` now falls back to `ast-grep` instead of PATH `sg` when the bundled `@ast-grep/cli` binary cannot be resolved, avoiding Linux util-linux `sg` collisions. Thanks to @Ramblurr for the original GH #112 investigation.
- Readmap subprocess mappers now avoid shell `exec` interpolation, so paths containing shell metacharacters such as `"`, `$`, `;`, `|`, `&`, and newlines no longer break mapper output.
- TUI diff previews now include textual gutter markers (`▌+ `, `▌- `, `▌  `) so add/remove/context rows remain distinguishable without color.

This also bumps the package version from `0.8.10` to `0.8.11` in both `package.json` and `package-lock.json` and updates README guidance for the new fallback/safety behavior.

## What changed

- Updated `resolveSgBinary()` to use `ast-grep` as the PATH fallback while preserving bundled `@ast-grep/cli` resolution.
- Migrated Python, Go, JSON, and ctags mapper subprocess calls to `execFile` with argv arrays.
- Replaced fallback mapper shell grep/head scanning with in-process scanning.
- Replaced mapper `wc -l < file` shell calls with JS line counting.
- Added regression tests for quoted/metacharacter paths across affected mappers.
- Added identity-theme diff renderer tests for color-stripped gutter markers.
- Updated write/edit render tests for the new marker format.
- Added CHANGELOG credit for @Ramblurr and GH #112.
- Updated README docs and package version tests for `0.8.11`.

## Verification

- `npm run typecheck` — clean
- `npm test` — 337 files / 1462 tests passed
- Focused regression suite — 11 files / 26 tests passed

## Notes for reviewers

- The ast-grep fix intentionally uses the minimum accepted fallback change and does not add PATH probing.
- Mapper `MAPPER_VERSION` constants remain `1` because output shape is unchanged.
- ctags quoted-path runtime coverage depends on Universal/Exuberant ctags being installed; structural ctags safety assertions run deterministically.
