### PR TITLE
chore: ignore go_outline binary; drop stale debug files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ TOOL_TESTING_REPORT*.md
 USER_REALISTIC_TESTING_REPORT*.md
 .tmp-verify/
 
+# Compiled outline helpers (sources are tracked; binaries are not)
+scripts/go_outline
+
 # ── GSD baseline (auto-generated) ──
 .gsd
 *.code-workspace


### PR DESCRIPTION
Tiny cleanup spotted while wrapping up the 0.8.12 install-hang fix.

- Add `scripts/go_outline` to `.gitignore` — it's an untracked compiled Mach-O binary that's been dirtying `git status` for everyone. The matching `.go` source is already tracked; the build output should not be.
- Delete four stale debug files from `.megapowers/` left over from old sessions (`bare-cr.txt`, `tmp-edit-test.txt`, `tmp-repro-159-replace.txt`, `tmp-repro-159-replace-all.txt`). `.megapowers/` is already gitignored so these were untracked — the deletion is local-only and doesn't appear in the diff.

No code changes, no test changes, no behavior change.