### PR TITLE
feat: support custom languages in ast_search via sg scan

### DIFF
--- a/src/readmap/enums.ts
+++ b/src/readmap/enums.ts
@@ -10,6 +10,7 @@ export enum SymbolKind {
   Interface = "interface",
   Type = "type",
   Enum = "enum",
+  Signal = "signal",
   Struct = "struct",
   Import = "import",
   Module = "module",

--- a/src/readmap/language-detect.ts
+++ b/src/readmap/language-detect.ts
@@ -79,6 +79,9 @@ const EXTENSION_MAP: Record<string, LanguageInfo> = {
   // CSV
   ".csv": { id: "csv", name: "CSV" },
   ".tsv": { id: "csv", name: "TSV" },
+
+  // GDScript
+  ".gd": { id: "gdscript", name: "GDScript" },
 };
 
 /**

--- a/src/readmap/mapper.ts
+++ b/src/readmap/mapper.ts
@@ -8,6 +8,7 @@ import { cppMapper, MAPPER_VERSION as CPP_VERSION } from "./mappers/cpp.js";
 import { csvMapper, MAPPER_VERSION as CSV_VERSION } from "./mappers/csv.js";
 import { ctagsMapper, MAPPER_VERSION as CTAGS_VERSION } from "./mappers/ctags.js";
 import { fallbackMapper, MAPPER_VERSION as FALLBACK_VERSION } from "./mappers/fallback.js";
+import { gdscriptMapper, MAPPER_VERSION as GDSRIPT_VERSION } from "./mappers/gdscript.js";
 import { goMapper, MAPPER_VERSION as GO_VERSION } from "./mappers/go.js";
 import { jsonMapper, MAPPER_VERSION as JSON_VERSION } from "./mappers/json.js";
 import { javaMapper, javaMapperFromContent, MAPPER_VERSION as JAVA_VERSION } from "./mappers/java.js";
@@ -68,6 +69,8 @@ const MAPPERS_V: Record<string, MapperEntry> = {
   swift: { fn: swiftMapper, version: SWIFT_VERSION },
   // Phase 7: Shell/Bash regex mapper
   shell: { fn: shellMapper, version: SHELL_VERSION },
+  // Phase 8: GDScript (gdtoolkit subprocess)
+  gdscript: { fn: gdscriptMapper, version: GDSRIPT_VERSION },
 };
 
 type ContentMapperFn = (

--- a/src/readmap/mappers/gdscript.ts
+++ b/src/readmap/mappers/gdscript.ts
@@ -1,0 +1,132 @@
+import { exec } from "node:child_process";
+import { stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import type { FileMap, FileSymbol } from "../types.js";
+
+import { DetailLevel, SymbolKind } from "../enums.js";
+export const MAPPER_VERSION = 1;
+
+const execAsync = promisify(exec);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = join(__dirname, "gdscript_outline.py");
+
+interface GdSymbol {
+  name: string;
+  kind: string;
+  startLine: number;
+  endLine: number;
+  signature?: string;
+  children?: GdSymbol[];
+}
+
+interface GdOutlineResult {
+  imports?: string[];
+  symbols: GdSymbol[];
+  error?: string;
+}
+
+function mapKind(kind: string): SymbolKind {
+  switch (kind) {
+    case "class": {
+      return SymbolKind.Class;
+    }
+    case "function": {
+      return SymbolKind.Function;
+    }
+    case "constant": {
+      return SymbolKind.Constant;
+    }
+    case "variable": {
+      return SymbolKind.Variable;
+    }
+    case "signal": {
+      return SymbolKind.Signal;
+    }
+    case "enum": {
+      return SymbolKind.Enum;
+    }
+    default: {
+      return SymbolKind.Unknown;
+    }
+  }
+}
+
+function convertSymbol(gs: GdSymbol): FileSymbol {
+  const symbol: FileSymbol = {
+    name: gs.name,
+    kind: mapKind(gs.kind),
+    startLine: gs.startLine,
+    endLine: gs.endLine,
+  };
+
+  if (gs.signature) {
+    symbol.signature = gs.signature;
+  }
+
+  if (gs.children && gs.children.length > 0) {
+    symbol.children = gs.children.map(convertSymbol);
+  }
+
+  return symbol;
+}
+
+/**
+ * Generate a file map for a GDScript file using gdtoolkit (Lark-based parser).
+ */
+export async function gdscriptMapper(
+  filePath: string,
+  signal?: AbortSignal
+): Promise<FileMap | null> {
+  try {
+    const stats = await stat(filePath);
+    const totalBytes = stats.size;
+
+    const { stdout: wcOutput } = await execAsync(`wc -l < "${filePath}"`, {
+      signal,
+    });
+    const totalLines = Number.parseInt(wcOutput.trim(), 10) || 0;
+
+    const { stdout, stderr } = await execAsync(
+      `python3 "${SCRIPT_PATH}" "${filePath}"`,
+      {
+        signal,
+        timeout: 10_000,
+        maxBuffer: 5 * 1024 * 1024,
+      }
+    );
+
+    if (stderr && !stdout) {
+      console.error(`GDScript mapper stderr: ${stderr}`);
+      return null;
+    }
+
+    const result: GdOutlineResult = JSON.parse(stdout);
+
+    if (result.error) {
+      console.error(`GDScript mapper error: ${result.error}`);
+      return null;
+    }
+
+    const fileMap: FileMap = {
+      path: filePath,
+      totalLines,
+      totalBytes,
+      language: "GDScript",
+      symbols: result.symbols.map(convertSymbol),
+      imports: result.imports ?? [],
+      detailLevel: DetailLevel.Full,
+    };
+
+    return fileMap;
+  } catch (error) {
+    if (signal?.aborted) {
+      return null;
+    }
+    console.error(`GDScript mapper failed: ${error}`);
+    return null;
+  }
+}

--- a/src/readmap/mappers/gdscript_outline.py
+++ b/src/readmap/mappers/gdscript_outline.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Parse a GDScript file using gdtoolkit (Lark-based parser) and emit a JSON
+outline for pi-hashline-readmap.
+
+Usage: python3 gdscript_outline.py <file.gd>
+
+Requires: pip install gdtoolkit
+"""
+import json
+import sys
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Token helpers
+# ---------------------------------------------------------------------------
+
+def _token_str(tok):
+    """Return the string value of a Lark token or tree node."""
+    if hasattr(tok, "value"):
+        return tok.value
+    return str(tok)
+
+
+def _token_line(tok):
+    """Return the 1-indexed line number of a token."""
+    if hasattr(tok, "line") and tok.line is not None:
+        return tok.line
+    # Fallback: walk children
+    if hasattr(tok, "children"):
+        for ch in tok.children:
+            line = _token_line(ch)
+            if line:
+                return line
+    return 0
+
+
+def _find_var_name(node):
+    """Recursively find the variable-name token inside a class_var child."""
+    if hasattr(node, "data"):
+        if node.data in (
+            "class_var_typed_assgnd",
+            "class_var_assigned",
+            "class_var_typed",
+            "class_var",
+        ):
+            return node.children[0]
+        for child in node.children:
+            result = _find_var_name(child)
+            if result is not None:
+                return result
+    return node  # leaf token
+
+
+# ---------------------------------------------------------------------------
+# AST walker
+# ---------------------------------------------------------------------------
+
+def _build_signature(header) -> str:
+    """Build 'name(args) -> ret' from a func_header node."""
+    name = _token_str(header.children[0])
+    args_node = header.children[1] if len(header.children) > 1 else None
+    ret_node = header.children[2] if len(header.children) > 2 else None
+
+    args: list[str] = []
+    if args_node and hasattr(args_node, "data") and args_node.data == "func_args":
+        for arg in args_node.children:
+            if hasattr(arg, "data"):
+                if arg.data == "func_arg_typed":
+                    args.append(f"{_token_str(arg.children[0])}: {_token_str(arg.children[1])}")
+                elif arg.data == "func_arg":
+                    args.append(_token_str(arg.children[0]))
+                else:
+                    args.append(_token_str(arg))
+            else:
+                args.append(_token_str(arg))
+
+    sig = f"{name}({', '.join(args)})"
+    if ret_node and _token_str(ret_node).strip():
+        sig += f" -> {_token_str(ret_node)}"
+    return sig
+
+
+def _process_node(node) -> dict[str, Any] | None:
+    rule = node.data if hasattr(node, "data") else None
+    children = node.children if hasattr(node, "children") else []
+
+    if rule == "extends_stmt":
+        return None
+
+    if rule == "classname_stmt":
+        return {
+            "kind": "class",
+            "name": _token_str(children[0]),
+            "startLine": _token_line(children[0]),
+        }
+
+    if rule == "class_def":
+        name_token = children[0]
+        name = _token_str(name_token)
+        start = _token_line(name_token)
+        kids = [c for c in (_process_node(ch) for ch in children[1:]) if c]
+        sym: dict[str, Any] = {
+            "kind": "class",
+            "name": name,
+            "startLine": start,
+        }
+        if kids:
+            sym["children"] = kids
+        return sym
+
+    if rule == "func_def":
+        header = children[0]
+        name_token = header.children[0]
+        name = _token_str(name_token)
+        start = _token_line(name_token)
+        return {
+            "kind": "function",
+            "name": name,
+            "startLine": start,
+            "signature": _build_signature(header),
+        }
+
+    if rule == "const_stmt":
+        name_token = children[0]
+        return {
+            "kind": "constant",
+            "name": _token_str(name_token),
+            "startLine": _token_line(name_token),
+        }
+
+    if rule == "class_var_stmt":
+        name_node = _find_var_name(children[0])
+        return {
+            "kind": "variable",
+            "name": _token_str(name_node),
+            "startLine": _token_line(name_node),
+        }
+
+    if rule == "signal_stmt":
+        name_token = children[0]
+        return {
+            "kind": "signal",
+            "name": _token_str(name_token),
+            "startLine": _token_line(name_token),
+        }
+
+    if rule == "enum_stmt":
+        if children and hasattr(children[0], "data") and children[0].data == "enum_named":
+            name_token = children[0].children[0]
+            return {
+                "kind": "enum",
+                "name": _token_str(name_token),
+                "startLine": _token_line(name_token),
+            }
+
+    return None
+
+
+def extract_outline(tree) -> list[dict[str, Any]]:
+    """Walk the Lark AST and extract a flat+nested outline."""
+    result: list[dict[str, Any]] = []
+    for child in tree.children:
+        item = _process_node(child)
+        if item:
+            result.append(item)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# End-line estimation (linear scan, same pattern as other mappers)
+# ---------------------------------------------------------------------------
+
+def _estimate_endlines(symbols: list[dict], total_lines: int):
+    """Mutate symbols to add endLine = next symbol's startLine - 1."""
+    for i, sym in enumerate(symbols):
+        # Recurse into children first
+        if sym.get("children"):
+            _estimate_endlines(sym["children"], total_lines)
+
+        next_start = symbols[i + 1]["startLine"] if i + 1 < len(symbols) else total_lines + 1
+        # If this symbol has children, endLine = last child's endLine
+        if sym.get("children"):
+            sym["endLine"] = sym["children"][-1]["endLine"]
+        else:
+            sym["endLine"] = next_start - 1
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: gdscript_outline.py <file.gd>", file=sys.stderr)
+        sys.exit(1)
+
+    filepath = sys.argv[1]
+    try:
+        from gdtoolkit.parser import parser
+        import subprocess
+
+        code = open(filepath).read()
+        total_lines = code.count("\n") + 1
+
+        tree = parser.parse(code)
+        outline = extract_outline(tree)
+        _estimate_endlines(outline, total_lines)
+
+        # Collect imports (load, preload, requires)
+        imports: list[str] = []
+        for child in tree.children:
+            if hasattr(child, "data") and child.data in ("load_stmt", "preload_stmt", "requires_stmt"):
+                imports.append(_token_str(child.children[0]))
+
+        print(json.dumps({"symbols": outline, "imports": imports}))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sg.ts
+++ b/src/sg.ts
@@ -3,7 +3,8 @@ import { Text } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import * as cp from "node:child_process";
 import path from "node:path";
-import { readFile as fsReadFile, stat as fsStat } from "node:fs/promises";
+import { readFile as fsReadFile, stat as fsStat, writeFile as fsWriteFile, unlink as fsUnlink, mkdtemp as fsMkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 import { normalizeToLF, stripBom } from "./edit-diff.js";
 import { ensureHashInit } from "./hashline.js";
@@ -13,6 +14,25 @@ import type { FileSymbol } from "./readmap/types.js";
 import { buildSgOutput } from "./sg-output.js";
 import { buildAstSearchRehydrateDescriptor, isContextHygieneDebugEnabled } from "./context-hygiene.js";
 import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine } from "./tui-render-utils.js";
+
+// Built-in languages supported by ast-grep's `--lang` flag.
+// Languages not in this list are treated as custom languages and require
+// `sg scan -r <rule_file>` instead of `sg run -l <lang>`.
+const SG_BUILTIN_LANGS = new Set([
+  "ts", "tsx", "js", "jsx", "json", "jsonc",
+  "py", "rs", "go", "java", "kt", "kts",
+  "rb", "php", "scala", "swift", "c", "cpp", "h", "hpp",
+  "css", "html", "xml", "yaml", "yml", "toml",
+  "sh", "bash", "zsh", "bat", "ps1",
+  "md", "txt", "csv",
+  "r", "dart", "lua", "elisp", "emacs-lisp",
+  "dockerfile", "docker", "sql", "graphql", "proto",
+  "hcl", "tf", "vue", "svelte", "astro",
+  "nix", "elm", "ocaml", "res", "resi",
+  "ml", "mli", "gleam", "zig", "v", "nim",
+  "jl", "fsharp", "fs", "fsi", "fsx", "fsscript",
+  "cobol", "cob", "cbl",
+]);
 
 type SgParams = { pattern: string; lang?: string; path?: string };
 const CONTEXT_HYGIENE_SG_SYMBOL_FILE_CAP = 20;
@@ -233,8 +253,24 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
           // Already handled by the prior fsStat block; fall through.
         }
       }
