### PR TITLE
feat(config): add native Hashline settings JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,23 +227,81 @@ PI_RTK_BYPASS=1 git log --stat
 
 ## Configuration
 
-Most users do not need configuration. Use environment variables when you want to tighten visible grep output budgets, change where structural map caches are stored, disable persistent map caching, tune Bash output recovery, or enable context-hygiene debugging.
+Most users do not need configuration. Durable Hashline options can live in JSON settings files, while existing environment variables remain supported for temporary overrides and are **not deprecated**.
+
+Canonical settings files:
+
+- Global: `~/.pi/agent/hashline-readmap/settings.json`
+- Project: `<repo>/.pi/hashline-readmap/settings.json`
+
+Precedence is: environment variables > project JSON > global JSON > built-in defaults. Project JSON overrides global JSON field-by-field. Unsupported legacy or alias paths are intentionally not read: `~/.pi/agent/settings.json`, `<repo>/.pi/settings.json`, `~/.pi/hashline-readmap/settings.json`, and `<repo>/.pi/hashline-readmap.json`.
+
+Example project settings:
+
+```json
+{
+  "grep": {
+    "maxLines": 1200,
+    "maxBytes": 40960
+  },
+  "mapCache": {
+    "dir": ".cache/hashline/maps",
+    "enabled": true
+  },
+  "bashContextGuard": {
+    "enabled": true,
+    "maxLines": 1500,
+    "maxBytes": 40960,
+    "headLines": 60,
+    "tailLines": 100
+  }
+}
+```
+
+JSON fields:
+
+| JSON field | Environment override | Default / ceiling behavior |
+|---|---|---|
+| `grep.maxLines` | `PI_HASHLINE_GREP_MAX_LINES` | Tightens `grep`'s final visible line budget; above-default values are clamped down to the built-in default |
+| `grep.maxBytes` | `PI_HASHLINE_GREP_MAX_BYTES` | Tightens `grep`'s final visible byte budget; above-default values are clamped down to the built-in default |
+| `mapCache.dir` | `PI_HASHLINE_MAP_CACHE_DIR` | Overrides the persistent structural-map cache directory; otherwise falls back to `$XDG_CACHE_HOME/pi-hashline-readmap/maps`, then `~/.cache/pi-hashline-readmap/maps` |
+| `mapCache.enabled` | `PI_HASHLINE_NO_PERSIST_MAPS=1` | Defaults to `true`; the env var disables on-disk map caching regardless of JSON |
+| `bashContextGuard.enabled` | `PI_HASHLINE_BASH_CONTEXT_GUARD` | Defaults to `true`; exact env value `0` disables the guard, any other set value enables it |
+| `bashContextGuard.maxLines` | `PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES` | Tightens the post-RTK Bash guard line budget; default/ceiling `2000` |
+| `bashContextGuard.maxBytes` | `PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES` | Tightens the post-RTK Bash guard byte budget; default/ceiling `51200` raw bytes |
+| `bashContextGuard.headLines` | `PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES` | Tightens the guarded preview head size; default/ceiling `80` |
+| `bashContextGuard.tailLines` | `PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES` | Tightens the guarded preview tail size; default/ceiling `120` |
+
+Budget fields must be strict positive base-10 integers. Zero, negative, signed, decimal, hexadecimal, exponent notation, separators, empty strings, and whitespace-only values are ignored. Malformed JSON files and invalid fields degrade safely: valid fields continue to apply where practical, invalid fields are ignored, and the loader emits non-fatal warnings where available.
+
+Other environment-only options:
 
 | Variable | Purpose | Default / behavior |
 |---|---|---|
-| `PI_HASHLINE_GREP_MAX_LINES` | Tighten `grep`'s final visible line budget | Positive base-10 integer; invalid/unset values use the built-in default; above-default values are clamped down |
-| `PI_HASHLINE_GREP_MAX_BYTES` | Tighten `grep`'s final visible byte budget | Positive base-10 integer; invalid/unset values use the built-in default; above-default values are clamped down |
-| `PI_HASHLINE_MAP_CACHE_DIR` | Override the persistent structural-map cache directory | Uses the provided path verbatim |
 | `XDG_CACHE_HOME` | Base directory for the persistent map cache when no explicit cache dir is set | Cache lives under `$XDG_CACHE_HOME/pi-hashline-readmap/maps` |
-| `PI_HASHLINE_NO_PERSIST_MAPS=1` | Disable the on-disk structural-map cache | Keeps caching in-memory only |
 | `PI_NUSHELL_CONFIG` | Override the Nushell config path used by `nu` | Otherwise prefers `~/.config/pi/nushell/config.nu`, then `--no-config-file` |
 | `PI_RTK_BYPASS=1` | Disable route-specific `bash` compression for one command invocation | ANSI is still stripped; anti-pattern hints still apply; the Bash context guard can still trim oversized output |
-| `PI_HASHLINE_BASH_CONTEXT_GUARD=0` | Disable the Bash context guard and original-output restoration layer | Any value other than exact `0` leaves the default-on guard enabled |
-| `PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES` | Tighten the post-RTK Bash guard line budget | Positive base-10 integer; invalid/unset values use `2000`; above-default values are clamped down |
-| `PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES` | Tighten the post-RTK Bash guard byte budget | Positive base-10 integer interpreted as raw bytes; invalid/unset values use `51200`; above-default values are clamped down |
-| `PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES` | Tighten the guarded preview head size | Positive base-10 integer; invalid/unset values use `80`; above-default values are clamped down |
-| `PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES` | Tighten the guarded preview tail size | Positive base-10 integer; invalid/unset values use `120`; above-default values are clamped down |
 | `PI_CONTEXT_HYGIENE_DEBUG=1` | Register the debug-only `context_hygiene_report` read-only tool | Disabled unless explicitly set to `1` |
+
+Migration example:
+
+```bash
+# before: shell startup file
+export PI_HASHLINE_GREP_MAX_LINES=1200
+export PI_HASHLINE_GREP_MAX_BYTES=40960
+export PI_HASHLINE_MAP_CACHE_DIR=.cache/hashline/maps
+export PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES=1500
+```
+
+After, in `<repo>/.pi/hashline-readmap/settings.json`:
+
+```json
+{
+  "grep": { "maxLines": 1200, "maxBytes": 40960 },
+  "mapCache": { "dir": ".cache/hashline/maps" },
+  "bashContextGuard": { "maxLines": 1500 }
+}
+```
 
 ## Advanced documentation
 

--- a/docs/exploratory-functional-testing.md
+++ b/docs/exploratory-functional-testing.md
@@ -25,6 +25,33 @@ This document is not a bug diary. It is the current testing reference for what t
 
 ## Expected functionality
 
