### PR TITLE
fix(tui): clean up edit/write rendering (wrap, collapse, gutter)

### DIFF
--- a/src/edit.ts
+++ b/src/edit.ts
@@ -19,19 +19,16 @@ import { replaceSymbol } from "./replace-symbol.js";
 import { buildEditPreviewKey, buildPendingEditPreviewData, resolvePendingDiffPreview, type PendingDiffPreviewResult } from "./pending-diff-preview.js";
 import { buildDiffData, type DiffBlockRange } from "./diff-data.js";
 import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, summaryLine } from "./tui-render-utils.js";
-import { renderTuiDiff } from "./tui-diff-renderer.js";
+import { DiffPreviewComponent } from "./tui-diff-component.js";
 import { buildContextHygieneMetadata, buildFileResource, type ContextHygieneMetadata } from "./context-hygiene.js";
 
 const EDIT_PENDING_PREVIEW_STATE_KEY = "hashline-edit-pending-preview";
 
-function formatPendingPreviewText(summary: string, preview: PendingDiffPreviewResult | undefined, theme: any, width: number | undefined, expanded: boolean): string {
-	if (!preview || preview.type !== "ok") return clampLinesToWidth(summary.split("\n"), width).join("\n");
-  const diffWidth = width ?? 80;
-  const diffData = buildDiffData({ path: preview.data.filePath, oldContent: preview.data.previousContent, newContent: preview.data.nextContent, diff: preview.data.diff });
-  const diffSummary = `${summary}\n${summaryLine(preview.data.headerLabel, { hidden: !expanded })}`;
-  if (!expanded) return clampLinesToWidth(diffSummary.split("\n"), width).join("\n");
-  const text = `${diffSummary}\n${renderTuiDiff({ diffData, width: diffWidth, theme, expanded: true }).lines.join("\n")}`;
-  return clampLinesToWidth(text.split("\n"), width).join("\n");
+function pendingPreviewLines(summary: string, preview: PendingDiffPreviewResult | undefined, expanded: boolean): { lines: string[]; diffData?: ReturnType<typeof buildDiffData>; headerLabel?: string } {
+	if (!preview || preview.type !== "ok") return { lines: summary.split("\n") };
+	const diffData = buildDiffData({ path: preview.data.filePath, oldContent: preview.data.previousContent, newContent: preview.data.nextContent, diff: preview.data.diff });
+	const headerLine = summaryLine(preview.data.headerLabel, { hidden: !expanded });
+	return { lines: [summary, headerLine], diffData: expanded ? diffData : undefined, headerLabel: preview.data.headerLabel };
 }
 
 export function wrapWriteError(err: any, path: string): Error {
@@ -634,10 +631,20 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				previewKey,
 				() => buildPendingEditPreviewData(args ?? {}, context.cwd ?? process.cwd()),
 			);
-			text = formatPendingPreviewText(text, preview, theme, context.width, !!context.expanded);
-			const component = context.lastComponent ?? new Text("", 0, 0);
-			component.setText(text);
-			return component;
+			const expanded = !!context.expanded;
+			const preview2 = pendingPreviewLines(text, preview, expanded);
+			if (preview2.diffData) {
+				const diffComponent = context.lastComponent instanceof DiffPreviewComponent
+					? context.lastComponent
+					: new DiffPreviewComponent({ prefixLines: preview2.lines, diffData: preview2.diffData, theme, expanded: true });
+				diffComponent.update({ prefixLines: preview2.lines, diffData: preview2.diffData, theme, expanded: true });
+				return diffComponent;
+			}
+			const textComponent = (context.lastComponent && !(context.lastComponent instanceof DiffPreviewComponent))
+				? context.lastComponent
+				: new Text("", 0, 0);
+			textComponent.setText(clampLinesToWidth(preview2.lines, context.width).join("\n"));
+			return textComponent;
 		},
 			renderResult(result: any, options: ToolRenderResultOptions, theme: any, ...rest: any[]) {
 			const context: { isPartial?: boolean; isError?: boolean; expanded?: boolean; lastComponent?: any; width?: number } =
@@ -691,7 +698,13 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				if (info.semanticBadge) badges.push(info.semanticBadge.replace(/^✓\s*/, ""));
 				if (info.warningsBadge) badges.push(info.warningsBadge);
 				text = summaryLine(badges.join(" • "), { hidden: !!diffData && !expanded });
-				if (expanded && diffData) text += "\n" + renderTuiDiff({ diffData, width, theme, expanded: true }).lines.join("\n");
+				if (expanded && diffData) {
+					const diffComponent = context.lastComponent instanceof DiffPreviewComponent
+						? context.lastComponent
+						: new DiffPreviewComponent({ prefixLines: text.split("\n"), diffData, theme, expanded: true });
+					diffComponent.update({ prefixLines: text.split("\n"), diffData, theme, expanded: true });
+					return diffComponent;
+				}
 			}
 			return new Text(clampLinesToWidth(text.split("\n"), width).join("\n"), 0, 0);
 		},

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -610,7 +610,7 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			});
 		},
 		renderCall(args: any, theme: any, ...rest: any[]) {
-			const context: { argsComplete?: boolean; lastComponent?: any; cwd?: string; state?: Record<string, any>; invalidate?: () => void; width?: number; expanded?: boolean } = rest[0] ?? {};
+			const context: { argsComplete?: boolean; executionStarted?: boolean; lastComponent?: any; cwd?: string; state?: Record<string, any>; invalidate?: () => void; width?: number; expanded?: boolean } = rest[0] ?? {};
 			const argsComplete = context.argsComplete ?? false;
 			const { path: filePath, suffix } = formatEditCallText(args, argsComplete);
 
@@ -624,6 +624,17 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				text += ` ${theme.fg("dim", suffix)}`;
 			}
 			text = clampLineToWidth(text, context.width);
+			// Once execution has started, the pending preview's only job is done:
+			// renderResult will carry the story ("↳ edited +N -M" with the same
+			// expandable diff). Keeping the "↳ pending edit" sub-line and its
+			// preview alongside the final result is just duplicate noise.
+			if (context.executionStarted) {
+				const textComponent = (context.lastComponent && !(context.lastComponent instanceof DiffPreviewComponent))
+					? context.lastComponent
+					: new Text("", 0, 0);
+				textComponent.setText(text);
+				return textComponent;
+			}
 			const previewKey = buildEditPreviewKey(args ?? {});
 			const preview = resolvePendingDiffPreview(
 				context,

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -24,11 +24,14 @@ import { buildContextHygieneMetadata, buildFileResource, type ContextHygieneMeta
 
 const EDIT_PENDING_PREVIEW_STATE_KEY = "hashline-edit-pending-preview";
 
-function formatPendingPreviewText(summary: string, preview: PendingDiffPreviewResult | undefined, theme: any, width = 80): string {
+function formatPendingPreviewText(summary: string, preview: PendingDiffPreviewResult | undefined, theme: any, width: number | undefined, expanded: boolean): string {
 	if (!preview || preview.type !== "ok") return clampLinesToWidth(summary.split("\n"), width).join("\n");
-	const diffData = buildDiffData({ path: preview.data.filePath, oldContent: preview.data.previousContent, newContent: preview.data.nextContent, diff: preview.data.diff });
-	const text = `${summary}\n${summaryLine(preview.data.headerLabel)}\n${renderTuiDiff({ diffData, width, theme, expanded: true }).lines.join("\n")}`;
-	return clampLinesToWidth(text.split("\n"), width).join("\n");
+  const diffWidth = width ?? 80;
+  const diffData = buildDiffData({ path: preview.data.filePath, oldContent: preview.data.previousContent, newContent: preview.data.nextContent, diff: preview.data.diff });
+  const diffSummary = `${summary}\n${summaryLine(preview.data.headerLabel, { hidden: !expanded })}`;
+  if (!expanded) return clampLinesToWidth(diffSummary.split("\n"), width).join("\n");
+  const text = `${diffSummary}\n${renderTuiDiff({ diffData, width: diffWidth, theme, expanded: true }).lines.join("\n")}`;
+  return clampLinesToWidth(text.split("\n"), width).join("\n");
 }
 
 export function wrapWriteError(err: any, path: string): Error {
@@ -610,7 +613,7 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			});
 		},
 		renderCall(args: any, theme: any, ...rest: any[]) {
-			const context: { argsComplete?: boolean; lastComponent?: any; cwd?: string; state?: Record<string, any>; invalidate?: () => void; width?: number } = rest[0] ?? {};
+			const context: { argsComplete?: boolean; lastComponent?: any; cwd?: string; state?: Record<string, any>; invalidate?: () => void; width?: number; expanded?: boolean } = rest[0] ?? {};
 			const argsComplete = context.argsComplete ?? false;
 			const { path: filePath, suffix } = formatEditCallText(args, argsComplete);
 
@@ -631,7 +634,7 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				previewKey,
 				() => buildPendingEditPreviewData(args ?? {}, context.cwd ?? process.cwd()),
 			);
-			text = formatPendingPreviewText(text, preview, theme, context.width);
+			text = formatPendingPreviewText(text, preview, theme, context.width, !!context.expanded);
 			const component = context.lastComponent ?? new Text("", 0, 0);
 			component.setText(text);
 			return component;

--- a/src/tui-diff-component.ts
+++ b/src/tui-diff-component.ts
@@ -1,0 +1,86 @@
+import type { Component } from "@earendil-works/pi-tui";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import type { DiffData } from "./diff-data.js";
+import { renderTuiDiff } from "./tui-diff-renderer.js";
+import { clampLineToWidth, normalizeWidth, type RendererTheme } from "./tui-render-utils.js";
+
+export interface DiffPreviewComponentOptions {
+	/**
+	 * Lines rendered before the diff body (e.g. tool summary, "pending edit"
+	 * header). Each entry is one logical line; the component is responsible
+	 * for clamping to the render-time width.
+	 */
+	prefixLines?: string[];
+	/**
+	 * Lines rendered after the diff body (e.g. trailing hints). Currently
+	 * unused but kept for symmetry.
+	 */
+	suffixLines?: string[];
+	/** Diff body data. */
+	diffData: DiffData;
+	/** Theme passed through to renderTuiDiff for color tinting. */
+	theme: RendererTheme;
+	/** Whether the diff body should render in expanded form. */
+	expanded: boolean;
+	/**
+	 * Optional fallback width used when render() receives an invalid width
+	 * (zero, negative, NaN). Defaults to 80.
+	 */
+	fallbackWidth?: number;
+}
+
+/**
+ * Self-rendering component for a tool's diff preview that defers wrapping
+ * decisions to the TUI render pass.
+ *
+ * `renderTuiDiff` (and the underlying `wrapWithHangingIndent` helper) need
+ * the real viewport width to choose between split / unified / compact / summary
+ * modes and to wrap long content rows with prefix-aligned continuation lines.
+ * Pi's `ToolRenderContext` does NOT carry the render-time width, so any
+ * pre-baked output is forced to assume a fallback (80 columns). This
+ * component holds the source data instead, then renders at the width pi's TUI
+ * actually passes in.
+ */
+export class DiffPreviewComponent implements Component {
+	private options: DiffPreviewComponentOptions;
+	private cachedWidth: number | undefined;
+	private cachedLines: string[] | undefined;
+
+	constructor(options: DiffPreviewComponentOptions) {
+		this.options = options;
+	}
+
+	update(options: DiffPreviewComponentOptions): void {
+		this.options = options;
+		this.invalidate();
+	}
+
+	invalidate(): void {
+		this.cachedWidth = undefined;
+		this.cachedLines = undefined;
+	}
+
+	render(width: number): string[] {
+		const normalized = normalizeWidth(width, this.options.fallbackWidth ?? 80);
+		if (this.cachedLines && this.cachedWidth === normalized) return this.cachedLines;
+		const lines: string[] = [];
+		for (const prefix of this.options.prefixLines ?? []) {
+			for (const line of prefix.split("\n")) lines.push(clampLineToWidth(line, normalized));
+		}
+		const body = renderTuiDiff({
+			diffData: this.options.diffData,
+			width: normalized,
+			theme: this.options.theme,
+			expanded: this.options.expanded,
+		});
+		for (const line of body.lines) lines.push(line);
+		for (const suffix of this.options.suffixLines ?? []) {
+			for (const line of suffix.split("\n")) lines.push(clampLineToWidth(line, normalized));
+		}
+		// Final safety clamp: each rendered line must fit within the viewport.
+		const clamped = lines.map((line) => (visibleWidth(line) <= normalized ? line : clampLineToWidth(line, normalized)));
+		this.cachedLines = clamped;
+		this.cachedWidth = normalized;
+		return clamped;
+	}
+}

--- a/src/tui-diff-renderer.ts
+++ b/src/tui-diff-renderer.ts
@@ -1,6 +1,6 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
 import type { DiffData, DiffEntry, DiffSpan } from "./diff-data.js";
-import { clampLineToWidth, clampLinesToWidth, normalizeWidth, type RendererTheme } from "./tui-render-utils.js";
+import { clampLineToWidth, clampLinesToWidth, normalizeWidth, wrapWithHangingIndent, type RendererTheme } from "./tui-render-utils.js";
 
 export type TuiDiffMode = "split" | "unified" | "compact" | "summary";
 export type RenderTuiDiffInput = { diffData: DiffData; width: number; theme: RendererTheme; expanded: boolean };
@@ -24,8 +24,26 @@ function inlineText(input: RenderTuiDiffInput, index: number, entry: DiffEntry):
   if (!pair) return textOf(entry);
   return entry.kind === "remove" ? spans(input.theme, pair.removeSpans, textOf(entry)) : entry.kind === "add" ? spans(input.theme, pair.addSpans, textOf(entry)) : textOf(entry);
 }