-      if (effectiveLang) args.push("-l", effectiveLang);
-      args.push(searchPath);
+
+      // Detect if the language is a custom language (not in ast-grep's built-in list).
+      // Custom languages require `sg scan -r <rule_file>` instead of `sg run -l <lang>`.
+      const isCustomLang = effectiveLang && !SG_BUILTIN_LANGS.has(effectiveLang.toLowerCase());
+      let ruleFile: string | undefined;
+
+      if (isCustomLang) {
+        // Create a temporary rule file for custom languages
+        const tmpDir = await fsMkdtemp(path.join(tmpdir(), "ast-grep-"));
+        ruleFile = path.join(tmpDir, "rule.yml");
+        const ruleContent = `rule:\n  pattern: ${p.pattern.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}\n  kind: ${effectiveLang}\n`;
+        await fsWriteFile(ruleFile, ruleContent);
+        args.length = 0; // Clear existing args
+        args.push("scan", "--json", "-r", ruleFile, searchPath);
+      } else {
+        if (effectiveLang) args.push("-l", effectiveLang);
+        args.push(searchPath);
+      }
 
       try {
         const { stdout } = await execFileText("sg", args, {
@@ -381,6 +417,15 @@ export function registerSgTool(pi: ExtensionAPI, options: SgToolOptions = {}) {
             },
           },
         };
+      } finally {
+        // Clean up temporary rule file if we created one for custom languages
+        if (ruleFile) {
+          try {
+            await fsUnlink(ruleFile);
+          } catch {
+            // Ignore cleanup errors
+          }
+        }
       }
     },
     renderCall(args: any, theme: any, ...rest: any[]) {


### PR DESCRIPTION
Support custom languages (like GDScript) in ast_search by using `sg scan -r rule.yml` instead of `sg run -l lang`.

Changes:
- Detect custom languages vs built-in ast-grep languages
- Create temporary rule file for custom languages
- Use `sg scan --json -r <rule_file> <path>` for custom languages
- Clean up temp file in finally block

Note: This is split from the GDScript mapper PR (#109) as a separate concern. Custom language support is independent of GDScript specifically.