+### Hashline settings JSON
+
+Expected behavior:
+
+- reads global settings from `~/.pi/agent/hashline-readmap/settings.json`
+- reads project settings from `<repo>/.pi/hashline-readmap/settings.json`
+- does not read unsupported paths such as `~/.pi/agent/settings.json`, `<repo>/.pi/settings.json`, `~/.pi/hashline-readmap/settings.json`, or `<repo>/.pi/hashline-readmap.json`
+- applies precedence as env vars > project JSON > global JSON > built-in defaults
+- supports JSON fields for grep budgets, map-cache directory/enabled state, and Bash context guard settings
+- preserves existing env-only behavior for all supported `PI_HASHLINE_*` variables
+- ignores malformed JSON files safely and reports non-fatal warnings where available
+- ignores invalid field values field-by-field where practical
+- treats budget fields as strict positive base-10 integers and ignores zero, negative, signed, decimal, hex, exponent, separator, empty, and whitespace-only values
+
+Practical expectation:
+
+- a user should be able to move durable Hashline configuration out of shell startup files and into global or project JSON settings, while still using env vars for temporary overrides
+
+JSON settings verification procedure:
+
+- create a temporary global settings file at `~/.pi/agent/hashline-readmap/settings.json` with a below-default `grep.maxLines`, run `grep` against a result set larger than that limit, and confirm the visible output budget follows the JSON value
+- create a project settings file at `<repo>/.pi/hashline-readmap/settings.json` with a different `grep.maxLines` and confirm it overrides the global JSON value when no `PI_HASHLINE_GREP_MAX_LINES` env var is set
+- remove or rename both canonical JSON files, set the equivalent `PI_HASHLINE_*` env vars, and confirm the existing env-only grep, map-cache, and Bash context-guard behavior still applies
+- set both JSON and env values for the same field, then confirm the env value wins; include `PI_HASHLINE_MAP_CACHE_DIR`, `PI_HASHLINE_NO_PERSIST_MAPS=1`, and `PI_HASHLINE_BASH_CONTEXT_GUARD=0` in this override check
+- put settings in unsupported paths such as `~/.pi/agent/settings.json`, `<repo>/.pi/settings.json`, `~/.pi/hashline-readmap/settings.json`, or `<repo>/.pi/hashline-readmap.json`, with canonical files absent, and confirm those files have no effect
+- introduce malformed JSON and invalid budget values, then confirm public tool resolvers continue without throwing and fall back to valid env, valid other JSON fields, or defaults
+
 ### `read`
 
 Expected behavior:

--- a/src/grep-budget.ts
+++ b/src/grep-budget.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "@earendil-works/pi-coding-agent";
+import { resolveHashlineJsonSettings } from "./hashline-settings.js";
 
 const POSITIVE_BASE10_INT = /^[1-9][0-9]*$/;
 
@@ -38,10 +39,18 @@ export interface GrepOutputBudget {
 export const GREP_OUTPUT_DEFAULT_MAX_LINES = DEFAULT_MAX_LINES;
 export const GREP_OUTPUT_DEFAULT_MAX_BYTES = Math.min(DEFAULT_MAX_BYTES, 50 * 1024);
 
-function resolveDimension(rawEnvValue: string | undefined, ceiling: number): number {
+function resolveEnvDimension(rawEnvValue: string | undefined, ceiling: number): number | undefined {
 	const parsed = parsePositiveBase10Int(rawEnvValue);
-	if (parsed === undefined) return ceiling;
-	return Math.min(parsed, ceiling);
+	return parsed === undefined ? undefined : Math.min(parsed, ceiling);
+}
+
+function resolveDimension(rawEnvValue: string | undefined, jsonValue: number | undefined, ceiling: number): number {
+	if (rawEnvValue !== undefined) {
+		const envValue = resolveEnvDimension(rawEnvValue, ceiling);
+		if (envValue !== undefined) return envValue;
+	}
+	if (jsonValue !== undefined) return Math.min(jsonValue, ceiling);
+	return ceiling;
 }
 
 /**
@@ -54,13 +63,16 @@ function resolveDimension(rawEnvValue: string | undefined, ceiling: number): num
  * are used as-is.
  */
 export function resolveGrepOutputBudget(): GrepOutputBudget {
+	const settings = resolveHashlineJsonSettings().settings.grep;
 	return {
 		maxLines: resolveDimension(
 			process.env.PI_HASHLINE_GREP_MAX_LINES,
+			settings?.maxLines,
 			GREP_OUTPUT_DEFAULT_MAX_LINES,
 		),
 		maxBytes: resolveDimension(
 			process.env.PI_HASHLINE_GREP_MAX_BYTES,
+			settings?.maxBytes,
 			GREP_OUTPUT_DEFAULT_MAX_BYTES,
 		),
 	};

--- a/src/hashline-settings.ts
+++ b/src/hashline-settings.ts
@@ -1,0 +1,193 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface HashlineJsonSettings {
+  grep?: { maxLines?: number; maxBytes?: number };
+  mapCache?: { dir?: string; enabled?: boolean };
+  bashContextGuard?: { enabled?: boolean; maxLines?: number; maxBytes?: number; headLines?: number; tailLines?: number };
+}
+export interface HashlineSettingsWarning { source: string; message: string; path?: string }
+export interface HashlineSettingsResult { settings: HashlineJsonSettings; warnings: HashlineSettingsWarning[] }
+let pathOverride: { globalSettingsPath?: string; projectSettingsPath?: string } | null = null;
+export function __setHashlineSettingsPathsForTest(paths: { globalSettingsPath?: string; projectSettingsPath?: string }): void { pathOverride = { ...paths }; }
+export function __resetHashlineSettingsPathsForTest(): void { pathOverride = null; }
+function defaultGlobalSettingsPath(): string { return join(homedir(), ".pi/agent/hashline-readmap/settings.json"); }
+function defaultProjectSettingsPath(): string { return join(process.cwd(), ".pi/hashline-readmap/settings.json"); }
+function isRecord(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value); }
+function invalid(source: string, path: string): HashlineSettingsWarning { return { source, path, message: `Invalid hashline setting at ${path}` }; }
+function readJsonObjectEnd(text: string, open: number): number {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = open; i < text.length; i += 1) {
+    const char = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+    } else if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+function readJsonStringEnd(text: string, quote: number): number {
+  let escaped = false;
+  for (let i = quote + 1; i < text.length; i += 1) {
+    const char = text[i];
+    if (escaped) escaped = false;
+    else if (char === "\\") escaped = true;
+    else if (char === '"') return i;
+  }
+  return -1;
+}
+function readTopLevelObjectBodies(rawText: string, section: string): string[] {
+  const bodies: string[] = [];
+  let depth = 0;
+  for (let i = 0; i < rawText.length; i += 1) {
+    const char = rawText[i];
+    if (char === '"') {
+      const end = readJsonStringEnd(rawText, i);
+      if (end < 0) return bodies;
+      if (depth === 1) {
+        const fieldName = rawText.slice(i + 1, end);
+        let cursor = end + 1;
+        while (/\s/.test(rawText[cursor] ?? "")) cursor += 1;
+        if (rawText[cursor] === ":") {
+          cursor += 1;
+          while (/\s/.test(rawText[cursor] ?? "")) cursor += 1;
+          if (fieldName === section && rawText[cursor] === "{") {
+            const objectEnd = readJsonObjectEnd(rawText, cursor);
+            if (objectEnd < 0) return bodies;
+            bodies.push(rawText.slice(cursor + 1, objectEnd));
+            i = objectEnd;
+            continue;
+          }
+        }
+      }
+      i = end;
+    } else if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth = Math.max(0, depth - 1);
+    }
+  }
+  return bodies;
+}
+function rawFieldTokens(rawText: string, path: string): string[] {
+  const [section, key] = path.split(".");
+  const bodies = readTopLevelObjectBodies(rawText, section);
+  if (bodies.length !== 1) return [];
+  const body = bodies[0];
+  const tokens: string[] = [];
+  let depth = 0;
+  for (let i = 0; i < body.length; i += 1) {
+    const char = body[i];
+    if (char === '"') {
+      const end = readJsonStringEnd(body, i);
+      if (end < 0) return tokens;
+      if (depth === 0) {
+        const fieldName = body.slice(i + 1, end);
+        let cursor = end + 1;
+        while (/\s/.test(body[cursor] ?? "")) cursor += 1;
+        if (body[cursor] === ":") {
+          cursor += 1;
+          while (/\s/.test(body[cursor] ?? "")) cursor += 1;
+          if (fieldName === key) {
+            const valueStart = cursor;
+            while (cursor < body.length && !/[,}\s]/.test(body[cursor])) cursor += 1;
+            tokens.push(body.slice(valueStart, cursor));
+          }
+        }
+      }
+      i = end;
+    } else if (char === "{" || char === "[") {
+      depth += 1;
+    } else if (char === "}" || char === "]") {
+      depth = Math.max(0, depth - 1);
+    }
+  }
+  return tokens;
+}
+function isStrictJsonPositiveInteger(rawText: string, path: string, value: unknown): value is number {
+  const tokens = rawFieldTokens(rawText, path);
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 && tokens.length === 1 && /^[1-9][0-9]*$/.test(tokens[0]);
+}
+function readPositive(raw: Record<string, unknown>, key: string, path: string, source: string, rawText: string, warnings: HashlineSettingsWarning[]): number | undefined {
+  if (!(key in raw)) return undefined;
+  if (isStrictJsonPositiveInteger(rawText, path, raw[key])) return raw[key];
+  warnings.push(invalid(source, path));
+  return undefined;
+}
+function readBoolean(raw: Record<string, unknown>, key: string, path: string, source: string, warnings: HashlineSettingsWarning[]): boolean | undefined {
+  if (!(key in raw)) return undefined;
+  if (typeof raw[key] === "boolean") return raw[key];
+  warnings.push(invalid(source, path));
+  return undefined;
+}
+function validateSettings(raw: unknown, source: string, rawText: string): HashlineSettingsResult {
+  const settings: HashlineJsonSettings = {};
+  const warnings: HashlineSettingsWarning[] = [];
+  if (!isRecord(raw)) return { settings, warnings };
+  if (isRecord(raw.grep)) {
+    const grep: NonNullable<HashlineJsonSettings["grep"]> = {};
+    const maxLines = readPositive(raw.grep, "maxLines", "grep.maxLines", source, rawText, warnings);
+    if (maxLines !== undefined) grep.maxLines = maxLines;
+    const maxBytes = readPositive(raw.grep, "maxBytes", "grep.maxBytes", source, rawText, warnings);
+    if (maxBytes !== undefined) grep.maxBytes = maxBytes;
+    if (Object.keys(grep).length > 0) settings.grep = grep;
+  }
+  if (isRecord(raw.mapCache)) {
+    const mapCache: NonNullable<HashlineJsonSettings["mapCache"]> = {};
+    if ("dir" in raw.mapCache) {
+      if (typeof raw.mapCache.dir === "string" && raw.mapCache.dir.length > 0) mapCache.dir = raw.mapCache.dir;
+      else warnings.push(invalid(source, "mapCache.dir"));
+    }
+    const enabled = readBoolean(raw.mapCache, "enabled", "mapCache.enabled", source, warnings);
+    if (enabled !== undefined) mapCache.enabled = enabled;
+    if (Object.keys(mapCache).length > 0) settings.mapCache = mapCache;
+  }
+  if (isRecord(raw.bashContextGuard)) {
+    const bashContextGuard: NonNullable<HashlineJsonSettings["bashContextGuard"]> = {};
+    const enabled = readBoolean(raw.bashContextGuard, "enabled", "bashContextGuard.enabled", source, warnings);
+    if (enabled !== undefined) bashContextGuard.enabled = enabled;
+    for (const key of ["maxLines", "maxBytes", "headLines", "tailLines"] as const) {
+      const value = readPositive(raw.bashContextGuard, key, `bashContextGuard.${key}`, source, rawText, warnings);
+      if (value !== undefined) bashContextGuard[key] = value;
+    }
+    if (Object.keys(bashContextGuard).length > 0) settings.bashContextGuard = bashContextGuard;
+  }
+  return { settings, warnings };
+}
+function readSettingsFile(path: string): HashlineSettingsResult {
+  if (!existsSync(path)) return { settings: {}, warnings: [] };
+  try {
+    const text = readFileSync(path, "utf8");
+    return validateSettings(JSON.parse(text) as unknown, path, text);
+  } catch (error) {
+    return { settings: {}, warnings: [{ source: path, message: `Invalid JSON: ${error instanceof Error ? error.message : String(error)}` }] };
+  }
+}
+function mergeSettings(base: HashlineJsonSettings, override: HashlineJsonSettings): HashlineJsonSettings {
+  const merged: HashlineJsonSettings = {};
+  const grep = { ...(base.grep ?? {}), ...(override.grep ?? {}) };
+  if (Object.keys(grep).length > 0) merged.grep = grep;
+  const mapCache = { ...(base.mapCache ?? {}), ...(override.mapCache ?? {}) };
+  if (Object.keys(mapCache).length > 0) merged.mapCache = mapCache;
+  const bashContextGuard = { ...(base.bashContextGuard ?? {}), ...(override.bashContextGuard ?? {}) };
+  if (Object.keys(bashContextGuard).length > 0) merged.bashContextGuard = bashContextGuard;
+  return merged;
+}
+export function resolveHashlineJsonSettings(): HashlineSettingsResult {
+  const globalResult = readSettingsFile(pathOverride?.globalSettingsPath ?? defaultGlobalSettingsPath());
+  const projectResult = readSettingsFile(pathOverride?.projectSettingsPath ?? defaultProjectSettingsPath());
+  return { settings: mergeSettings(globalResult.settings, projectResult.settings), warnings: [...globalResult.warnings, ...projectResult.warnings] };
+}