-function unifiedRows(input: RenderTuiDiffInput): string[] { return input.diffData.entries.map((e, i) => e.kind === "meta" ? null : tint(input.theme, e, `▌${gutterMarker(e)} ${lineNo(e)} │ ${inlineText(input, i, e)}`)).filter((row): row is string => row !== null); }
-function compactRows(input: RenderTuiDiffInput): string[] { return input.diffData.entries.map((e, i) => e.kind === "add" || e.kind === "remove" ? tint(input.theme, e, `▌${gutterMarker(e)} ${lineNo(e)} ${inlineText(input, i, e)}`) : null).filter((row): row is string => row !== null); }
+function unifiedRows(input: RenderTuiDiffInput, width: number): string[] {
+  const rows: string[] = [];
+  for (const [i, e] of input.diffData.entries.entries()) {
+    if (e.kind === "meta") continue;
+    const prefix = `▌${gutterMarker(e)} ${lineNo(e)} │ `;
+    const tinted = wrapWithHangingIndent(prefix, inlineText(input, i, e), width, { tint: (text) => tint(input.theme, e, text) });
+    rows.push(...tinted);
+  }
+  return rows;
+}
+function compactRows(input: RenderTuiDiffInput, width: number): string[] {
+  const rows: string[] = [];
+  for (const [i, e] of input.diffData.entries.entries()) {
+    if (e.kind !== "add" && e.kind !== "remove") continue;
+    const prefix = `▌${gutterMarker(e)} ${lineNo(e)} `;
+    const tinted = wrapWithHangingIndent(prefix, inlineText(input, i, e), width, { tint: (text) => tint(input.theme, e, text) });
+    rows.push(...tinted);
+  }
+  return rows;
+}
 function splitRows(input: RenderTuiDiffInput, width: number): string[] {
   const pane = Math.max(10, Math.floor((width - 3) / 2));
   const rows = [`${"old".padEnd(pane)} │ new`];
@@ -46,6 +64,6 @@ export function renderTuiDiff(input: RenderTuiDiffInput): RenderTuiDiffOutput {
   const lines = [header(input.diffData, mode, width)];
   if (!input.expanded) return { mode, width, lines: clampLinesToWidth([...lines, hiddenHint(input.diffData.entries.length, hunkCount(input.diffData), width)], width) };
   if (mode === "summary") return { mode, width, lines: clampLinesToWidth(lines, width) };
-  const rows = mode === "split" ? splitRows(input, width) : mode === "compact" ? compactRows(input) : unifiedRows(input);
-  return { mode, width, lines: clampLinesToWidth([...lines, ...rows], width) };
+  const rows = mode === "split" ? splitRows(input, width) : mode === "compact" ? compactRows(input, width) : unifiedRows(input, width);
+  return { mode, width, lines: [...lines, ...rows] };
 }

--- a/src/tui-diff-renderer.ts
+++ b/src/tui-diff-renderer.ts
@@ -6,7 +6,15 @@ export type TuiDiffMode = "split" | "unified" | "compact" | "summary";
 export type RenderTuiDiffInput = { diffData: DiffData; width: number; theme: RendererTheme; expanded: boolean };
 export type RenderTuiDiffOutput = { mode: TuiDiffMode; width: number; lines: string[] };
 
-function chooseMode(width: number): TuiDiffMode { return width >= 100 ? "split" : width >= 50 ? "unified" : width >= 24 ? "compact" : "summary"; }
+function hasOldSide(data: DiffData): boolean { return data.entries.some((e) => e.kind === "remove" || e.kind === "context"); }
+function chooseMode(width: number, data: DiffData): TuiDiffMode {
+  if (width < 24) return "summary";
+  if (width < 50) return "compact";
+  // Split mode wastes half the pane on pure-add diffs (pending creates,
+  // write to a new file) so fall back to unified when there is no old side.
+  if (width >= 100 && hasOldSide(data)) return "split";
+  return "unified";
+}
 function hunkCount(data: DiffData): number { return Math.max(1, data.blockRanges?.length ?? (data.entries.some((e) => e.kind === "add" || e.kind === "remove") ? 1 : 0)); }
 function compactHeader(data: DiffData): string { return `↳ diff +${data.stats.added} -${data.stats.removed}`; }
 function header(data: DiffData, mode: TuiDiffMode, width: number): string {
@@ -17,6 +25,7 @@ function header(data: DiffData, mode: TuiDiffMode, width: number): string {
 function lineNo(entry: DiffEntry): string { return String(entry.kind === "add" ? entry.newLine : entry.kind === "remove" ? entry.oldLine : entry.kind === "context" ? entry.newLine : ""); }
 function gutterMarker(entry: DiffEntry): string { return entry.kind === "add" ? "+" : entry.kind === "remove" ? "-" : " "; }
 function textOf(entry: DiffEntry): string { return "text" in entry ? entry.text : ""; }
+function padRightVisual(line: string, width: number): string { const visible = visibleWidth(line); return visible >= width ? line : line + " ".repeat(width - visible); }
 function tint(theme: RendererTheme, entry: DiffEntry, text: string): string { return entry.kind === "add" ? theme.fg("success", text) : entry.kind === "remove" ? theme.fg("error", text) : theme.fg("toolOutput", text); }
 function spans(theme: RendererTheme, spans: DiffSpan[] | undefined, fallback: string): string { return spans?.map((s) => s.kind === "add" ? theme.fg("success", s.text) : s.kind === "remove" ? theme.fg("error", s.text) : s.text).join("") ?? fallback; }
 function inlineText(input: RenderTuiDiffInput, index: number, entry: DiffEntry): string {
@@ -46,11 +55,25 @@ function compactRows(input: RenderTuiDiffInput, width: number): string[] {
 }
 function splitRows(input: RenderTuiDiffInput, width: number): string[] {
   const pane = Math.max(10, Math.floor((width - 3) / 2));
-  const rows = [`${"old".padEnd(pane)} │ new`];
+  const rows = [`${padRightVisual("old", pane)} │ new`];
+  const blankPane = " ".repeat(pane);
   for (const [i, e] of input.diffData.entries.entries()) {
-    if (e.kind === "remove") rows.push(`${clampLineToWidth(`▌- ${e.oldLine} │ ${inlineText(input, i, e)}`, pane)} │ ${""}`);
-    else if (e.kind === "add") rows.push(`${"".padEnd(pane)} │ ${clampLineToWidth(`▌+ ${e.newLine} │ ${inlineText(input, i, e)}`, pane)}`);
-    else if (e.kind === "context") rows.push(`${clampLineToWidth(`▌  ${e.oldLine} │ ${e.text}`, pane)} │ ${clampLineToWidth(`▌  ${e.newLine} │ ${e.text}`, pane)}`);
+    if (e.kind === "remove") {
+      const left = wrapWithHangingIndent(`▌- ${e.oldLine} │ `, inlineText(input, i, e), pane, { tint: (text) => tint(input.theme, e, text) });
+      for (const line of left) rows.push(`${padRightVisual(line, pane)} │ ${blankPane}`);
+    } else if (e.kind === "add") {
+      const right = wrapWithHangingIndent(`▌+ ${e.newLine} │ `, inlineText(input, i, e), pane, { tint: (text) => tint(input.theme, e, text) });
+      for (const line of right) rows.push(`${blankPane} │ ${line}`);
+    } else if (e.kind === "context") {
+      const left = wrapWithHangingIndent(`▌  ${e.oldLine} │ `, e.text, pane, { tint: (text) => tint(input.theme, e, text) });
+      const right = wrapWithHangingIndent(`▌  ${e.newLine} │ `, e.text, pane, { tint: (text) => tint(input.theme, e, text) });
+      const maxLen = Math.max(left.length, right.length);
+      for (let k = 0; k < maxLen; k++) {
+        const l = left[k] ?? blankPane;
+        const r = right[k] ?? blankPane;
+        rows.push(`${padRightVisual(l, pane)} │ ${r}`);
+      }
+    }
   }
   return rows;
 }
@@ -60,7 +83,7 @@ function hiddenHint(hiddenLines: number, hiddenHunks: number, width: number): st
 }
 export function renderTuiDiff(input: RenderTuiDiffInput): RenderTuiDiffOutput {
   const width = normalizeWidth(input.width);
-  const mode = chooseMode(width);
+  const mode = chooseMode(width, input.diffData);
   const lines = [header(input.diffData, mode, width)];
   if (!input.expanded) return { mode, width, lines: clampLinesToWidth([...lines, hiddenHint(input.diffData.entries.length, hunkCount(input.diffData), width)], width) };
   if (mode === "summary") return { mode, width, lines: clampLinesToWidth(lines, width) };

--- a/src/tui-render-utils.ts
+++ b/src/tui-render-utils.ts
@@ -49,6 +49,38 @@ export function wrapLinesToWidth(lines: string[], width: number | undefined): st
   });
 }
 
+export interface WrapWithHangingIndentOptions {
+  /** Optional transform applied to each produced line (e.g. theme tinting). */
+  tint?: (text: string) => string;
+}
+
+/**
+ * Wrap a single visual row that has a leading prefix (gutter, line number,
+ * separator) such that continuation lines are indented to align with the
+ * content column. Each produced line is clamped to `width`. If `tint` is
+ * provided, it is applied to each output line so theme styling extends across
+ * wrapped rows without leaking the prefix into the colored span.
+ */
+export function wrapWithHangingIndent(
+  prefix: string,
+  content: string,
+  width: number | undefined,
+  options: WrapWithHangingIndentOptions = {},
+): string[] {
+  const tint = options.tint ?? ((text: string) => text);
+  if (width === undefined || width === null) return [tint(prefix + content)];
+  const normalized = normalizeWidth(width);
+  const combined = prefix + content;
+  if (visibleWidth(combined) <= normalized) return [tint(combined)];
+  const prefixWidth = visibleWidth(prefix);
+  const contentWidth = Math.max(1, normalized - prefixWidth);
+  const wrapped = wrapTextWithAnsi(content, contentWidth);
+  if (wrapped.length === 0) return [tint(clampLineToWidth(prefix, normalized))];
+  const indent = " ".repeat(prefixWidth);
+  return wrapped.map((line, index) =>
+    tint(clampLineToWidth(index === 0 ? prefix + line : indent + line, normalized)),
+  );
+}
 const HASHLINE_CONTENT_RE = /^(\d+:[0-9a-fA-F]+\|)(.*)$/;
 
 export function wrapReadHashlinesForWidth(text: string, width: number | undefined): string {

--- a/src/write.ts
+++ b/src/write.ts
@@ -410,6 +410,18 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
       const lineCount = typeof content === "string" ? content.split("\n").length : 0;
       const bytes = typeof content === "string" ? Buffer.byteLength(content, "utf8") : 0;
       let text = clampLineToWidth(`${label} ${theme.fg("muted", path)}${typeof content === "string" ? ` (${lineCount} ${lineCount === 1 ? "line" : "lines"} • ${bytes} B)` : ""}`, context.width);
+      // Once execution has started, the pending preview's only job is done:
+      // renderResult will carry the story ("↳ created" / "↳ overwritten" with
+      // expandable content or diff). Showing the "↳ pending…" sub-line and
+      // its preview alongside the final result is just duplicate noise — the
+      // pre-execution state can no longer change in any meaningful way.
+      if (context.executionStarted) {
+        const textComponent = (context.lastComponent && !(context.lastComponent instanceof DiffPreviewComponent))
+          ? context.lastComponent
+          : new Text("", 0, 0);
+        textComponent.setText(text);
+        return textComponent;
+      }
       const previewKey = buildWritePreviewKey(args ?? {});
       const preview = resolvePendingDiffPreview(context, WRITE_PENDING_PREVIEW_STATE_KEY, previewKey, () => buildPendingWritePreviewData(args ?? {}, context.cwd ?? process.cwd()));
       const expanded = !!context.expanded;

--- a/src/write.ts
+++ b/src/write.ts
@@ -19,12 +19,17 @@ import { renderTuiDiff } from "./tui-diff-renderer.js";
 
 const WRITE_PENDING_PREVIEW_STATE_KEY = "hashline-write-pending-preview";
 
-function formatPendingWritePreviewText(summary: string, preview: PendingDiffPreviewResult | undefined, theme: any, width: number | undefined): string {
+function formatPendingWritePreviewText(summary: string, preview: PendingDiffPreviewResult | undefined, theme: any, width: number | undefined, expanded: boolean): string {
   if (!preview || preview.type !== "ok") return width === undefined ? summary : clampLinesToWidth(summary.split("\n"), width).join("\n");
   const diffWidth = width ?? 80;
   const diffData = buildDiffData({ path: preview.data.filePath, oldContent: preview.data.previousContent, newContent: preview.data.nextContent, diff: preview.data.diff });
+  const headerLine = summaryLine(preview.data.headerLabel, { hidden: !expanded });
+  if (!expanded) {
+    const collapsed = [summary, headerLine];
+    return width === undefined ? collapsed.join("\n") : clampLinesToWidth(collapsed, width).join("\n");
+  }
   const diffLines = renderTuiDiff({ diffData, width: diffWidth, theme, expanded: true }).lines;
-  const lines = [summary, summaryLine(preview.data.headerLabel), ...diffLines];
+  const lines = [summary, headerLine, ...diffLines];
   return width === undefined ? lines.join("\n") : clampLinesToWidth(lines, width).join("\n");
 }
 
@@ -391,7 +396,7 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
       let text = clampLineToWidth(`${label} ${theme.fg("muted", path)}${typeof content === "string" ? ` (${lineCount} ${lineCount === 1 ? "line" : "lines"} • ${bytes} B)` : ""}`, context.width);
       const previewKey = buildWritePreviewKey(args ?? {});
       const preview = resolvePendingDiffPreview(context, WRITE_PENDING_PREVIEW_STATE_KEY, previewKey, () => buildPendingWritePreviewData(args ?? {}, context.cwd ?? process.cwd()));
-      text = formatPendingWritePreviewText(text, preview, theme, context.width);
+      text = formatPendingWritePreviewText(text, preview, theme, context.width, !!context.expanded);
       const component = context.lastComponent ?? new Text("", 0, 0);
       component.setText(text);
       return component;

--- a/src/write.ts
+++ b/src/write.ts
@@ -21,8 +21,13 @@ const WRITE_PENDING_PREVIEW_STATE_KEY = "hashline-write-pending-preview";
 
 function pendingWritePreviewParts(summary: string, preview: PendingDiffPreviewResult | undefined, expanded: boolean): { lines: string[]; diffData?: DiffData } {
   if (!preview || preview.type !== "ok") return { lines: summary.split("\n") };
+  // Pure creates (write to a new file) have no "old" side and every line is an add —
+  // a diff-shaped preview is just noise. Only render diff UI when overwriting an
+  // existing file, where the diff actually carries signal.
+  const hasOldSide = preview.data.fileExistedBeforeWrite;
+  const headerLine = summaryLine(preview.data.headerLabel, { hidden: hasOldSide && !expanded });
+  if (!hasOldSide) return { lines: [summary, headerLine] };
   const diffData = buildDiffData({ path: preview.data.filePath, oldContent: preview.data.previousContent, newContent: preview.data.nextContent, diff: preview.data.diff });
-  const headerLine = summaryLine(preview.data.headerLabel, { hidden: !expanded });
   return { lines: [summary, headerLine], diffData: expanded ? diffData : undefined };
 }
 
@@ -416,8 +421,13 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
       }
       const diffData = details.diffData;
       const state = details.writeState === "overwritten" ? "overwritten" : "created";
-      let text = summaryLine(state, { hidden: !!diffData && !expanded });
-      if (expanded && diffData) {
+      // Pure creates always render every line as an add — the diff body has no
+      // signal beyond "here is the new file". Suppress the diff UI (and the
+      // "Ctrl+O to expand" hint that goes with it) for creates; keep it for
+      // overwrites where the old/new comparison is informative.
+      const hasExpandableDiff = !!diffData && state === "overwritten";
+      let text = summaryLine(state, { hidden: hasExpandableDiff && !expanded });
+      if (expanded && hasExpandableDiff) {
         const diffComponent = context.lastComponent instanceof DiffPreviewComponent
           ? context.lastComponent
           : new DiffPreviewComponent({ prefixLines: text.split("\n"), diffData, theme, expanded: true });

--- a/src/write.ts
+++ b/src/write.ts
@@ -21,28 +21,38 @@ const WRITE_PENDING_PREVIEW_STATE_KEY = "hashline-write-pending-preview";
 
 const CONTENT_PREVIEW_MAX_LINES = 200;
 
-function formatContentPreviewLines(content: string): string[] {
+function formatContentPreviewLines(content: string, theme: any): string[] {
   const lines = content.split("\n");
   // Drop the single trailing blank produced by a terminal newline so the
   // preview reads naturally.
   if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
-  const indented = lines.slice(0, CONTENT_PREVIEW_MAX_LINES).map((line) => `  ${line}`);
+  const shown = lines.slice(0, CONTENT_PREVIEW_MAX_LINES);
+  // Right-align line numbers so the body has a stable column for the content.
+  // The dim gutter ("  N │ ") visually distinguishes the body from the
+  // "↳ created / pending create" header above it without re-introducing
+  // diff chrome (no +/- marker, no red/green tint).
+  const width = String(shown.length).length;
+  const fg = theme?.fg ?? ((_style: string, text: string) => text);
+  const formatted = shown.map((line, index) => {
+    const gutter = fg("dim", `${String(index + 1).padStart(width, " ")} │ `);
+    return `  ${gutter}${line}`;
+  });
   if (lines.length > CONTENT_PREVIEW_MAX_LINES) {
-    indented.push(`  … ${lines.length - CONTENT_PREVIEW_MAX_LINES} more lines not shown`);
+    formatted.push(`  ${fg("dim", `… ${lines.length - CONTENT_PREVIEW_MAX_LINES} more lines not shown`)}`);
   }
-  return indented;
+  return formatted;
 }
 
-function pendingWritePreviewParts(summary: string, preview: PendingDiffPreviewResult | undefined, expanded: boolean): { lines: string[]; diffData?: DiffData } {
+function pendingWritePreviewParts(summary: string, preview: PendingDiffPreviewResult | undefined, expanded: boolean, theme: any): { lines: string[]; diffData?: DiffData } {
   if (!preview || preview.type !== "ok") return { lines: summary.split("\n") };
   // Pure creates (write to a new file) have no "old" side, so a diff-shaped
-  // preview is just noise. Show the new file's content (indented, no gutter,
-  // no line numbers, no colors) when expanded; otherwise just a Ctrl+O hint.
+  // preview is just noise. Show the new file's content with a dim gutter of
+  // line numbers when expanded; otherwise just a Ctrl+O hint.
   const hasOldSide = preview.data.fileExistedBeforeWrite;
   const headerLine = summaryLine(preview.data.headerLabel, { hidden: !expanded });
   if (!hasOldSide) {
     const lines = [summary, headerLine];
-    if (expanded) lines.push(...formatContentPreviewLines(preview.data.nextContent));
+    if (expanded) lines.push(...formatContentPreviewLines(preview.data.nextContent, theme));
     return { lines };
   }
   const diffData = buildDiffData({ path: preview.data.filePath, oldContent: preview.data.previousContent, newContent: preview.data.nextContent, diff: preview.data.diff });
@@ -425,7 +435,7 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
       const previewKey = buildWritePreviewKey(args ?? {});
       const preview = resolvePendingDiffPreview(context, WRITE_PENDING_PREVIEW_STATE_KEY, previewKey, () => buildPendingWritePreviewData(args ?? {}, context.cwd ?? process.cwd()));
       const expanded = !!context.expanded;
-      const parts = pendingWritePreviewParts(text, preview, expanded);
+      const parts = pendingWritePreviewParts(text, preview, expanded, theme);
       if (parts.diffData) {
         const diffComponent = context.lastComponent instanceof DiffPreviewComponent
           ? context.lastComponent
@@ -461,7 +471,7 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
         const lines = header.split("\n");
         if (expanded && hasContent) {
           const content = ptcLines.map((l) => l.raw).join("\n");
-          lines.push(...formatContentPreviewLines(content));
+          lines.push(...formatContentPreviewLines(content, theme));
         }
         return new Text(clampLinesToWidth(lines, width).join("\n"), 0, 0);
       }

--- a/src/write.ts
+++ b/src/write.ts
@@ -15,22 +15,15 @@ import { buildPendingWritePreviewData, buildWritePreviewKey, resolvePendingDiffP
 import { generateCompactOrFullDiff, normalizeToLF, hasBareCarriageReturn } from "./edit-diff.js";
 import { buildDiffData, type DiffData } from "./diff-data.js";
 import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine } from "./tui-render-utils.js";
-import { renderTuiDiff } from "./tui-diff-renderer.js";
+import { DiffPreviewComponent } from "./tui-diff-component.js";
 
 const WRITE_PENDING_PREVIEW_STATE_KEY = "hashline-write-pending-preview";
 
-function formatPendingWritePreviewText(summary: string, preview: PendingDiffPreviewResult | undefined, theme: any, width: number | undefined, expanded: boolean): string {
-  if (!preview || preview.type !== "ok") return width === undefined ? summary : clampLinesToWidth(summary.split("\n"), width).join("\n");
-  const diffWidth = width ?? 80;
+function pendingWritePreviewParts(summary: string, preview: PendingDiffPreviewResult | undefined, expanded: boolean): { lines: string[]; diffData?: DiffData } {
+  if (!preview || preview.type !== "ok") return { lines: summary.split("\n") };
   const diffData = buildDiffData({ path: preview.data.filePath, oldContent: preview.data.previousContent, newContent: preview.data.nextContent, diff: preview.data.diff });
   const headerLine = summaryLine(preview.data.headerLabel, { hidden: !expanded });
-  if (!expanded) {
-    const collapsed = [summary, headerLine];
-    return width === undefined ? collapsed.join("\n") : clampLinesToWidth(collapsed, width).join("\n");
-  }
-  const diffLines = renderTuiDiff({ diffData, width: diffWidth, theme, expanded: true }).lines;
-  const lines = [summary, headerLine, ...diffLines];
-  return width === undefined ? lines.join("\n") : clampLinesToWidth(lines, width).join("\n");
+  return { lines: [summary, headerLine], diffData: expanded ? diffData : undefined };
 }
 
 const MAX_LINES = 2000;
@@ -396,10 +389,20 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
       let text = clampLineToWidth(`${label} ${theme.fg("muted", path)}${typeof content === "string" ? ` (${lineCount} ${lineCount === 1 ? "line" : "lines"} • ${bytes} B)` : ""}`, context.width);
       const previewKey = buildWritePreviewKey(args ?? {});
       const preview = resolvePendingDiffPreview(context, WRITE_PENDING_PREVIEW_STATE_KEY, previewKey, () => buildPendingWritePreviewData(args ?? {}, context.cwd ?? process.cwd()));
-      text = formatPendingWritePreviewText(text, preview, theme, context.width, !!context.expanded);
-      const component = context.lastComponent ?? new Text("", 0, 0);
-      component.setText(text);
-      return component;
+      const expanded = !!context.expanded;
+      const parts = pendingWritePreviewParts(text, preview, expanded);
+      if (parts.diffData) {
+        const diffComponent = context.lastComponent instanceof DiffPreviewComponent
+          ? context.lastComponent
+          : new DiffPreviewComponent({ prefixLines: parts.lines, diffData: parts.diffData, theme, expanded: true });
+        diffComponent.update({ prefixLines: parts.lines, diffData: parts.diffData, theme, expanded: true });
+        return diffComponent;
+      }
+      const textComponent = (context.lastComponent && !(context.lastComponent instanceof DiffPreviewComponent))
+        ? context.lastComponent
+        : new Text("", 0, 0);
+      textComponent.setText(clampLinesToWidth(parts.lines, context.width).join("\n"));
+      return textComponent;
     },
     renderResult(result: any, options: any, theme: any, context: any = {}) {
       const expanded = isRendererExpanded(options, context);
@@ -414,7 +417,13 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
       const diffData = details.diffData;
       const state = details.writeState === "overwritten" ? "overwritten" : "created";
       let text = summaryLine(state, { hidden: !!diffData && !expanded });
-      if (expanded && diffData) text += "\n" + renderTuiDiff({ diffData, width, theme, expanded: true }).lines.join("\n");
+      if (expanded && diffData) {
+        const diffComponent = context.lastComponent instanceof DiffPreviewComponent
+          ? context.lastComponent
+          : new DiffPreviewComponent({ prefixLines: text.split("\n"), diffData, theme, expanded: true });
+        diffComponent.update({ prefixLines: text.split("\n"), diffData, theme, expanded: true });
+        return diffComponent;
+      }
       return new Text(clampLinesToWidth(text.split("\n"), width).join("\n"), 0, 0);
     },
   };

--- a/src/write.ts
+++ b/src/write.ts
@@ -32,7 +32,9 @@ function formatContentPreviewLines(content: string, theme: any): string[] {
   // "↳ created / pending create" header above it without re-introducing
   // diff chrome (no +/- marker, no red/green tint).
   const width = String(shown.length).length;
-  const fg = theme?.fg ?? ((_style: string, text: string) => text);
+  // Bind theme.fg so we keep its `this` (the Theme uses internal state); fall back
+  // to an identity tint when no theme is provided (e.g. in tests).
+  const fg = typeof theme?.fg === "function" ? (style: string, text: string) => theme.fg(style, text) : (_style: string, text: string) => text;
   const formatted = shown.map((line, index) => {
     const gutter = fg("dim", `${String(index + 1).padStart(width, " ")} │ `);
     return `  ${gutter}${line}`;

--- a/src/write.ts
+++ b/src/write.ts
@@ -19,14 +19,32 @@ import { DiffPreviewComponent } from "./tui-diff-component.js";
 
 const WRITE_PENDING_PREVIEW_STATE_KEY = "hashline-write-pending-preview";
 
+const CONTENT_PREVIEW_MAX_LINES = 200;
+
+function formatContentPreviewLines(content: string): string[] {
+  const lines = content.split("\n");
+  // Drop the single trailing blank produced by a terminal newline so the
+  // preview reads naturally.
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  const indented = lines.slice(0, CONTENT_PREVIEW_MAX_LINES).map((line) => `  ${line}`);
+  if (lines.length > CONTENT_PREVIEW_MAX_LINES) {
+    indented.push(`  … ${lines.length - CONTENT_PREVIEW_MAX_LINES} more lines not shown`);
+  }
+  return indented;
+}
+
 function pendingWritePreviewParts(summary: string, preview: PendingDiffPreviewResult | undefined, expanded: boolean): { lines: string[]; diffData?: DiffData } {
   if (!preview || preview.type !== "ok") return { lines: summary.split("\n") };
-  // Pure creates (write to a new file) have no "old" side and every line is an add —
-  // a diff-shaped preview is just noise. Only render diff UI when overwriting an
-  // existing file, where the diff actually carries signal.
+  // Pure creates (write to a new file) have no "old" side, so a diff-shaped
+  // preview is just noise. Show the new file's content (indented, no gutter,
+  // no line numbers, no colors) when expanded; otherwise just a Ctrl+O hint.
   const hasOldSide = preview.data.fileExistedBeforeWrite;
-  const headerLine = summaryLine(preview.data.headerLabel, { hidden: hasOldSide && !expanded });
-  if (!hasOldSide) return { lines: [summary, headerLine] };
+  const headerLine = summaryLine(preview.data.headerLabel, { hidden: !expanded });
+  if (!hasOldSide) {
+    const lines = [summary, headerLine];
+    if (expanded) lines.push(...formatContentPreviewLines(preview.data.nextContent));
+    return { lines };
+  }
   const diffData = buildDiffData({ path: preview.data.filePath, oldContent: preview.data.previousContent, newContent: preview.data.nextContent, diff: preview.data.diff });
   return { lines: [summary, headerLine], diffData: expanded ? diffData : undefined };
 }
@@ -421,11 +439,22 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
       }
       const diffData = details.diffData;
       const state = details.writeState === "overwritten" ? "overwritten" : "created";
-      // Pure creates always render every line as an add — the diff body has no
-      // signal beyond "here is the new file". Suppress the diff UI (and the
-      // "Ctrl+O to expand" hint that goes with it) for creates; keep it for
-      // overwrites where the old/new comparison is informative.
-      const hasExpandableDiff = !!diffData && state === "overwritten";
+      // Pure creates: render the new file's contents on expand (no diff chrome)
+      // instead of a diff body — every line is an add, so the gutter, line
+      // numbers, and red/green tinting are noise.
+      if (state === "created") {
+        const ptcLines = (details.ptcValue?.lines ?? []) as Array<{ raw: string }>;
+        const hasContent = ptcLines.length > 0;
+        const header = summaryLine(state, { hidden: hasContent && !expanded });
+        const lines = header.split("\n");
+        if (expanded && hasContent) {
+          const content = ptcLines.map((l) => l.raw).join("\n");
+          lines.push(...formatContentPreviewLines(content));
+        }
+        return new Text(clampLinesToWidth(lines, width).join("\n"), 0, 0);
+      }
+      // Overwrite: the old vs new comparison still carries signal — keep the diff UI.
+      const hasExpandableDiff = !!diffData;
       let text = summaryLine(state, { hidden: hasExpandableDiff && !expanded });
       if (expanded && hasExpandableDiff) {
         const diffComponent = context.lastComponent instanceof DiffPreviewComponent

--- a/tests/edit-pending-diff-render-success.test.ts
+++ b/tests/edit-pending-diff-render-success.test.ts
@@ -57,4 +57,30 @@ describe("edit renderCall pending diff preview", () => {
 		expect(rendered).toContain("↳ diff +1 -1");
 		expect(rendered).toContain("▌+ 1 │ const unique = 2;");
 	});
+
+	it("collapses the pending preview to just the call line once execution has started", async () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-edit-exec-collapse-"));
+		const filePath = resolve(cwd, "sample.ts");
+		writeFileSync(filePath, "const unique = 1;\n", "utf-8");
+		const tool = getEditTool();
+		const args = { path: filePath, edits: [{ replace: { old_text: "const unique = 1;", new_text: "const unique = 2;" } }] };
+
+		// Before execution: pending preview with the full diff visible.
+		const before: any = { argsComplete: true, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined, expanded: true };
+		const beforeFirst = tool.renderCall(args, theme, before);
+		await Promise.resolve();
+		const beforeSecond = tool.renderCall(args, theme, { ...before, lastComponent: beforeFirst });
+		const beforeText = textOf(beforeSecond);
+		expect(beforeText).toContain("pending edit");
+		expect(beforeText).toContain("↳ diff +1 -1");
+
+		// After execution starts: the call row drops the pending preview — renderResult will
+		// carry the post-exec story (↳ edited +N -M with the same expandable diff).
+		const after: any = { argsComplete: true, executionStarted: true, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined, expanded: true };
+		const afterRendered = textOf(tool.renderCall(args, theme, after));
+		expect(afterRendered).toContain("edit");
+		expect(afterRendered).not.toContain("pending");
+		expect(afterRendered).not.toContain("↳ diff +");
+		expect(afterRendered).not.toContain("▌");
+	});
 });

--- a/tests/edit-pending-diff-render-success.test.ts
+++ b/tests/edit-pending-diff-render-success.test.ts
@@ -21,12 +21,31 @@ const theme = {
 };
 
 describe("edit renderCall pending diff preview", () => {
-	it("renders a pending edit preview", async () => {
+	it("renders a collapsed pending edit preview by default", async () => {
 		const cwd = mkdtempSync(resolve(tmpdir(), "pi-edit-pending-success-"));
 		const filePath = resolve(cwd, "sample.ts");
 		writeFileSync(filePath, "const unique = 1;\n", "utf-8");
 		const tool = getEditTool();
-		const context: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined };
+		const context: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined, expanded: false };
+		const args = { path: filePath, edits: [{ replace: { old_text: "const unique = 1;", new_text: "const unique = 2;" } }] };
+
+		const first = tool.renderCall(args, theme, context);
+		await Promise.resolve();
+		const second = tool.renderCall(args, theme, { ...context, lastComponent: first });
+		const rendered = textOf(second);
+
+		expect(rendered).toContain("pending edit");
+		expect(rendered).toContain("Ctrl+O to expand");
+		expect(rendered).not.toContain("↳ diff +1 -1");
+		expect(rendered).not.toContain("▌+ 1");
+	});
+
+	it("renders the full diff body when expanded", async () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-edit-pending-expanded-"));
+		const filePath = resolve(cwd, "sample.ts");
+		writeFileSync(filePath, "const unique = 1;\n", "utf-8");
+		const tool = getEditTool();
+		const context: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined, expanded: true };
 		const args = { path: filePath, edits: [{ replace: { old_text: "const unique = 1;", new_text: "const unique = 2;" } }] };
 
 		const first = tool.renderCall(args, theme, context);

--- a/tests/edit-render-tui.test.ts
+++ b/tests/edit-render-tui.test.ts
@@ -45,7 +45,7 @@ describe("edit TUI renderer", () => {
     writeFileSync(filePath, "const value = 1;\n", "utf-8");
     const t = tool();
     const args = { path: filePath, edits: [{ replace: { old_text: "const value = 1;", new_text: "const value = 2;" } }] };
-    const context: any = { argsComplete: false, cwd, state: {}, invalidate: vi.fn() };
+    const context: any = { argsComplete: false, cwd, state: {}, invalidate: vi.fn(), expanded: true };
     const first = t.renderCall(args, theme, context);
     await Promise.resolve();
     const second = t.renderCall(args, theme, { ...context, lastComponent: first });

--- a/tests/edit-render-tui.test.ts
+++ b/tests/edit-render-tui.test.ts
@@ -5,14 +5,14 @@ import { tmpdir } from "node:os";
 import { registerEditTool } from "../src/edit.js";
 
 const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
-function textOf(component: any): string { return component?.text ?? component?.render?.(120)?.join("\n") ?? ""; }
+function textOf(component: any, width = 120): string { return component?.text ?? component?.render?.(width)?.join("\n") ?? ""; }
 function tool(): any { let registered: any; registerEditTool({ registerTool(def: any) { registered = def; } } as any, { wasReadInSession: () => true } as any); return registered; }
 
 describe("edit TUI renderer", () => {
   it("shows edit summary before final diff and preserves model-facing data", () => {
     const result: any = { content: [{ type: "text", text: "1:abc|one\n2:def|TWO" }], details: { diff: "-2 two\n+2 TWO", diffData: { version: 1, stats: { added: 1, removed: 1, context: 0 }, entries: [{ kind: "remove", oldLine: 2, text: "two" }, { kind: "add", newLine: 2, text: "TWO" }] }, ptcValue: { warnings: [], noopEdits: [], semanticSummary: { classification: "semantic" }, diffData: { sentinel: true } } } };
     const before = JSON.stringify(result.details);
-    const rendered = textOf(tool().renderResult(result, { expanded: true, width: 80 }, theme, { expanded: true, width: 80 }));
+    const rendered = textOf(tool().renderResult(result, { expanded: true, width: 80 }, theme, { expanded: true, width: 80 }), 80);
     expect(rendered.split("\n")[0]).toBe("↳ edited +1 -1 • semantic");
     expect(rendered).toContain("↳ diff +1 -1 • 1 hunk • 1 file • unified");
     expect(rendered).toContain("▌+ 2 │ TWO");

--- a/tests/renderer-expanded-width-coverage.test.ts
+++ b/tests/renderer-expanded-width-coverage.test.ts
@@ -45,8 +45,9 @@ describe("owned renderer expanded and width coverage", () => {
     const editText = textOf(edit.renderResult({ content: [{ type: "text", text: "1:abc|new" }], details: { diffData: { version: 1, stats: { added: 1, removed: 0, context: 0 }, entries: [{ kind: "add", newLine: 1, text: "new" }] }, ptcValue: { warnings: [], noopEdits: [], semanticSummary: { classification: "semantic" } } } }, { expanded: true }, theme, { expanded: true }), 80);
     expect(editText).toContain("↳ diff +1 -0");
 
-    const writeText = textOf(write.renderResult({ content: [{ type: "text", text: "1:abc|new" }], details: { writeState: "created", diffData: { version: 1, stats: { added: 1, removed: 0, context: 0 }, entries: [{ kind: "add", newLine: 1, text: "new" }] } } }, { expanded: true }, theme, { expanded: true }), 80);
-    expect(writeText).toContain("↳ diff +1 -0");
+    // Pure create has no diff UI — every line is an add. Use overwritten state to exercise the diff renderer.
+    const writeText = textOf(write.renderResult({ content: [{ type: "text", text: "1:abc|new" }], details: { writeState: "overwritten", diffData: { version: 1, stats: { added: 1, removed: 1, context: 0 }, entries: [{ kind: "remove", oldLine: 1, text: "old" }, { kind: "add", newLine: 1, text: "new" }] } } }, { expanded: true }, theme, { expanded: true }), 80);
+    expect(writeText).toContain("↳ diff +1 -1");
 
     const nuText = textOf(nu.renderResult({ content: [{ type: "text", text: "row\nsecond" }] }, { expanded: true }, theme, { expanded: true }), 80);
     expect(nuText).toContain("second");
@@ -86,7 +87,7 @@ describe("owned renderer expanded and width coverage", () => {
       textOf(renderers.edit.renderCall({ path: "src/very/long/path/edit-target.ts", edits: [{ replace: { old_text: "old", new_text: "new" } }] }, theme, { width, argsComplete: true }), width),
       textOf(renderers.edit.renderResult({ content: [{ type: "text", text: "1:abc|new" }], details: { diffData: { version: 1, stats: { added: 1, removed: 0, context: 0 }, entries: [{ kind: "add", newLine: 1, text: "new value with a long tail" }] }, ptcValue: { warnings: [], noopEdits: [] } } }, { expanded: true, width }, theme, { expanded: true, width }), width),
       textOf(renderers.write.renderCall({ path: "src/very/long/path/write-target.ts", content: "one\ntwo" }, theme, { width }), width),
-      textOf(renderers.write.renderResult({ content: [{ type: "text", text: "1:abc|new" }], details: { writeState: "created", diffData: { version: 1, stats: { added: 1, removed: 0, context: 0 }, entries: [{ kind: "add", newLine: 1, text: "new value with a long tail" }] } } }, { expanded: true, width }, theme, { expanded: true, width }), width),
+      textOf(renderers.write.renderResult({ content: [{ type: "text", text: "1:abc|new" }], details: { writeState: "overwritten", diffData: { version: 1, stats: { added: 1, removed: 1, context: 0 }, entries: [{ kind: "remove", oldLine: 1, text: "old value with a long tail" }, { kind: "add", newLine: 1, text: "new value with a long tail" }] } } }, { expanded: true, width }, theme, { expanded: true, width }), width),
       textOf(renderers.nu.renderCall({ command: "ls | where name =~ very-long-pattern" }, theme, { width }), width),
       textOf(renderers.nu.renderResult({ content: [{ type: "text", text: "very long output row" }] }, { expanded: true, width }, theme, { expanded: true, width }), width),
       textOf(renderers.sg.renderCall({ pattern: "console.log($VERY_LONG_ARGUMENT)", path: "src/very/long/path", lang: "typescript" }, theme, { width }), width),

--- a/tests/tui-diff-component.test.ts
+++ b/tests/tui-diff-component.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { DiffPreviewComponent } from "../src/tui-diff-component.js";
+import type { DiffData } from "../src/diff-data.js";
+
+const identityTheme = { fg: (_kind: string, text: string) => text } as any;
+
+const longText = "the quick brown fox jumps over the lazy dog and then keeps going far past the right edge of the viewport without stopping";
+
+const longDiffData: DiffData = {
+	version: 1,
+	entries: [
+		{ kind: "remove", oldLine: 1, text: longText },
+		{ kind: "add", newLine: 1, text: longText.toUpperCase() },
+		{ kind: "context", oldLine: 2, newLine: 2, text: "tail" },
+	],
+	stats: { added: 1, removed: 1, context: 1 },
+	blockRanges: [{ kind: "add", startLine: 1, endLine: 2 }],
+};
+
+describe("DiffPreviewComponent", () => {
+	it("renders at the width passed to render() rather than a baked-in fallback", () => {
+		const comp = new DiffPreviewComponent({
+			prefixLines: ["edit /tmp/file.txt (1 edit)", "↳ pending edit"],
+			diffData: longDiffData,
+			theme: identityTheme,
+			expanded: true,
+		});
+		const at60 = comp.render(60);
+		const at160 = comp.render(160);
+		for (const line of at60) expect(visibleWidth(line)).toBeLessThanOrEqual(60);
+		for (const line of at160) expect(visibleWidth(line)).toBeLessThanOrEqual(160);
+		// At 60 columns we must be in unified mode (>= 50 and < 100) and content wraps.
+		expect(at60.join("\n")).toContain("↳ diff +1 -1 • 1 hunk • 1 file • unified");
+		expect(at60.length).toBeGreaterThan(at160.length);
+		// No row should be truncated with an ellipsis when wrap is feasible.
+		expect(at60.some((line) => line.endsWith("..."))).toBe(false);
+	});
+
+	it("respects expanded=false by omitting the body and showing a hidden hint", () => {
+		const comp = new DiffPreviewComponent({
+			prefixLines: ["write sample.txt", "↳ pending overwrite"],
+			diffData: longDiffData,
+			theme: identityTheme,
+			expanded: false,
+		});
+		const lines = comp.render(120);
+		const text = lines.join("\n");
+		expect(text).toContain("write sample.txt");
+		expect(text).toContain("↳ pending overwrite");
+		// In collapsed mode the diff renderer emits the hidden-content hint
+		// rather than the body rows.
+		expect(text).not.toContain("▌- 1 │ ");
+		expect(text).not.toContain("▌+ 1 │ ");
+		expect(text).toMatch(/^…|^… \(/m);
+	});
+
+	it("invalidates cached output when update() changes inputs", () => {
+		const comp = new DiffPreviewComponent({
+			prefixLines: ["first"],
+			diffData: longDiffData,
+			theme: identityTheme,
+			expanded: true,
+		});
+		const first = comp.render(80).join("\n");
+		comp.update({ prefixLines: ["second"], diffData: longDiffData, theme: identityTheme, expanded: true });
+		const second = comp.render(80).join("\n");
+		expect(first).toContain("first");
+		expect(second).toContain("second");
+		expect(second).not.toContain("first");
+	});
+});

--- a/tests/tui-diff-renderer.test.ts
+++ b/tests/tui-diff-renderer.test.ts
@@ -91,4 +91,35 @@ describe("renderTuiDiff", () => {
     expect(renderTuiDiff({ diffData, width: 36, theme, expanded: false }).lines.at(-1)).toMatch(/^… \(/);
     expect(renderTuiDiff({ diffData, width: 8, theme, expanded: false }).lines.at(-1)).toBe("…");
   });
+
+  it("wraps long diff rows with hanging indent instead of truncating with ellipsis", () => {
+    const longText = "the quick brown fox jumps over the lazy dog and keeps going far past the right edge";
+    const longDiffData: DiffData = {
+      version: 1,
+      entries: [
+        { kind: "remove", oldLine: 1, text: longText },
+        { kind: "add", newLine: 1, text: longText.toUpperCase() },
+        { kind: "context", oldLine: 2, newLine: 2, text: "tail" },
+      ],
+      stats: { added: 1, removed: 1, context: 1 },
+      blockRanges: [{ kind: "add", startLine: 1, endLine: 2 }],
+    };
+    const width = 60;
+    const out = renderTuiDiff({ diffData: longDiffData, width, theme: identityTheme, expanded: true });
+    expect(out.mode).toBe("unified");
+    for (const line of out.lines) expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+    expect(out.lines.some((line) => line.endsWith("..."))).toBe(false);
+    const removeIdx = out.lines.findIndex((line) => line.startsWith("▌- 1 │ "));
+    expect(removeIdx).toBeGreaterThanOrEqual(0);
+    const indent = " ".repeat(visibleWidth("▌- 1 │ "));
+    expect(out.lines[removeIdx + 1]?.startsWith(indent)).toBe(true);
+    const reassembled = [out.lines[removeIdx]!.slice(visibleWidth("▌- 1 │ "))];
+    let cursor = removeIdx + 1;
+    while (cursor < out.lines.length && out.lines[cursor]!.startsWith(indent) && !out.lines[cursor]!.startsWith("▌")) {
+      reassembled.push(out.lines[cursor]!.slice(indent.length));
+      cursor++;
+    }
+    const collapse = (s: string) => s.replace(/\s+/g, " ").trim();
+    expect(collapse(reassembled.join(" "))).toBe(collapse(longText));
+  });
 });

--- a/tests/tui-diff-renderer.test.ts
+++ b/tests/tui-diff-renderer.test.ts
@@ -122,4 +122,39 @@ describe("renderTuiDiff", () => {
     const collapse = (s: string) => s.replace(/\s+/g, " ").trim();
     expect(collapse(reassembled.join(" "))).toBe(collapse(longText));
   });
+
+  it("falls back to unified mode for pure-add diffs even when the pane is wide enough for split", () => {
+    const pureAdd: DiffData = {
+      version: 1,
+      entries: [
+        { kind: "add", newLine: 1, text: "first added line" },
+        { kind: "add", newLine: 2, text: "second added line" },
+        { kind: "add", newLine: 3, text: "third added line" },
+      ],
+      stats: { added: 3, removed: 0, context: 0 },
+      blockRanges: [{ kind: "add", startLine: 1, endLine: 3 }],
+    };
+    const out = renderTuiDiff({ diffData: pureAdd, width: 160, theme: identityTheme, expanded: true });
+    expect(out.mode).toBe("unified");
+    const text = out.lines.join("\n");
+    expect(text).toContain("▌+ 1 │ first added line");
+    expect(text).not.toMatch(/^old\s+│ new$/m);
+  });
+
+  it("split mode tints add/remove/context rows on both panes", () => {
+    const colorTheme = {
+      fg: (kind: string, text: string) => `<${kind}>${text}</${kind}>`,
+      bold: (text: string) => text,
+    } as any;
+    const out = renderTuiDiff({ diffData: markerDiffData, width: 140, theme: colorTheme, expanded: true });
+    expect(out.mode).toBe("split");
+    const text = out.lines.join("\n");
+    // remove row appears tinted on the left pane
+    expect(text).toMatch(/<error>[^<]*▌- 1 │ one[^<]*<\/error>/);
+    // add row appears tinted on the right pane
+    expect(text).toMatch(/<success>[^<]*▌\+ 1 │ ONE[^<]*<\/success>/);
+    // context row is tinted with toolOutput on both sides
+    const contextMatches = text.match(/<toolOutput>[^<]*▌\s{2}2 │ two[^<]*<\/toolOutput>/g) ?? [];
+    expect(contextMatches.length).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/tests/write-pending-diff-render-success.test.ts
+++ b/tests/write-pending-diff-render-success.test.ts
@@ -21,11 +21,26 @@ const theme = {
 };
 
 describe("write renderCall pending diff preview", () => {
-	it("renders a pending overwrite preview", () => {
+	it("renders a collapsed pending overwrite preview by default", () => {
 		const cwd = mkdtempSync(resolve(tmpdir(), "pi-write-pending-success-"));
 		writeFileSync(resolve(cwd, "sample.txt"), "old value\n", "utf-8");
 		const tool = getWriteTool();
-		const context: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined };
+		const context: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined, expanded: false };
+
+		const rendered = tool.renderCall({ path: "sample.txt", content: "new value\n" }, theme, context);
+		const text = textOf(rendered);
+
+		expect(text).toContain("↳ pending overwrite");
+		expect(text).toContain("Ctrl+O to expand");
+		expect(text).not.toContain("↳ diff +1 -1");
+		expect(text).not.toContain("▌- 1");
+	});
+
+	it("renders the full diff body when expanded", () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-write-pending-expanded-"));
+		writeFileSync(resolve(cwd, "sample.txt"), "old value\n", "utf-8");
+		const tool = getWriteTool();
+		const context: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined, expanded: true };
 
 		const rendered = tool.renderCall({ path: "sample.txt", content: "new value\n" }, theme, context);
 		const text = textOf(rendered);

--- a/tests/write-pending-diff-render-success.test.ts
+++ b/tests/write-pending-diff-render-success.test.ts
@@ -68,8 +68,8 @@ describe("write renderCall pending diff preview", () => {
 		const expandedContext: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined, expanded: true };
 		const expanded = textOf(tool.renderCall({ path: "fresh.txt", content: "hello\nworld\n" }, theme, expandedContext));
 		expect(expanded).toContain("↳ pending create");
-		expect(expanded).toContain("  hello");
-		expect(expanded).toContain("  world");
+		expect(expanded).toContain("  1 │ hello");
+		expect(expanded).toContain("  2 │ world");
 		expect(expanded).not.toContain("↳ diff +");
 		expect(expanded).not.toContain("▌+");
 	});

--- a/tests/write-pending-diff-render-success.test.ts
+++ b/tests/write-pending-diff-render-success.test.ts
@@ -54,16 +54,23 @@ describe("write renderCall pending diff preview", () => {
 	it("suppresses the diff body for pending create (pure-add) writes", () => {
 		const cwd = mkdtempSync(resolve(tmpdir(), "pi-write-pending-create-"));
 		const tool = getWriteTool();
-		const context: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined, expanded: true };
 
-		const rendered = tool.renderCall({ path: "fresh.txt", content: "hello\nworld\n" }, theme, context);
-		const text = textOf(rendered);
+		// Collapsed: just the "pending create" header with a Ctrl+O hint. No diff header, no body, no file contents.
+		const collapsedContext: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined, expanded: false };
+		const collapsed = textOf(tool.renderCall({ path: "fresh.txt", content: "hello\nworld\n" }, theme, collapsedContext));
+		expect(collapsed).toContain("↳ pending create");
+		expect(collapsed).toContain("Ctrl+O to expand");
+		expect(collapsed).not.toContain("↳ diff +");
+		expect(collapsed).not.toContain("▌+");
+		expect(collapsed).not.toContain("hello");
 
-		expect(text).toContain("↳ pending create");
-		// Pure creates have no "old" side — the diff UI (header, gutters, line numbers) is suppressed.
-		expect(text).not.toContain("↳ diff +");
-		expect(text).not.toContain("▌+");
-		// And the "Ctrl+O to expand" hint shouldn't appear on either pending create line, because there is nothing more to expand into.
-		expect(text).not.toContain("Ctrl+O to expand");
+		// Expanded: the new file's contents are shown indented (no gutter, no line numbers, no colors).
+		const expandedContext: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined, expanded: true };
+		const expanded = textOf(tool.renderCall({ path: "fresh.txt", content: "hello\nworld\n" }, theme, expandedContext));
+		expect(expanded).toContain("↳ pending create");
+		expect(expanded).toContain("  hello");
+		expect(expanded).toContain("  world");
+		expect(expanded).not.toContain("↳ diff +");
+		expect(expanded).not.toContain("▌+");
 	});
 });

--- a/tests/write-pending-diff-render-success.test.ts
+++ b/tests/write-pending-diff-render-success.test.ts
@@ -50,4 +50,20 @@ describe("write renderCall pending diff preview", () => {
 		expect(text).toContain("▌- 1 │ old value");
 		expect(text).toContain("▌+ 1 │ new value");
 	});
+
+	it("suppresses the diff body for pending create (pure-add) writes", () => {
+		const cwd = mkdtempSync(resolve(tmpdir(), "pi-write-pending-create-"));
+		const tool = getWriteTool();
+		const context: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined, expanded: true };
+
+		const rendered = tool.renderCall({ path: "fresh.txt", content: "hello\nworld\n" }, theme, context);
+		const text = textOf(rendered);
+
+		expect(text).toContain("↳ pending create");
+		// Pure creates have no "old" side — the diff UI (header, gutters, line numbers) is suppressed.
+		expect(text).not.toContain("↳ diff +");
+		expect(text).not.toContain("▌+");
+		// And the "Ctrl+O to expand" hint shouldn't appear on either pending create line, because there is nothing more to expand into.
+		expect(text).not.toContain("Ctrl+O to expand");
+	});
 });

--- a/tests/write-render-tui.test.ts
+++ b/tests/write-render-tui.test.ts
@@ -37,13 +37,13 @@ describe("write TUI renderer", () => {
     const cwd = mkdtempSync(resolve(tmpdir(), "pi-write-render-"));
     writeFileSync(resolve(cwd, "old.txt"), "old\n", "utf-8");
     const t = tool();
-    const createContext: any = { cwd, state: {}, invalidate: vi.fn() };
+    const createContext: any = { cwd, state: {}, invalidate: vi.fn(), expanded: true };
     const first = t.renderCall({ path: "new.txt", content: "one\ntwo" }, theme, createContext);
     const second = t.renderCall({ path: "new.txt", content: "one\ntwo" }, theme, { ...createContext, lastComponent: first });
     expect(textOf(second)).toContain("↳ pending create");
     expect(textOf(second)).toContain("↳ diff +2 -0");
 
-    const overwriteContext: any = { cwd, state: {}, invalidate: vi.fn() };
+    const overwriteContext: any = { cwd, state: {}, invalidate: vi.fn(), expanded: true };
     const third = t.renderCall({ path: "old.txt", content: "old\nnew" }, theme, overwriteContext);
     const fourth = t.renderCall({ path: "old.txt", content: "old\nnew" }, theme, { ...overwriteContext, lastComponent: third });
     expect(textOf(fourth)).toContain("↳ pending overwrite");

--- a/tests/write-render-tui.test.ts
+++ b/tests/write-render-tui.test.ts
@@ -81,4 +81,33 @@ describe("write TUI renderer", () => {
     expect(overwriteText).toContain("↳ pending overwrite");
     expect(overwriteText).toContain("↳ diff +1 -0");
   });
+
+  it("collapses the pending preview to just the call line once execution has started", () => {
+    const cwd = mkdtempSync(resolve(tmpdir(), "pi-write-exec-collapse-"));
+    writeFileSync(resolve(cwd, "old.txt"), "old\n", "utf-8");
+    const t = tool();
+
+    // Before execution: pending preview is visible (with content for create, diff for overwrite).
+    const beforeCreate: any = { cwd, state: {}, invalidate: vi.fn(), expanded: true, argsComplete: true, executionStarted: false };
+    const beforeCreateText = textOf(t.renderCall({ path: "new.txt", content: "one\ntwo" }, theme, beforeCreate));
+    expect(beforeCreateText).toContain("↳ pending create");
+
+    const beforeOverwrite: any = { cwd, state: {}, invalidate: vi.fn(), expanded: true, argsComplete: true, executionStarted: false };
+    const beforeOverwriteText = textOf(t.renderCall({ path: "old.txt", content: "old\nnew" }, theme, beforeOverwrite));
+    expect(beforeOverwriteText).toContain("↳ pending overwrite");
+
+    // After execution starts: the call row drops the pending preview entirely.
+    // renderResult is responsible for the post-exec story (↳ created / ↳ overwritten).
+    const afterCreate: any = { cwd, state: {}, invalidate: vi.fn(), expanded: true, argsComplete: true, executionStarted: true };
+    const afterCreateText = textOf(t.renderCall({ path: "new.txt", content: "one\ntwo" }, theme, afterCreate));
+    expect(afterCreateText).toBe("write new.txt (2 lines • 7 B)");
+    expect(afterCreateText).not.toContain("pending");
+    expect(afterCreateText).not.toContain("  one");
+
+    const afterOverwrite: any = { cwd, state: {}, invalidate: vi.fn(), expanded: true, argsComplete: true, executionStarted: true };
+    const afterOverwriteText = textOf(t.renderCall({ path: "old.txt", content: "old\nnew" }, theme, afterOverwrite));
+    expect(afterOverwriteText).toBe("write old.txt (2 lines • 7 B)");
+    expect(afterOverwriteText).not.toContain("pending");
+    expect(afterOverwriteText).not.toContain("diff +");
+  });
 });

--- a/tests/write-render-tui.test.ts
+++ b/tests/write-render-tui.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { registerWriteTool } from "../src/write.js";
 
 const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
-function textOf(component: any): string { return component?.text ?? component?.render?.(120)?.join("\n") ?? ""; }
+function textOf(component: any, width = 120): string { return component?.text ?? component?.render?.(width)?.join("\n") ?? ""; }
 function tool(): any { let registered: any; registerWriteTool({ registerTool(def: any) { registered = def; } } as any, {} as any); return registered; }
 
 describe("write TUI renderer", () => {
@@ -15,7 +15,7 @@ describe("write TUI renderer", () => {
     const baseDiffData = { version: 1, stats: { added: 3, removed: 0, context: 0 }, entries: [{ kind: "add", newLine: 1, text: "one" }, { kind: "add", newLine: 2, text: "two" }, { kind: "add", newLine: 3, text: "three" }] };
     const created: any = { content: [{ type: "text", text: "1:abc|one\n2:def|two\n3:aaa|three" }], details: { writeState: "created", diffData: baseDiffData, ptcValue: { tool: "write", diffData: { sentinel: true } } } };
     const before = JSON.stringify(created.details);
-    const rendered = textOf(t.renderResult(created, { expanded: true, width: 80 }, theme, { expanded: true, width: 80 }));
+    const rendered = textOf(t.renderResult(created, { expanded: true, width: 80 }, theme, { expanded: true, width: 80 }), 80);
     expect(rendered.split("\n")[0]).toBe("↳ created");
     expect(rendered).toContain("↳ diff +3 -0 • 1 hunk • 1 file • unified");
     expect(rendered).toContain("▌+ 1 │ one");

--- a/tests/write-render-tui.test.ts
+++ b/tests/write-render-tui.test.ts
@@ -13,16 +13,26 @@ describe("write TUI renderer", () => {
     const t = tool();
     expect(textOf(t.renderCall({ path: "tmp/file.txt", content: "one\ntwo\nthree" }, theme, {}))).toBe("write tmp/file.txt (3 lines • 13 B)");
     const baseDiffData = { version: 1, stats: { added: 3, removed: 0, context: 0 }, entries: [{ kind: "add", newLine: 1, text: "one" }, { kind: "add", newLine: 2, text: "two" }, { kind: "add", newLine: 3, text: "three" }] };
+    // Pure create: diff UI is suppressed — every line is an add and the gutter/line-numbers add no signal.
     const created: any = { content: [{ type: "text", text: "1:abc|one\n2:def|two\n3:aaa|three" }], details: { writeState: "created", diffData: baseDiffData, ptcValue: { tool: "write", diffData: { sentinel: true } } } };
     const before = JSON.stringify(created.details);
-    const rendered = textOf(t.renderResult(created, { expanded: true, width: 80 }, theme, { expanded: true, width: 80 }), 80);
-    expect(rendered.split("\n")[0]).toBe("↳ created");
-    expect(rendered).toContain("↳ diff +3 -0 • 1 hunk • 1 file • unified");
-    expect(rendered).toContain("▌+ 1 │ one");
+    const createdRendered = textOf(t.renderResult(created, { expanded: true, width: 80 }, theme, { expanded: true, width: 80 }), 80);
+    expect(createdRendered).toBe("↳ created");
+    expect(createdRendered).not.toContain("diff +");
+    expect(createdRendered).not.toContain("▌+");
     expect(JSON.stringify(created.details)).toBe(before);
 
-    const overwritten: any = { content: created.content, details: { ...created.details, writeState: "overwritten" } };
-    expect(textOf(t.renderResult(overwritten, {}, theme, {}))).toBe("↳ overwritten • Ctrl+O to expand");
+    // Overwrite: diff UI is preserved — the old vs new comparison still has signal.
+    const overwrittenDiffData = { version: 1, stats: { added: 1, removed: 1, context: 0 }, entries: [{ kind: "remove", oldLine: 1, text: "old" }, { kind: "add", newLine: 1, text: "new" }] };
+    const overwritten: any = { content: created.content, details: { writeState: "overwritten", diffData: overwrittenDiffData, ptcValue: { tool: "write" } } };
+    const overwrittenRendered = textOf(t.renderResult(overwritten, { expanded: true, width: 80 }, theme, { expanded: true, width: 80 }), 80);
+    expect(overwrittenRendered.split("\n")[0]).toBe("↳ overwritten");
+    expect(overwrittenRendered).toContain("↳ diff +1 -1 • 1 hunk • 1 file • unified");
+    expect(overwrittenRendered).toContain("▌- 1 │ old");
+    expect(overwrittenRendered).toContain("▌+ 1 │ new");
+
+    const collapsed: any = { content: created.content, details: { ...created.details, writeState: "overwritten", diffData: overwrittenDiffData } };
+    expect(textOf(t.renderResult(collapsed, {}, theme, {}))).toBe("↳ overwritten • Ctrl+O to expand");
   });
 
 
@@ -37,15 +47,22 @@ describe("write TUI renderer", () => {
     const cwd = mkdtempSync(resolve(tmpdir(), "pi-write-render-"));
     writeFileSync(resolve(cwd, "old.txt"), "old\n", "utf-8");
     const t = tool();
+
+    // Pending create: no diff UI — just the summary + "pending create" header.
     const createContext: any = { cwd, state: {}, invalidate: vi.fn(), expanded: true };
     const first = t.renderCall({ path: "new.txt", content: "one\ntwo" }, theme, createContext);
     const second = t.renderCall({ path: "new.txt", content: "one\ntwo" }, theme, { ...createContext, lastComponent: first });
-    expect(textOf(second)).toContain("↳ pending create");
-    expect(textOf(second)).toContain("↳ diff +2 -0");
+    const createdText = textOf(second);
+    expect(createdText).toContain("↳ pending create");
+    expect(createdText).not.toContain("diff +");
+    expect(createdText).not.toContain("▌+");
 
+    // Pending overwrite: diff UI is preserved — old vs new still carries signal.
     const overwriteContext: any = { cwd, state: {}, invalidate: vi.fn(), expanded: true };
     const third = t.renderCall({ path: "old.txt", content: "old\nnew" }, theme, overwriteContext);
     const fourth = t.renderCall({ path: "old.txt", content: "old\nnew" }, theme, { ...overwriteContext, lastComponent: third });
-    expect(textOf(fourth)).toContain("↳ pending overwrite");
+    const overwriteText = textOf(fourth);
+    expect(overwriteText).toContain("↳ pending overwrite");
+    expect(overwriteText).toContain("↳ diff +1 -0");
   });
 });

--- a/tests/write-render-tui.test.ts
+++ b/tests/write-render-tui.test.ts
@@ -13,13 +13,27 @@ describe("write TUI renderer", () => {
     const t = tool();
     expect(textOf(t.renderCall({ path: "tmp/file.txt", content: "one\ntwo\nthree" }, theme, {}))).toBe("write tmp/file.txt (3 lines • 13 B)");
     const baseDiffData = { version: 1, stats: { added: 3, removed: 0, context: 0 }, entries: [{ kind: "add", newLine: 1, text: "one" }, { kind: "add", newLine: 2, text: "two" }, { kind: "add", newLine: 3, text: "three" }] };
-    // Pure create: diff UI is suppressed — every line is an add and the gutter/line-numbers add no signal.
-    const created: any = { content: [{ type: "text", text: "1:abc|one\n2:def|two\n3:aaa|three" }], details: { writeState: "created", diffData: baseDiffData, ptcValue: { tool: "write", diffData: { sentinel: true } } } };
+    // Pure create: diff UI is suppressed — every line is an add. The expanded
+    // form shows the new file's contents indented (no gutter, no line numbers,
+    // no colors).
+    const createdPtcLines = [
+      { line: 1, hash: "abc", anchor: "1:abc", raw: "one", display: "one" },
+      { line: 2, hash: "def", anchor: "2:def", raw: "two", display: "two" },
+      { line: 3, hash: "aaa", anchor: "3:aaa", raw: "three", display: "three" },
+    ];
+    const created: any = { content: [{ type: "text", text: "1:abc|one\n2:def|two\n3:aaa|three" }], details: { writeState: "created", diffData: baseDiffData, ptcValue: { tool: "write", diffData: { sentinel: true }, lines: createdPtcLines } } };
     const before = JSON.stringify(created.details);
-    const createdRendered = textOf(t.renderResult(created, { expanded: true, width: 80 }, theme, { expanded: true, width: 80 }), 80);
-    expect(createdRendered).toBe("↳ created");
-    expect(createdRendered).not.toContain("diff +");
-    expect(createdRendered).not.toContain("▌+");
+
+    const createdCollapsed = textOf(t.renderResult(created, {}, theme, {}), 80);
+    expect(createdCollapsed).toBe("↳ created • Ctrl+O to expand");
+
+    const createdExpanded = textOf(t.renderResult(created, { expanded: true, width: 80 }, theme, { expanded: true, width: 80 }), 80);
+    expect(createdExpanded.split("\n")[0]).toBe("↳ created");
+    expect(createdExpanded).toContain("  one");
+    expect(createdExpanded).toContain("  two");
+    expect(createdExpanded).toContain("  three");
+    expect(createdExpanded).not.toContain("diff +");
+    expect(createdExpanded).not.toContain("▌+");
     expect(JSON.stringify(created.details)).toBe(before);
 
     // Overwrite: diff UI is preserved — the old vs new comparison still has signal.
@@ -48,12 +62,14 @@ describe("write TUI renderer", () => {
     writeFileSync(resolve(cwd, "old.txt"), "old\n", "utf-8");
     const t = tool();
 
-    // Pending create: no diff UI — just the summary + "pending create" header.
+    // Pending create: no diff UI — expanded shows the new content indented.
     const createContext: any = { cwd, state: {}, invalidate: vi.fn(), expanded: true };
     const first = t.renderCall({ path: "new.txt", content: "one\ntwo" }, theme, createContext);
     const second = t.renderCall({ path: "new.txt", content: "one\ntwo" }, theme, { ...createContext, lastComponent: first });
     const createdText = textOf(second);
     expect(createdText).toContain("↳ pending create");
+    expect(createdText).toContain("  one");
+    expect(createdText).toContain("  two");
     expect(createdText).not.toContain("diff +");
     expect(createdText).not.toContain("▌+");
 

--- a/tests/write-render-tui.test.ts
+++ b/tests/write-render-tui.test.ts
@@ -110,4 +110,30 @@ describe("write TUI renderer", () => {
     expect(afterOverwriteText).not.toContain("pending");
     expect(afterOverwriteText).not.toContain("diff +");
   });
+
+  it("renders the create content preview when theme.fg uses `this` (regression: bind theme.fg)", () => {
+    // Real pi themes implement Theme.fg as a method on a class instance that
+    // reads `this.fgColors`. If the renderer extracts `theme.fg` without
+    // binding, calling it standalone crashes with "Cannot read properties of
+    // undefined (reading 'fgColors')". This stub mimics that contract.
+    class MethodTheme {
+      tag: string;
+      constructor() { this.tag = "truecolor"; }
+      fg(style: string, text: string) { if (!this.tag) throw new TypeError("this is undefined"); return `[${style}]${text}[/${style}]`; }
+      bold(text: string) { return text; }
+    }
+    const methodTheme: any = new MethodTheme();
+    const t = tool();
+    const ptcLines = [
+      { line: 1, hash: "abc", anchor: "1:abc", raw: "one", display: "one" },
+      { line: 2, hash: "def", anchor: "2:def", raw: "two", display: "two" },
+    ];
+    const created: any = { content: [{ type: "text", text: "1:abc|one\n2:def|two" }], details: { writeState: "created", ptcValue: { tool: "write", lines: ptcLines } } };
+    let rendered: any;
+    expect(() => { rendered = t.renderResult(created, { expanded: true, width: 80 }, methodTheme, { expanded: true, width: 80 }); }).not.toThrow();
+    const out = textOf(rendered, 80);
+    expect(out).toContain("↳ created");
+    expect(out).toContain("[dim]1 │ [/dim]one");
+    expect(out).toContain("[dim]2 │ [/dim]two");
+  });
 });

--- a/tests/write-render-tui.test.ts
+++ b/tests/write-render-tui.test.ts
@@ -29,9 +29,9 @@ describe("write TUI renderer", () => {
 
     const createdExpanded = textOf(t.renderResult(created, { expanded: true, width: 80 }, theme, { expanded: true, width: 80 }), 80);
     expect(createdExpanded.split("\n")[0]).toBe("↳ created");
-    expect(createdExpanded).toContain("  one");
-    expect(createdExpanded).toContain("  two");
-    expect(createdExpanded).toContain("  three");
+    expect(createdExpanded).toContain("  1 │ one");
+    expect(createdExpanded).toContain("  2 │ two");
+    expect(createdExpanded).toContain("  3 │ three");
     expect(createdExpanded).not.toContain("diff +");
     expect(createdExpanded).not.toContain("▌+");
     expect(JSON.stringify(created.details)).toBe(before);
@@ -68,8 +68,8 @@ describe("write TUI renderer", () => {
     const second = t.renderCall({ path: "new.txt", content: "one\ntwo" }, theme, { ...createContext, lastComponent: first });
     const createdText = textOf(second);
     expect(createdText).toContain("↳ pending create");
-    expect(createdText).toContain("  one");
-    expect(createdText).toContain("  two");
+    expect(createdText).toContain("  1 │ one");
+    expect(createdText).toContain("  2 │ two");
     expect(createdText).not.toContain("diff +");
     expect(createdText).not.toContain("▌+");
 


### PR DESCRIPTION
## Summary

Cleans up `edit` and `write` TUI rendering after several rounds of manual testing. Six commits, scoped to TUI-only paths; no change to tool execution semantics or non-TUI output.

The work grew organically from "long diff rows truncate with `...`" into a broader pass on how `edit`/`write` rows look across all the states a tool can be in (streaming → pending → executing → completed, collapsed vs. expanded).

## What changed (commit-by-commit)

### 1. `77e4d69` — wrap long diff rows; collapse pending previews

- New helper `wrapWithHangingIndent` (`src/tui-render-utils.ts`) wraps a prefixed row to width with continuation-line indent aligned to the prefix column; optional per-line `tint` so theme color spans extend correctly across wrapped lines.
- `src/tui-diff-renderer.ts` `unifiedRows` / `compactRows` use it instead of hard-truncating with `clampLinesToWidth`.
- `edit.ts` / `write.ts` pending previews honor `context.expanded`, so the call row collapses once execution finishes.

### 2. `5643807` — defer wrapping to render-time width via `DiffPreviewComponent`

- **Root cause of "still wrapping at 78 cols":** pi's `ToolRenderContext` doesn't carry the viewport `width`. The wrapped text was being baked into a `Text` component at the wrong width.
- New `DiffPreviewComponent` (`src/tui-diff-component.ts`) implements `Component` and runs `renderTuiDiff` at the width passed into `render(width)`, caching per-width.
- `edit.ts` / `write.ts` return a `DiffPreviewComponent` when there's diff content and the view is expanded; plain `Text` otherwise.

### 3. `f28d9c6` — tint split-mode rows; skip split for pure-add diffs

- `splitRows` now runs add / remove / context entries through `wrapWithHangingIndent({ tint })` so all three get red / green / muted tinting on both panes.
- New `padRightVisual` pads by visible width so the central `│` separator stays aligned through ANSI codes.
- `chooseMode` requires `hasOldSide(data)` before picking split; pure-add diffs (pending creates, write to a new file) fall through to unified at the same width.

### 4. `08248e4` + `2d40309` — drop diff UI for `write` creates; show indented content instead

- Pure creates (`write` to a new file) have no "old" side — every line is an add and the diff chrome (`▌+`, line numbers, `+N -0` header, red/green tint) carries no signal.
- Gated on `preview.data.fileExistedBeforeWrite` (pending) and `writeState === "overwritten"` (final).
- Creates now show the new file's contents **on expand** (no diff chrome). Overwrites keep the full diff component because old vs. new still carries signal.
- Capped at 200 lines with `… N more lines not shown` truncation footer.

### 5. `f42138a` — drop pending preview from `renderCall` once execution starts

- `renderCall` and `renderResult` always stack; once execution kicks off, the pre-exec pending row and the post-exec result row are guaranteed to match. Two rows is duplicate noise.
- `renderCall` now short-circuits to just the top call line (`edit path (N edits)` / `write path (N lines • B B)`) once `context.executionStarted` is `true`. The post-exec story is carried entirely by `renderResult`.
- Applies symmetrically to **`edit`** and **`write`**.

### 6. `923b1fd` + `ade1186` — dim line-number gutter for create content preview

- The "indented content" body from step 4 sat flush against `↳ created` with only two spaces of indentation, so the header and body bled together visually.
- Added a right-aligned, dim line-number gutter (`  N │ `) — same `│` separator the diff renderer uses, but without `▌+`/`▌-` markers or red/green tint. Gives the body a stable column and a clear boundary against the header.
- **`ade1186`** fixes a `this`-binding bug: real pi themes implement `Theme.fg` as a class method that reads `this.fgColors`. Calling `const fg = theme.fg; fg(...)` standalone crashed with `Cannot read properties of undefined (reading 'fgColors')`. The framework's `renderResult` `try/catch {}` swallowed the error silently and fell back to the raw `result.content[0].text` (hashlines like `1:c88|…`). Fix: route through `theme.fg(style, text)` to preserve `this`. Regression test uses a method-style theme stub that crashes the previous code.

## Resulting row shapes

```
edit src/foo.ts (1 edit)
 ↳ edited +1 -1 • semantic                 (Ctrl+O to expand → tinted diff)

write tmp/new.txt (6 lines • 219 B)
 ↳ created                                 (Ctrl+O to expand →)
   1 │ first line of the new file          ← dim "1 │ " gutter
   2 │ second line
   …

write tmp/existing.txt (4 lines • …)
 ↳ overwritten                             (Ctrl+O to expand → tinted diff
                                            of old vs. new)
```

Each row collapses to a single sub-line, never two. While args stream / before execution starts, the pending preview still renders (`↳ pending edit` / `↳ pending create` / `↳ pending overwrite`) so users still see "here's what's about to happen."

## Tests

- `tui-diff-renderer.test.ts` — long-line wrapping at width 60 (unified mode, no `...`, prefix-aligned continuation rows, content reassembles); split-mode tinting on both panes; pure-add stays unified at width 160.
- `tui-diff-component.test.ts` — render(60) vs. render(160) produce different layouts and modes (deferred wrapping works).
- `edit-pending-diff-render-success.test.ts` — collapsed vs. expanded pending edit; pending preview disappears once `executionStarted: true`.
- `write-pending-diff-render-success.test.ts` — collapsed vs. expanded pending overwrite (full diff); pending create suppresses diff and shows indented content with `N │ ` gutter on expand.
- `write-render-tui.test.ts` — created result shows indented content, no diff chrome; overwritten result still shows full diff; pending preview disappears once `executionStarted: true`; regression test against a method-style theme stub that crashes if `theme.fg` is called without `this` binding.
- `edit-render-tui.test.ts` / `renderer-expanded-width-coverage.test.ts` — updated to the new shape (width 80 for unified-mode assertions; overwrite fixtures where the diff renderer is exercised).

## Verification

- `npm run typecheck` — clean
- `npm test` — **1474 / 1474 pass**
- Manually re-tested in TUI after each commit against `pi-desktop-default-dark` theme.

## Notes for reviewers

- The pending preview only suppresses *after* `context.executionStarted` flips. While args stream, you still see `↳ pending edit • Ctrl+O to expand` and can preview the diff/content.
- `DiffPreviewComponent` caches per-width — resizing the TUI re-renders correctly without recomputing on every keystroke.
- The fix in `ade1186` (binding `theme.fg`) is worth flagging: any future extension that destructures `theme.fg` will hit the same silent fallback. Worth considering an upstream improvement to the framework's `renderResult` try/catch to surface (or at least log) the swallowed error.
- No change to non-TUI output paths, hashline anchors, or tool execution semantics.