--- a/src/map-cache.ts
+++ b/src/map-cache.ts
@@ -7,6 +7,7 @@ import {
   contentHashFor64k,
   readCached,
   writeCached,
+  persistenceEnabled,
 } from "./persistent-map-cache.js";
 interface CacheEntry {
 	mtimeMs: number;
@@ -16,9 +17,6 @@ interface CacheEntry {
 export const MAP_CACHE_MAX_SIZE = 500;
 const cache = new Map<string, CacheEntry>();
 let maxSize = MAP_CACHE_MAX_SIZE;
-function persistenceEnabled(): boolean {
-	return process.env.PI_HASHLINE_NO_PERSIST_MAPS !== "1";
-}
 function rememberInMemory(absPath: string, entry: CacheEntry): void {
 	if (cache.has(absPath)) cache.delete(absPath);
 	cache.set(absPath, entry);

--- a/src/persistent-map-cache.ts
+++ b/src/persistent-map-cache.ts
@@ -4,16 +4,21 @@ import { createHash, randomBytes } from "node:crypto";
 import { open, readFile, writeFile as fsWriteFile, mkdir as fsMkdir, rename, readdir, stat, unlink } from "node:fs/promises";
 import xxhashWasm from "xxhash-wasm";
 import type { FileMap } from "./readmap/types.js";
+import { resolveHashlineJsonSettings } from "./hashline-settings.js";
 
 /**
- * Resolve the on-disk map-cache directory using env precedence:
+ * Resolve the on-disk map-cache directory using config precedence:
  * 1. `PI_HASHLINE_MAP_CACHE_DIR` (when non-empty) — used verbatim.
- * 2. `$XDG_CACHE_HOME/pi-hashline-readmap/maps` (when non-empty).
- * 3. `~/.cache/pi-hashline-readmap/maps`.
+ * 2. JSON `mapCache.dir` (when configured).
+ * 3. `$XDG_CACHE_HOME/pi-hashline-readmap/maps` (when non-empty).
+ * 4. `~/.cache/pi-hashline-readmap/maps`.
  */
 export function resolveCacheDir(): string {
   const explicit = process.env.PI_HASHLINE_MAP_CACHE_DIR;
   if (explicit && explicit.length > 0) return explicit;
+
+  const configured = resolveHashlineJsonSettings().settings.mapCache?.dir;
+  if (configured && configured.length > 0) return configured;
 
   const xdg = process.env.XDG_CACHE_HOME;
   if (xdg && xdg.length > 0) return join(xdg, "pi-hashline-readmap/maps");
@@ -21,8 +26,11 @@ export function resolveCacheDir(): string {
   return join(homedir(), ".cache/pi-hashline-readmap/maps");
 }
 
-function persistenceEnabled(): boolean {
-  return process.env.PI_HASHLINE_NO_PERSIST_MAPS !== "1";
+export function persistenceEnabled(): boolean {
+  if (process.env.PI_HASHLINE_NO_PERSIST_MAPS === "1") return false;
+  const configured = resolveHashlineJsonSettings().settings.mapCache?.enabled;
+  if (configured !== undefined) return configured;
+  return true;
 }
 
 /**
@@ -189,10 +197,11 @@ export function __setEvictionHooksForTest(
   if (typeof hooks.cap === "number") evictionCap = hooks.cap;
 }
 
+const CACHE_KEY_FILE = /^[0-9a-f]{32}\.json$/;
 async function maybeEvict(): Promise<void> {
   try {
     const dir = resolveCacheDir();
-    const names = (await readdir(dir)).filter((n) => n.endsWith(".json"));
+    const names = (await readdir(dir)).filter((n) => CACHE_KEY_FILE.test(n));
     if (names.length <= evictionCap) return;
 
     const entries: Array<{ path: string; age: number }> = [];

--- a/src/rtk/bash-context-guard.ts
+++ b/src/rtk/bash-context-guard.ts
@@ -3,6 +3,7 @@ import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parsePositiveBase10Int } from "../grep-budget.js";
+import { resolveHashlineJsonSettings } from "../hashline-settings.js";
 import type { BashOriginalOutputMetadata } from "./bash-original-output.js";
 
 export const BASH_CONTEXT_GUARD_DEFAULT_MAX_LINES = 2000;
@@ -68,10 +69,18 @@ function mergeFs(overrides: Partial<BashContextGuardFs> | undefined): BashContex
   return { ...defaultFs(), ...(overrides ?? {}) };
 }
 
-function resolveDimension(rawEnvValue: string | undefined, ceiling: number): number {
+function resolveEnvDimension(rawEnvValue: string | undefined, ceiling: number): number | undefined {
   const parsed = parsePositiveBase10Int(rawEnvValue);
-  if (parsed === undefined) return ceiling;
-  return Math.min(parsed, ceiling);
+  return parsed === undefined ? undefined : Math.min(parsed, ceiling);
+}
+
+function resolveDimension(rawEnvValue: string | undefined, jsonValue: number | undefined, ceiling: number): number {
+  if (rawEnvValue !== undefined) {
+    const envValue = resolveEnvDimension(rawEnvValue, ceiling);
+    if (envValue !== undefined) return envValue;
+  }
+  if (jsonValue !== undefined) return Math.min(jsonValue, ceiling);
+  return ceiling;
 }
 
 function lineCount(text: string): number {
@@ -193,12 +202,18 @@ function renderPreview(options: {
 }
 
 export function resolveBashContextGuardConfig(env: Env = process.env): BashContextGuardConfig {
+  const settings = resolveHashlineJsonSettings().settings.bashContextGuard;
+  const enabled = env.PI_HASHLINE_BASH_CONTEXT_GUARD === "0"
+    ? false
+    : env.PI_HASHLINE_BASH_CONTEXT_GUARD !== undefined
+      ? true
+      : settings?.enabled ?? true;
   return {
-    enabled: env.PI_HASHLINE_BASH_CONTEXT_GUARD !== "0",
-    maxLines: resolveDimension(env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES, BASH_CONTEXT_GUARD_DEFAULT_MAX_LINES),
-    maxBytes: resolveDimension(env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES, BASH_CONTEXT_GUARD_DEFAULT_MAX_BYTES),
-    headLines: resolveDimension(env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES, BASH_CONTEXT_GUARD_DEFAULT_HEAD_LINES),
-    tailLines: resolveDimension(env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES, BASH_CONTEXT_GUARD_DEFAULT_TAIL_LINES),
+    enabled,
+    maxLines: resolveDimension(env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES, settings?.maxLines, BASH_CONTEXT_GUARD_DEFAULT_MAX_LINES),
+    maxBytes: resolveDimension(env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES, settings?.maxBytes, BASH_CONTEXT_GUARD_DEFAULT_MAX_BYTES),
+    headLines: resolveDimension(env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES, settings?.headLines, BASH_CONTEXT_GUARD_DEFAULT_HEAD_LINES),
+    tailLines: resolveDimension(env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES, settings?.tailLines, BASH_CONTEXT_GUARD_DEFAULT_TAIL_LINES),
   };
 }
 

--- a/tests/bash-context-guard-config.test.ts
+++ b/tests/bash-context-guard-config.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { randomBytes } from "node:crypto";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   BASH_CONTEXT_GUARD_DEFAULT_HEAD_LINES,
   BASH_CONTEXT_GUARD_DEFAULT_MAX_BYTES,
@@ -6,6 +10,7 @@ import {
   BASH_CONTEXT_GUARD_DEFAULT_TAIL_LINES,
   resolveBashContextGuardConfig,
 } from "../src/rtk/bash-context-guard.js";
+import { __resetHashlineSettingsPathsForTest, __setHashlineSettingsPathsForTest } from "../src/hashline-settings.js";
 
 describe("resolveBashContextGuardConfig", () => {
   const saved = {
@@ -22,6 +27,10 @@ describe("resolveBashContextGuardConfig", () => {
     delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES;
     delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES;
     delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES;
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(tmpdir(), `missing-global-${randomBytes(6).toString("hex")}.json`),
+      projectSettingsPath: join(tmpdir(), `missing-project-${randomBytes(6).toString("hex")}.json`),
+    });
   });
 
   afterEach(() => {
@@ -35,6 +44,7 @@ describe("resolveBashContextGuardConfig", () => {
     else process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES = saved.headLines;
     if (saved.tailLines === undefined) delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES;
     else process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES = saved.tailLines;
+    __resetHashlineSettingsPathsForTest();
   });
 
   it("uses conservative defaults when env vars are unset", () => {
@@ -51,6 +61,82 @@ describe("resolveBashContextGuardConfig", () => {
     expect(BASH_CONTEXT_GUARD_DEFAULT_TAIL_LINES).toBe(120);
   });
 
+
+  it("uses JSON Bash context guard config when env is unset", async () => {
+    const root = join(tmpdir(), `bash-json-${randomBytes(6).toString("hex")}`);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({
+      bashContextGuard: {
+        enabled: false,
+        maxLines: 25,
+        maxBytes: 1024,
+        headLines: 3,
+        tailLines: 7,
+      },
+    }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+    try {
+      expect(resolveBashContextGuardConfig()).toEqual({
+        enabled: false,
+        maxLines: 25,
+        maxBytes: 1024,
+        headLines: 3,
+        tailLines: 7,
+      });
+    } finally {
+      __resetHashlineSettingsPathsForTest();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+
+  it("lets nonzero Bash guard env override JSON disabled", async () => {
+    const root = join(tmpdir(), `bash-env-${randomBytes(6).toString("hex")}`);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ bashContextGuard: { enabled: false } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD = "false";
+    try {
+      expect(resolveBashContextGuardConfig().enabled).toBe(true);
+    } finally {
+      delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD;
+      __resetHashlineSettingsPathsForTest();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls through to JSON Bash guard budget when env values are invalid", async () => {
+    const root = join(tmpdir(), `bash-invalid-env-json-${randomBytes(6).toString("hex")}`);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({
+      bashContextGuard: { maxLines: 25, maxBytes: 1024, headLines: 3, tailLines: 7 },
+    }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES = "abc";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES = "1e3";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES = "0";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES = "3.14";
+    try {
+      expect(resolveBashContextGuardConfig()).toEqual({
+        enabled: true,
+        maxLines: 25,
+        maxBytes: 1024,
+        headLines: 3,
+        tailLines: 7,
+      });
+    } finally {
+      delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES;
+      delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES;
+      delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES;
+      delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES;
+      __resetHashlineSettingsPathsForTest();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("uses valid below-default positive base-10 env values", () => {
     process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES = "25";
     process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES = "1024";
@@ -64,6 +150,27 @@ describe("resolveBashContextGuardConfig", () => {
       headLines: 3,
       tailLines: 7,
     });
+  });
+
+  it("keeps existing env-only Bash guard budget behavior", () => {
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES = "25";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES = "1024";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES = "3";
+    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES = "7";
+    try {
+      expect(resolveBashContextGuardConfig()).toEqual({
+        enabled: true,
+        maxLines: 25,
+        maxBytes: 1024,
+        headLines: 3,
+        tailLines: 7,
+      });
+    } finally {
+      delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_LINES;
+      delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES;
+      delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES;
+      delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES;
+    }
   });
 
   it("trims surrounding whitespace before parsing env values", () => {
@@ -106,12 +213,41 @@ describe("resolveBashContextGuardConfig", () => {
     });
   });
 
+  it("clamps above-default JSON Bash guard budget fields", async () => {
+    const root = join(tmpdir(), `bash-clamp-${randomBytes(6).toString("hex")}`);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({
+      bashContextGuard: {
+        maxLines: 99999,
+        maxBytes: 999999999,
+        headLines: 999,
+        tailLines: 999,
+      },
+    }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+    try {
+      expect(resolveBashContextGuardConfig()).toMatchObject({
+        maxLines: BASH_CONTEXT_GUARD_DEFAULT_MAX_LINES,
+        maxBytes: BASH_CONTEXT_GUARD_DEFAULT_MAX_BYTES,
+        headLines: BASH_CONTEXT_GUARD_DEFAULT_HEAD_LINES,
+        tailLines: BASH_CONTEXT_GUARD_DEFAULT_TAIL_LINES,
+      });
+    } finally {
+      __resetHashlineSettingsPathsForTest();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("disables the guard only when PI_HASHLINE_BASH_CONTEXT_GUARD is exactly 0", () => {
     process.env.PI_HASHLINE_BASH_CONTEXT_GUARD = "0";
-    expect(resolveBashContextGuardConfig().enabled).toBe(false);
-
-    process.env.PI_HASHLINE_BASH_CONTEXT_GUARD = "false";
-    expect(resolveBashContextGuardConfig().enabled).toBe(true);
+    try {
+      expect(resolveBashContextGuardConfig().enabled).toBe(false);
+      process.env.PI_HASHLINE_BASH_CONTEXT_GUARD = "false";
+      expect(resolveBashContextGuardConfig().enabled).toBe(true);
+    } finally {
+      delete process.env.PI_HASHLINE_BASH_CONTEXT_GUARD;
+    }
   });
 
   it("re-reads env on every call", () => {

--- a/tests/docs-hashline-settings.test.ts
+++ b/tests/docs-hashline-settings.test.ts
@@ -1,0 +1,13 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("Hashline settings documentation", () => {
+  it("documents exploratory verification steps for JSON settings, env fallback, and env overrides", async () => {
+    const doc = await readFile("docs/exploratory-functional-testing.md", "utf8");
+
+    expect(doc).toContain("JSON settings verification procedure:");
+    expect(doc).toContain("confirm it overrides the global JSON value");
+    expect(doc).toContain("confirm the existing env-only grep, map-cache, and Bash context-guard behavior still applies");
+    expect(doc).toContain("confirm the env value wins");
+  });
+});

--- a/tests/grep-budget.test.ts
+++ b/tests/grep-budget.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "@earendil-works/pi-coding-agent";
 import { resolveGrepOutputBudget, parsePositiveBase10Int } from "../src/grep-budget.js";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import { __resetHashlineSettingsPathsForTest, __setHashlineSettingsPathsForTest } from "../src/hashline-settings.js";
 
 const LINES_DEFAULT = DEFAULT_MAX_LINES; // 2000
 const BYTES_DEFAULT = Math.min(DEFAULT_MAX_BYTES, 50 * 1024); // 51200
@@ -48,6 +53,10 @@ describe("resolveGrepOutputBudget", () => {
 	beforeEach(() => {
 		delete process.env.PI_HASHLINE_GREP_MAX_LINES;
 		delete process.env.PI_HASHLINE_GREP_MAX_BYTES;
+		__setHashlineSettingsPathsForTest({
+			globalSettingsPath: join(tmpdir(), `missing-global-${randomBytes(6).toString("hex")}.json`),
+			projectSettingsPath: join(tmpdir(), `missing-project-${randomBytes(6).toString("hex")}.json`),
+		});
 	});
 
 	afterEach(() => {
@@ -55,6 +64,7 @@ describe("resolveGrepOutputBudget", () => {
 		else process.env.PI_HASHLINE_GREP_MAX_LINES = SAVED.lines;
 		if (SAVED.bytes === undefined) delete process.env.PI_HASHLINE_GREP_MAX_BYTES;
 		else process.env.PI_HASHLINE_GREP_MAX_BYTES = SAVED.bytes;
+		__resetHashlineSettingsPathsForTest();
 	});
 
 	it("returns current defaults when both env vars are unset", () => {
@@ -62,6 +72,82 @@ describe("resolveGrepOutputBudget", () => {
 			maxLines: LINES_DEFAULT,
 			maxBytes: BYTES_DEFAULT,
 		});
+	});
+
+	it("uses JSON grep budget when env is unset", async () => {
+		const root = join(tmpdir(), `grep-json-${randomBytes(6).toString("hex")}`);
+		const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+		await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+		await writeFile(projectSettingsPath, JSON.stringify({ grep: { maxLines: 12, maxBytes: 1024 } }));
+		__setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+		try {
+			expect(resolveGrepOutputBudget()).toEqual({ maxLines: 12, maxBytes: 1024 });
+		} finally {
+			__resetHashlineSettingsPathsForTest();
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+
+	it("lets env grep budget override JSON", async () => {
+		const root = join(tmpdir(), `grep-env-${randomBytes(6).toString("hex")}`);
+		const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+		await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+		await writeFile(projectSettingsPath, JSON.stringify({ grep: { maxLines: 12, maxBytes: 1024 } }));
+		__setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+		process.env.PI_HASHLINE_GREP_MAX_LINES = "7";
+		process.env.PI_HASHLINE_GREP_MAX_BYTES = "512";
+		try {
+			expect(resolveGrepOutputBudget()).toEqual({ maxLines: 7, maxBytes: 512 });
+		} finally {
+			delete process.env.PI_HASHLINE_GREP_MAX_LINES;
+			delete process.env.PI_HASHLINE_GREP_MAX_BYTES;
+			__resetHashlineSettingsPathsForTest();
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("falls through to JSON grep budget when env value is invalid", async () => {
+		const root = join(tmpdir(), `grep-invalid-env-json-${randomBytes(6).toString("hex")}`);
+		const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+		await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+		await writeFile(projectSettingsPath, JSON.stringify({ grep: { maxLines: 12, maxBytes: 1024 } }));
+		__setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+		process.env.PI_HASHLINE_GREP_MAX_LINES = "abc";
+		process.env.PI_HASHLINE_GREP_MAX_BYTES = "1e3";
+		try {
+			expect(resolveGrepOutputBudget()).toEqual({ maxLines: 12, maxBytes: 1024 });
+		} finally {
+			delete process.env.PI_HASHLINE_GREP_MAX_LINES;
+			delete process.env.PI_HASHLINE_GREP_MAX_BYTES;
+			__resetHashlineSettingsPathsForTest();
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("clamps above-default JSON grep budget to the built-in ceilings", async () => {
+		const root = join(tmpdir(), `grep-clamp-${randomBytes(6).toString("hex")}`);
+		const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+		await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+		await writeFile(projectSettingsPath, JSON.stringify({ grep: { maxLines: 99999, maxBytes: 999999999 } }));
+		__setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+		try {
+			expect(resolveGrepOutputBudget()).toEqual({ maxLines: LINES_DEFAULT, maxBytes: BYTES_DEFAULT });
+		} finally {
+			__resetHashlineSettingsPathsForTest();
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps existing env-only grep budget behavior", () => {
+		process.env.PI_HASHLINE_GREP_MAX_LINES = "10";
+		process.env.PI_HASHLINE_GREP_MAX_BYTES = "1024";
+		try {
+			expect(resolveGrepOutputBudget()).toEqual({ maxLines: 10, maxBytes: 1024 });
+		} finally {
+			delete process.env.PI_HASHLINE_GREP_MAX_LINES;
+			delete process.env.PI_HASHLINE_GREP_MAX_BYTES;
+		}
 	});
 
 	it("uses a valid below-default lines value as-is", () => {

--- a/tests/hashline-settings.test.ts
+++ b/tests/hashline-settings.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import {
+  __resetHashlineSettingsPathsForTest,
+  __setHashlineSettingsPathsForTest,
+  resolveHashlineJsonSettings,
+} from "../src/hashline-settings.js";
+
+export function tempRoot(prefix: string): string {
+  return join(tmpdir(), `${prefix}-${randomBytes(6).toString("hex")}`);
+}
+
+describe("resolveHashlineJsonSettings", () => {
+  const cleanup: string[] = [];
+
+  afterEach(async () => {
+    __resetHashlineSettingsPathsForTest();
+    await Promise.all(cleanup.map((path) => rm(path, { recursive: true, force: true })));
+    cleanup.length = 0;
+  });
+
+  it("treats missing settings files as empty settings", () => {
+    const root = tempRoot("hashline-settings-missing");
+    cleanup.push(root);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath: join(root, "repo/.pi/hashline-readmap/settings.json"),
+    });
+
+    expect(resolveHashlineJsonSettings()).toEqual({ settings: {}, warnings: [] });
+  });
+
+  it("reads the global Hashline settings file", async () => {
+    const root = tempRoot("hashline-settings-global");
+    cleanup.push(root);
+    const globalSettingsPath = join(root, "home/.pi/agent/hashline-readmap/settings.json");
+    await mkdir(join(globalSettingsPath, ".."), { recursive: true });
+    await writeFile(globalSettingsPath, JSON.stringify({ grep: { maxLines: 12 } }));
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath,
+      projectSettingsPath: join(root, "repo/.pi/hashline-readmap/settings.json"),
+    });
+
+    expect(resolveHashlineJsonSettings().settings.grep?.maxLines).toBe(12);
+  });
+
+  it("reads the project Hashline settings file", async () => {
+    const root = tempRoot("hashline-settings-project");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ grep: { maxBytes: 1024 } }));
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+
+    expect(resolveHashlineJsonSettings().settings.grep?.maxBytes).toBe(1024);
+  });
+
+  it("merges project settings over global settings field-by-field", async () => {
+    const root = tempRoot("hashline-settings-merge");
+    cleanup.push(root);
+    const globalSettingsPath = join(root, "home/.pi/agent/hashline-readmap/settings.json");
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(globalSettingsPath, ".."), { recursive: true });
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(globalSettingsPath, JSON.stringify({ grep: { maxLines: 100, maxBytes: 2000 } }));
+    await writeFile(projectSettingsPath, JSON.stringify({ grep: { maxLines: 25 } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath, projectSettingsPath });
+
+    expect(resolveHashlineJsonSettings().settings.grep).toEqual({ maxLines: 25, maxBytes: 2000 });
+  });
+
+  it("ignores malformed project JSON and reports a warning", async () => {
+    const root = tempRoot("hashline-settings-malformed-project");
+    cleanup.push(root);
+    const globalSettingsPath = join(root, "home/.pi/agent/hashline-readmap/settings.json");
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(globalSettingsPath, ".."), { recursive: true });
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(globalSettingsPath, JSON.stringify({ grep: { maxLines: 10 } }));
+    await writeFile(projectSettingsPath, "{not json");
+    __setHashlineSettingsPathsForTest({ globalSettingsPath, projectSettingsPath });
+
+    const result = resolveHashlineJsonSettings();
+    expect(result.settings.grep?.maxLines).toBe(10);
+    expect(result.warnings[0].message).toContain("Invalid JSON");
+  });
+
+
+  it("ignores invalid field values without discarding valid fields", async () => {
+    const root = tempRoot("hashline-settings-invalid-fields");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, `{
+      "grep": { "maxLines": 1e3, "maxBytes": 1.5 },
+      "mapCache": { "dir": "", "enabled": "no" },
+      "bashContextGuard": { "enabled": false, "maxLines": 1e3, "maxBytes": 1.5, "headLines": 0, "tailLines": 5 }
+    }`);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+
+    const result = resolveHashlineJsonSettings();
+    expect(result.settings).toEqual({
+      bashContextGuard: { enabled: false, tailLines: 5 },
+    });
+    expect(result.warnings.map((warning) => warning.path)).toEqual([
+      "grep.maxLines",
+      "grep.maxBytes",
+      "mapCache.dir",
+      "mapCache.enabled",
+      "bashContextGuard.maxLines",
+      "bashContextGuard.maxBytes",
+      "bashContextGuard.headLines",
+    ]);
+  });
+
+  it("rejects duplicate numeric JSON fields instead of accepting a mismatched parsed value", async () => {
+    const root = tempRoot("hashline-settings-duplicate-fields");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, `{
+      "grep": { "maxLines": 12, "maxLines": 0 },
+      "bashContextGuard": { "tailLines": 5, "tailLines": 1e3 }
+    }`);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+
+    const result = resolveHashlineJsonSettings();
+    expect(result.settings).toEqual({});
+    expect(result.warnings.map((warning) => warning.path)).toEqual([
+      "grep.maxLines",
+      "bashContextGuard.tailLines",
+    ]);
+  });
+
+  it("rejects duplicate top-level numeric sections instead of validating the wrong token", async () => {
+    const root = tempRoot("hashline-settings-duplicate-sections");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, `{
+      "grep": { "maxLines": 12 },
+      "grep": { "maxLines": 1e3 }
+    }`);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+
+    const result = resolveHashlineJsonSettings();
+    expect(result.settings).toEqual({});
+    expect(result.warnings.map((warning) => warning.path)).toEqual(["grep.maxLines"]);
+  });
+
+  it("ignores nested same-named sections when validating top-level numeric fields", async () => {
+    const root = tempRoot("hashline-settings-nested-section");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, `{
+      "metadata": { "grep": { "maxLines": 12 } },
+      "grep": { "maxLines": 1e3 }
+    }`);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+
+    const result = resolveHashlineJsonSettings();
+    expect(result.settings).toEqual({});
+    expect(result.warnings.map((warning) => warning.path)).toEqual(["grep.maxLines"]);
+  });
+
+
+  it("does not let unknown nested JSON content invalidate supported numeric fields", async () => {
+    const root = tempRoot("hashline-settings-unknown-nested");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, `{
+      "grep": { "note": "literal } brace", "nested": { "maxLines": 0 }, "maxLines": 12, "maxBytes": 1024 },
+      "bashContextGuard": { "nested": { "tailLines": 0 }, "tailLines": 5 }
+    }`);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+
+    const result = resolveHashlineJsonSettings();
+    expect(result.settings.grep).toEqual({ maxLines: 12, maxBytes: 1024 });
+    expect(result.settings.bashContextGuard).toEqual({ tailLines: 5 });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("ignores old and alias settings paths when canonical files are missing", async () => {
+    const root = tempRoot("hashline-settings-excluded");
+    cleanup.push(root);
+    const oldGlobal = join(root, "home/.pi/agent/settings.json");
+    const oldProject = join(root, "repo/.pi/settings.json");
+    const aliasGlobal = join(root, "home/.pi/hashline-readmap/settings.json");
+    const aliasProject = join(root, "repo/.pi/hashline-readmap.json");
+    for (const path of [oldGlobal, oldProject, aliasGlobal, aliasProject]) {
+      await mkdir(join(path, ".."), { recursive: true });
+      await writeFile(path, JSON.stringify({ grep: { maxLines: 99 } }));
+    }
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath: join(root, "repo/.pi/hashline-readmap/settings.json"),
+    });
+
+    expect(resolveHashlineJsonSettings()).toEqual({ settings: {}, warnings: [] });
+  });
+
+  it("ignores malformed global JSON and still uses project settings", async () => {
+    const root = tempRoot("hashline-settings-malformed-global");
+    cleanup.push(root);
+    const globalSettingsPath = join(root, "home/.pi/agent/hashline-readmap/settings.json");
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(globalSettingsPath, ".."), { recursive: true });
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(globalSettingsPath, "{not json");
+    await writeFile(projectSettingsPath, JSON.stringify({ grep: { maxLines: 10 } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath, projectSettingsPath });
+
+    const result = resolveHashlineJsonSettings();
+    expect(result.settings.grep?.maxLines).toBe(10);
+    expect(result.warnings[0].message).toContain("Invalid JSON");
+  });
+});

--- a/tests/persistent-map-cache.test.ts
+++ b/tests/persistent-map-cache.test.ts
@@ -7,6 +7,7 @@ import { resolveCacheDir, computeKey, contentHashFor64k, readCached, writeCached
 import * as persistentMapCacheModule from "../src/persistent-map-cache.js";
 import * as mapperModule from "../src/readmap/mapper.js";
 import { clearMapCache, getOrGenerateMap } from "../src/map-cache.js";
+import { __resetHashlineSettingsPathsForTest, __setHashlineSettingsPathsForTest } from "../src/hashline-settings.js";
 
 const SAVED = {
   dir: process.env.PI_HASHLINE_MAP_CACHE_DIR,
@@ -26,12 +27,17 @@ describe("resolveCacheDir", () => {
   beforeEach(() => {
     delete process.env.PI_HASHLINE_MAP_CACHE_DIR;
     delete process.env.XDG_CACHE_HOME;
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(tmpdir(), `missing-global-${randomBytes(6).toString("hex")}.json`),
+      projectSettingsPath: join(tmpdir(), `missing-project-${randomBytes(6).toString("hex")}.json`),
+    });
   });
 
   afterEach(() => {
     restoreEnv("PI_HASHLINE_MAP_CACHE_DIR", SAVED.dir);
     restoreEnv("XDG_CACHE_HOME", SAVED.xdg);
     restoreEnv("PI_HASHLINE_NO_PERSIST_MAPS", SAVED.noPersist);
+    __resetHashlineSettingsPathsForTest();
   });
 
   it("uses PI_HASHLINE_MAP_CACHE_DIR when set", () => {
@@ -47,6 +53,126 @@ describe("resolveCacheDir", () => {
 
   it("falls back to ~/.cache when neither env var set", () => {
     expect(resolveCacheDir()).toBe(join(homedir(), ".cache/pi-hashline-readmap/maps"));
+  });
+});
+
+
+describe("resolveCacheDir JSON settings", () => {
+  it("uses JSON mapCache.dir when env cache dir is unset", async () => {
+    delete process.env.PI_HASHLINE_MAP_CACHE_DIR;
+    delete process.env.XDG_CACHE_HOME;
+    const root = join(tmpdir(), `pmc-json-dir-${randomBytes(6).toString("hex")}`);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ mapCache: { dir: "/tmp/json-map-cache" } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+    try {
+      expect(resolveCacheDir()).toBe("/tmp/json-map-cache");
+    } finally {
+      __resetHashlineSettingsPathsForTest();
+      await rm(root, { recursive: true, force: true });
+      restoreEnv("PI_HASHLINE_MAP_CACHE_DIR", SAVED.dir);
+      restoreEnv("XDG_CACHE_HOME", SAVED.xdg);
+    }
+  });
+
+
+  it("lets PI_HASHLINE_MAP_CACHE_DIR override JSON mapCache.dir", async () => {
+    const root = join(tmpdir(), `pmc-env-dir-${randomBytes(6).toString("hex")}`);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ mapCache: { dir: "/tmp/json-map-cache" } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+    process.env.PI_HASHLINE_MAP_CACHE_DIR = "/tmp/env-map-cache";
+    try {
+      expect(resolveCacheDir()).toBe("/tmp/env-map-cache");
+    } finally {
+      __resetHashlineSettingsPathsForTest();
+      await rm(root, { recursive: true, force: true });
+      restoreEnv("PI_HASHLINE_MAP_CACHE_DIR", SAVED.dir);
+    }
+  });
+
+
+  it("keeps XDG_CACHE_HOME and home fallbacks when explicit config is unset", () => {
+    delete process.env.PI_HASHLINE_MAP_CACHE_DIR;
+    process.env.XDG_CACHE_HOME = "/tmp/xdg-cache";
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(tmpdir(), `missing-global-${randomBytes(6).toString("hex")}.json`),
+      projectSettingsPath: join(tmpdir(), `missing-project-${randomBytes(6).toString("hex")}.json`),
+    });
+    try {
+      expect(resolveCacheDir()).toBe("/tmp/xdg-cache/pi-hashline-readmap/maps");
+      delete process.env.XDG_CACHE_HOME;
+      expect(resolveCacheDir()).toBe(join(homedir(), ".cache/pi-hashline-readmap/maps"));
+    } finally {
+      __resetHashlineSettingsPathsForTest();
+      restoreEnv("PI_HASHLINE_MAP_CACHE_DIR", SAVED.dir);
+      restoreEnv("XDG_CACHE_HOME", SAVED.xdg);
+    }
+  });
+
+  it("disables persistence when JSON mapCache.enabled is false", async () => {
+    delete process.env.PI_HASHLINE_NO_PERSIST_MAPS;
+    const root = join(tmpdir(), `pmc-json-disabled-${randomBytes(6).toString("hex")}`);
+    const dir = join(root, "cache");
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ mapCache: { dir, enabled: false } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+    const map = { path: "/x", totalLines: 1, totalBytes: 1, language: "typescript", symbols: [], imports: [], detailLevel: "outline" } as any;
+    try {
+      await writeCachedRaw("json-disabled", map);
+      expect(await readCached("json-disabled")).toBeNull();
+    } finally {
+      __resetHashlineSettingsPathsForTest();
+      await rm(root, { recursive: true, force: true });
+      restoreEnv("PI_HASHLINE_NO_PERSIST_MAPS", SAVED.noPersist);
+    }
+  });
+
+  it("bypasses persistent lookup/write in getOrGenerateMap when JSON mapCache.enabled is false", async () => {
+    delete process.env.PI_HASHLINE_NO_PERSIST_MAPS;
+    const root = join(tmpdir(), `pmc-json-disabled-map-${randomBytes(6).toString("hex")}`);
+    const srcPath = join(root, "src.ts");
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(srcPath, "export const x = 1;\n");
+    await writeFile(projectSettingsPath, JSON.stringify({ mapCache: { enabled: false } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+    clearMapCache();
+    const readSpy = vi.spyOn(persistentMapCacheModule, "readCached");
+    const writeSpy = vi.spyOn(persistentMapCacheModule, "writeCached");
+    try {
+      expect(await getOrGenerateMap(srcPath)).not.toBeNull();
+      expect(readSpy).not.toHaveBeenCalled();
+      expect(writeSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.restoreAllMocks();
+      clearMapCache();
+      __resetHashlineSettingsPathsForTest();
+      await rm(root, { recursive: true, force: true });
+      restoreEnv("PI_HASHLINE_NO_PERSIST_MAPS", SAVED.noPersist);
+    }
+  });
+
+  it("lets PI_HASHLINE_NO_PERSIST_MAPS disable persistence over JSON", async () => {
+    const root = join(tmpdir(), `pmc-env-disabled-${randomBytes(6).toString("hex")}`);
+    const dir = join(root, "cache");
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ mapCache: { dir, enabled: true } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+    process.env.PI_HASHLINE_NO_PERSIST_MAPS = "1";
+    const map = { path: "/x", totalLines: 1, totalBytes: 1, language: "typescript", symbols: [], imports: [], detailLevel: "outline" } as any;
+    try {
+      await writeCachedRaw("env-disabled", map);
+      expect(await readCached("env-disabled")).toBeNull();
+    } finally {
+      __resetHashlineSettingsPathsForTest();
+      await rm(root, { recursive: true, force: true });
+      restoreEnv("PI_HASHLINE_NO_PERSIST_MAPS", SAVED.noPersist);
+    }
   });
 });
 
@@ -280,14 +406,41 @@ describe("writeCached eviction", () => {
       detailLevel: "outline",
     }) as any;
 
-    await writeCached("a", m(1));
-    await utimes(join(dir, "a.json"), new Date(Date.now() - 3000), new Date(Date.now() - 3000));
-    await writeCached("b", m(2));
-    await utimes(join(dir, "b.json"), new Date(Date.now() - 2000), new Date(Date.now() - 2000));
-    await writeCached("c", m(3));
+    const oldKey = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const midKey = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const newKey = "cccccccccccccccccccccccccccccccc";
+
+    await writeCached(oldKey, m(1));
+    await utimes(join(dir, `${oldKey}.json`), new Date(Date.now() - 3000), new Date(Date.now() - 3000));
+    await writeCached(midKey, m(2));
+    await utimes(join(dir, `${midKey}.json`), new Date(Date.now() - 2000), new Date(Date.now() - 2000));
+    await writeCached(newKey, m(3));
 
     const entries = (await readdir(dir)).filter((e) => e.endsWith(".json")).sort();
-    expect(entries).toEqual(["b.json", "c.json"]);
+    expect(entries).toEqual([`${midKey}.json`, `${newKey}.json`]);
+  });
+
+
+  it("does not evict unrelated JSON files in the configured cache directory", async () => {
+    __setEvictionHooksForTest({ interval: 2, cap: 1 });
+    const map = {
+      path: "/x",
+      totalLines: 1,
+      totalBytes: 1,
+      language: "t",
+      symbols: [],
+      imports: [],
+      detailLevel: "outline",
+    } as any;
+    const oldKey = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const newKey = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    await writeFile(join(dir, "settings.json"), "{}", "utf8");
+    await writeCached(oldKey, map);
+    await utimes(join(dir, `${oldKey}.json`), new Date(Date.now() - 3000), new Date(Date.now() - 3000));
+    await writeCached(newKey, map);
+
+    const entries = (await readdir(dir)).filter((e) => e.endsWith(".json")).sort();
+    expect(entries).toEqual([`${newKey}.json`, "settings.json"]);
   });
 });
 


### PR DESCRIPTION
Closes #143.

## Problem

Hashline configuration only worked through shell environment variables such as `PI_HASHLINE_GREP_MAX_LINES`, `PI_HASHLINE_MAP_CACHE_DIR`, `PI_HASHLINE_NO_PERSIST_MAPS`, and the Bash context-guard knobs. That made durable global settings and per-project overrides awkward, and pushed extension configuration into shell startup files.

## What changed

- Add a native Hashline settings loader for the canonical files `~/.pi/agent/hashline-readmap/settings.json` and `<repo>/.pi/hashline-readmap/settings.json`.
- Merge JSON settings with field-by-field project-over-global precedence while preserving environment variables as the highest-precedence override.
- Support JSON-backed `grep.maxLines` and `grep.maxBytes` for final visible grep output budgets.
- Support JSON-backed `mapCache.dir` and `mapCache.enabled` while preserving `PI_HASHLINE_MAP_CACHE_DIR`, `PI_HASHLINE_NO_PERSIST_MAPS=1`, and the existing XDG/home fallback order.
- Support JSON-backed `bashContextGuard.enabled`, `maxLines`, `maxBytes`, `headLines`, and `tailLines` while preserving exact `PI_HASHLINE_BASH_CONTEXT_GUARD=0` disable semantics.
- Keep budget settings stricter-only: strict positive base-10 integers are accepted; invalid, zero, negative, signed, decimal, hex, exponent, separator, empty, and whitespace-only values are ignored; above-default values clamp to built-in ceilings.
- Ignore malformed JSON safely and expose non-fatal loader warnings without discarding other valid fields where practical.
- Explicitly do not read unsupported legacy/alias paths such as `~/.pi/agent/settings.json`, `<repo>/.pi/settings.json`, `~/.pi/hashline-readmap/settings.json`, or `<repo>/.pi/hashline-readmap.json`.
- Update README configuration docs and exploratory testing notes with paths, schema, precedence, defaults, env migration, and verification steps.

## Verification

- `npm run typecheck`
- `npm test` — 358 files / 1540 tests
- `npx vitest run tests/persistent-map-cache.test.ts tests/hashline-settings.test.ts tests/grep-budget.test.ts tests/bash-context-guard-config.test.ts tests/docs-hashline-settings.test.ts` — 5 files / 89 tests
- Manual JSON settings reproduction confirmed project settings are read from `<repo>/.pi/hashline-readmap/settings.json`.

## Notes

- Existing `PI_HASHLINE_*` environment variables are not deprecated and continue to work as before.
- This intentionally does not bump the package version; versioning can be handled in the release PR.
