### PR TITLE
feat: add opt-in GDScript readmap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,30 @@ JSON fields:
 | `bashContextGuard.maxBytes` | `PI_HASHLINE_BASH_CONTEXT_GUARD_MAX_BYTES` | Tightens the post-RTK Bash guard byte budget; default/ceiling `51200` raw bytes |
 | `bashContextGuard.headLines` | `PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES` | Tightens the guarded preview head size; default/ceiling `80` |
 | `bashContextGuard.tailLines` | `PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES` | Tightens the guarded preview tail size; default/ceiling `120` |
-
+| `gdscript.enabled` | `PI_HASHLINE_GDSCRIPT` | Defaults to `false`; exact env value `1` enables the dedicated GDScript mapper and takes precedence over JSON |
 Budget fields must be strict positive base-10 integers. Zero, negative, signed, decimal, hexadecimal, exponent notation, separators, empty strings, and whitespace-only values are ignored. Malformed JSON files and invalid fields degrade safely: valid fields continue to apply where practical, invalid fields are ignored, and the loader emits non-fatal warnings where available.
+
+### Optional GDScript maps
+
+GDScript support is niche and opt-in. By default, `.gd` files continue to use the same ctags/fallback mapping path as other files without a dedicated enabled mapper, so existing users do not need any new dependency.
+
+To enable the dedicated GDScript structural mapper, install the Python backend in the environment where pi runs:
+
+```sh
+pip install gdtoolkit
+```
+
+or use an equivalent Python environment setup that makes `gdtoolkit.parser` importable by `python3`.
+
+Then enable it in `.pi/hashline-readmap/settings.json` (project) or `~/.pi/agent/hashline-readmap/settings.json` (global):
+
+```json
+{
+  "gdscript": { "enabled": true }
+}
+```
+
+For a one-off session, `PI_HASHLINE_GDSCRIPT=1` also enables the mapper and takes precedence over JSON settings. If the backend is missing or broken, Hashline falls back to ctags/fallback mapping; install `gdtoolkit` or unset `PI_HASHLINE_GDSCRIPT` to silence the diagnostic.
 
 Other environment-only options:
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "index.ts",
     "src/",
     "prompts/",
+    "scripts/gdscript_outline.py",
     "LICENSE",
     "README.md",
     "CHANGELOG.md"

--- a/scripts/gdscript_outline.py
+++ b/scripts/gdscript_outline.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+SYMBOL_KINDS = {
+    "class_name": "class",
+    "class_decl": "class",
+    "func_def": "function",
+    "function_def": "function",
+    "method_def": "method",
+    "var_stmt": "variable",
+    "property_stmt": "property",
+    "const_stmt": "constant",
+    "enum_stmt": "enum",
+    "signal_stmt": "signal",
+}
+IMPORT_KINDS = {"load", "preload", "requires"}
+
+
+def require_gdtoolkit_parser():
+    try:
+        from gdtoolkit import parser as gd_parser  # type: ignore
+        return gd_parser
+    except Exception as exc:
+        raise RuntimeError("missing gdtoolkit.parser; install with pip install gdtoolkit") from exc
+
+
+def node_kind(node):
+    return str(getattr(node, "data", getattr(node, "type", "")))
+
+
+def node_children(node):
+    return list(getattr(node, "children", []) or [])
+
+
+def node_line(node):
+    return int(getattr(node, "line", getattr(getattr(node, "meta", None), "line", 1)) or 1)
+
+
+def node_end_line(node):
+    return int(getattr(node, "end_line", getattr(getattr(node, "meta", None), "end_line", node_line(node))) or node_line(node))
+
+
+def node_value(node):
+    value = getattr(node, "value", None)
+    if value is not None:
+        return str(value)
+    if isinstance(node, str):
+        return node
+    for child in node_children(node):
+        child_value = node_value(child)
+        if child_value:
+            return child_value
+    return ""
+
+
+def walk(node):
+    yield node
+    for child in node_children(node):
+        yield from walk(child)
+
+
+def parse_source(gd_parser, source):
+    parse = getattr(gd_parser, "parse", None)
+    if callable(parse):
+        return parse(source)
+    parser_cls = getattr(gd_parser, "Parser", None)
+    if parser_cls is not None:
+        return parser_cls().parse(source)
+    raise RuntimeError("gdtoolkit.parser does not expose parse or Parser")
+
+
+def outline(tree):
+    imports = []
+    seen_imports = set()
+    symbols = []
+    for node in walk(tree):
+        kind = node_kind(node)
+        value = node_value(node)
+        if kind in IMPORT_KINDS and value and value not in seen_imports:
+            imports.append(value)
+            seen_imports.add(value)
+        symbol_kind = SYMBOL_KINDS.get(kind)
+        if symbol_kind and value:
+            symbol = {"name": value, "kind": symbol_kind, "startLine": node_line(node), "endLine": node_end_line(node)}
+            if symbol_kind in {"function", "method"}:
+                symbol["signature"] = value
+                if value.startswith("func "):
+                    name = value.removeprefix("func ").split("(", 1)[0].strip()
+                    if name:
+                        symbol["name"] = name
+            symbols.append(symbol)
+    return {"imports": imports, "symbols": symbols}
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(json.dumps({"error": "usage: gdscript_outline.py <file>"}))
+        return 0
+    try:
+        gd_parser = require_gdtoolkit_parser()
+        source = Path(sys.argv[1]).read_text(encoding="utf-8")
+        tree = parse_source(gd_parser, source)
+        print(json.dumps(outline(tree)))
+        return 0
+    except Exception as exc:
+        print(json.dumps({"error": str(exc)}))
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/hashline-settings.ts
+++ b/src/hashline-settings.ts
@@ -6,6 +6,7 @@ export interface HashlineJsonSettings {
   grep?: { maxLines?: number; maxBytes?: number };
   mapCache?: { dir?: string; enabled?: boolean };
   bashContextGuard?: { enabled?: boolean; maxLines?: number; maxBytes?: number; headLines?: number; tailLines?: number };
+  gdscript?: { enabled?: boolean };
 }
 export interface HashlineSettingsWarning { source: string; message: string; path?: string }
 export interface HashlineSettingsResult { settings: HashlineJsonSettings; warnings: HashlineSettingsWarning[] }
@@ -165,6 +166,12 @@ function validateSettings(raw: unknown, source: string, rawText: string): Hashli
     }
     if (Object.keys(bashContextGuard).length > 0) settings.bashContextGuard = bashContextGuard;
   }
+  if (isRecord(raw.gdscript)) {
+    const gdscript: NonNullable<HashlineJsonSettings["gdscript"]> = {};
+    const enabled = readBoolean(raw.gdscript, "enabled", "gdscript.enabled", source, warnings);
+    if (enabled !== undefined) gdscript.enabled = enabled;
+    if (Object.keys(gdscript).length > 0) settings.gdscript = gdscript;
+  }
   return { settings, warnings };
 }
 function readSettingsFile(path: string): HashlineSettingsResult {
@@ -184,10 +191,19 @@ function mergeSettings(base: HashlineJsonSettings, override: HashlineJsonSetting
   if (Object.keys(mapCache).length > 0) merged.mapCache = mapCache;
   const bashContextGuard = { ...(base.bashContextGuard ?? {}), ...(override.bashContextGuard ?? {}) };
   if (Object.keys(bashContextGuard).length > 0) merged.bashContextGuard = bashContextGuard;
+  const gdscript = { ...(base.gdscript ?? {}), ...(override.gdscript ?? {}) };
+  if (Object.keys(gdscript).length > 0) merged.gdscript = gdscript;
   return merged;
 }
 export function resolveHashlineJsonSettings(): HashlineSettingsResult {
   const globalResult = readSettingsFile(pathOverride?.globalSettingsPath ?? defaultGlobalSettingsPath());
   const projectResult = readSettingsFile(pathOverride?.projectSettingsPath ?? defaultProjectSettingsPath());
   return { settings: mergeSettings(globalResult.settings, projectResult.settings), warnings: [...globalResult.warnings, ...projectResult.warnings] };
+}
+
+export function isGdscriptMappingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.PI_HASHLINE_GDSCRIPT !== undefined) {
+    return env.PI_HASHLINE_GDSCRIPT === "1";
+  }
+  return resolveHashlineJsonSettings().settings.gdscript?.enabled === true;
 }

--- a/src/map-cache.ts
+++ b/src/map-cache.ts
@@ -47,8 +47,10 @@ export async function getOrGenerateMap(absPath: string): Promise<FileMap | null>
 	try {
 		const fileStat = await stat(absPath);
 		const { mtimeMs } = fileStat;
+		const lang = detectLanguage(absPath);
+		const bypassMapCache = lang?.id === "gdscript";
 		const cached = cache.get(absPath);
-		if (cached && cached.mtimeMs === mtimeMs) {
+		if (!bypassMapCache && cached && cached.mtimeMs === mtimeMs) {
 			const currentHash = await contentHashFor64k(absPath);
 			if (currentHash && currentHash === cached.contentHash) {
 				cache.delete(absPath);
@@ -56,10 +58,12 @@ export async function getOrGenerateMap(absPath: string): Promise<FileMap | null>
 				return cached.map;
 			}
 		}
-		if (!persistenceEnabled()) {
+		if (!persistenceEnabled() || bypassMapCache) {
 			const map = await generateMap(absPath);
-			const hash = await contentHashFor64k(absPath);
-			rememberInMemory(absPath, { mtimeMs, contentHash: hash, map });
+			if (!bypassMapCache) {
+				const hash = await contentHashFor64k(absPath);
+				rememberInMemory(absPath, { mtimeMs, contentHash: hash, map });
+			}
 			return map;
 		}
 
@@ -67,7 +71,6 @@ export async function getOrGenerateMap(absPath: string): Promise<FileMap | null>
 		try {
 			preContentHash = await contentHashFor64k(absPath);
 			if (preContentHash) {
-				const lang = detectLanguage(absPath);
 				const langIdentity = lang ? ALL_MAPPER_IDENTITIES[lang.id] : undefined;
 				const candidates = [
 					...(langIdentity ? [langIdentity] : []),
@@ -85,8 +88,8 @@ export async function getOrGenerateMap(absPath: string): Promise<FileMap | null>
 					);
 					const fromDisk = await readCached(key);
 					if (fromDisk) {
-					rememberInMemory(absPath, { mtimeMs, contentHash: preContentHash, map: fromDisk });
-					return fromDisk;
+						rememberInMemory(absPath, { mtimeMs, contentHash: preContentHash, map: fromDisk });
+						return fromDisk;
 					}
 				}
 			}

--- a/src/readmap/enums.ts
+++ b/src/readmap/enums.ts
@@ -22,6 +22,7 @@ export enum SymbolKind {
   Trigger = "trigger",
   Index = "index",
   Schema = "schema",
+  Signal = "signal",
   Unknown = "unknown",
 }
 

--- a/src/readmap/language-detect.ts
+++ b/src/readmap/language-detect.ts
@@ -26,6 +26,9 @@ const EXTENSION_MAP: Record<string, LanguageInfo> = {
   // Go
   ".go": { id: "go", name: "Go" },
 
+  // GDScript
+  ".gd": { id: "gdscript", name: "GDScript" },
+
   // Java
   ".java": { id: "java", name: "Java" },
 

--- a/src/readmap/mapper.ts
+++ b/src/readmap/mapper.ts
@@ -1,4 +1,5 @@
 import type { FileMap, MapOptions } from "./types.js";
+import { isGdscriptMappingEnabled } from "../hashline-settings.js";
 
 import { THRESHOLDS } from "./constants.js";
 import { detectLanguage } from "./language-detect.js";
@@ -8,6 +9,7 @@ import { csvMapper, MAPPER_VERSION as CSV_VERSION } from "./mappers/csv.js";
 import { ctagsMapper, MAPPER_VERSION as CTAGS_VERSION } from "./mappers/ctags.js";
 import { fallbackMapper, MAPPER_VERSION as FALLBACK_VERSION } from "./mappers/fallback.js";
 import { goMapper, MAPPER_VERSION as GO_VERSION } from "./mappers/go.js";
+import { gdscriptMapper, MAPPER_VERSION as GDSCRIPT_VERSION } from "./mappers/gdscript.js";
 import { jsonMapper, MAPPER_VERSION as JSON_VERSION } from "./mappers/json.js";
 import { javaMapper, javaMapperFromContent, MAPPER_VERSION as JAVA_VERSION } from "./mappers/java.js";
 import { jsonlMapper, MAPPER_VERSION as JSONL_VERSION } from "./mappers/jsonl.js";
@@ -41,6 +43,7 @@ const MAPPERS_V: Record<string, MapperEntry> = {
   python: { fn: pythonMapper, version: PYTHON_VERSION },
   // Phase 2: Go AST-based
   go: { fn: goMapper, version: GO_VERSION },
+  gdscript: { fn: gdscriptMapper, version: GDSCRIPT_VERSION },
   // Phase 3: Internal ts-morph mappers
   typescript: { fn: typescriptMapper, version: TYPESCRIPT_VERSION },
   javascript: { fn: typescriptMapper, version: TYPESCRIPT_VERSION },
@@ -117,7 +120,8 @@ export async function generateMapWithIdentity(
   const langInfo = detectLanguage(filePath);
   if (langInfo) {
     const entry = MAPPERS_V[langInfo.id];
-    if (entry) {
+    const mapperEnabled = langInfo.id !== "gdscript" || isGdscriptMappingEnabled();
+    if (entry && mapperEnabled) {
       const result = await entry.fn(filePath, signal);
       if (result) {
         return { map: result, mapperName: langInfo.id, mapperVersion: entry.version };

--- a/src/readmap/mappers/gdscript.ts
+++ b/src/readmap/mappers/gdscript.ts
@@ -1,0 +1,114 @@
+import { execFile, type ExecFileOptions } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { FileMap, FileSymbol } from "../types.js";
+import { DetailLevel, SymbolKind } from "../enums.js";
+import { reportParserError } from "../parser-errors.js";
+
+export const MAPPER_VERSION = 1;
+
+type ExecFileResult = { stdout: string; stderr: string };
+
+function execFileAsync(
+  file: string,
+  args: readonly string[],
+  options: ExecFileOptions,
+): Promise<ExecFileResult> {
+  return new Promise((resolve, reject) => {
+    execFile(file, [...args], options, (error, stdout, stderr) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve({ stdout: String(stdout), stderr: String(stderr) });
+    });
+  });
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = join(__dirname, "../../../scripts/gdscript_outline.py");
+
+interface GdscriptHelperSymbol {
+  name: string;
+  kind: string;
+  startLine: number;
+  endLine: number;
+  signature?: string;
+  children?: GdscriptHelperSymbol[];
+}
+
+interface GdscriptHelperResult {
+  imports?: string[];
+  symbols?: GdscriptHelperSymbol[];
+  error?: string;
+}
+
+function mapKind(kind: string): SymbolKind {
+  switch (kind) {
+    case "class": return SymbolKind.Class;
+    case "function": return SymbolKind.Function;
+    case "method": return SymbolKind.Method;
+    case "variable": return SymbolKind.Variable;
+    case "property": return SymbolKind.Property;
+    case "constant": return SymbolKind.Constant;
+    case "enum": return SymbolKind.Enum;
+    case "signal": return SymbolKind.Signal;
+    default: return SymbolKind.Unknown;
+  }
+}
+
+function convertSymbol(input: GdscriptHelperSymbol): FileSymbol {
+  const symbol: FileSymbol = {
+    name: input.name,
+    kind: mapKind(input.kind),
+    startLine: input.startLine,
+    endLine: input.endLine,
+  };
+  if (input.signature) symbol.signature = input.signature;
+  if (input.children?.length) symbol.children = input.children.map(convertSymbol);
+  return symbol;
+}
+
+function countLines(text: string): number {
+  return text.length === 0 ? 0 : text.split("\n").length;
+}
+
+function reportGdscriptBackendUnavailable(): void {
+  console.error("GDScript support requires pip install gdtoolkit or disabling PI_HASHLINE_GDSCRIPT");
+}
+
+export async function gdscriptMapper(filePath: string, signal?: AbortSignal): Promise<FileMap | null> {
+  try {
+    const stats = await stat(filePath);
+    const content = await readFile(filePath, "utf8");
+    if (signal?.aborted) return null;
+
+    const { stdout } = await execFileAsync("python3", [SCRIPT_PATH, filePath], {
+      signal,
+      timeout: 10_000,
+      maxBuffer: 5 * 1024 * 1024,
+    });
+    const parsed = JSON.parse(stdout) as GdscriptHelperResult;
+    if (parsed.error) {
+      if (parsed.error.includes("gdtoolkit")) reportGdscriptBackendUnavailable();
+      else reportParserError("gdscript-helper-error", new Error(parsed.error), { context: "GDScript mapper failed" });
+      return null;
+    }
+
+    return {
+      path: filePath,
+      totalLines: countLines(content),
+      totalBytes: stats.size,
+      language: "GDScript",
+      imports: parsed.imports ?? [],
+      symbols: (parsed.symbols ?? []).map(convertSymbol),
+      detailLevel: DetailLevel.Full,
+    };
+  } catch (error) {
+    if (signal?.aborted) return null;
+    reportParserError("gdscript-mapper-failed", error, { context: "GDScript mapper failed" });
+    return null;
+  }
+}

--- a/tests/fixtures/gdscript/Player.gd
+++ b/tests/fixtures/gdscript/Player.gd
@@ -1,0 +1,17 @@
+class_name Player
+extends Node
+
+signal health_changed(new_value: int)
+enum State { IDLE, DAMAGED, DEAD }
+
+const MAX_HEALTH := 100
+var health := MAX_HEALTH
+var weapon = preload("res://weapons/sword.gd")
+var enemy_scene = load("res://enemies/enemy.gd")
+var shared_constants = requires("res://shared/constants.gd")
+
+func _ready() -> void:
+	health_changed.emit(health)
+
+func take_damage(amount: int) -> void:
+	health -= amount

--- a/tests/gdscript-disabled-mapper-gate.test.ts
+++ b/tests/gdscript-disabled-mapper-gate.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import { __resetHashlineSettingsPathsForTest, __setHashlineSettingsPathsForTest } from "../src/hashline-settings.js";
+
+function tempRoot(prefix: string): string { return join(tmpdir(), `${prefix}-${randomBytes(6).toString("hex")}`); }
+
+describe("disabled GDScript mapper gate", () => {
+  const cleanup: string[] = [];
+  const originalEnv = process.env.PI_HASHLINE_GDSCRIPT;
+  afterEach(async () => {
+    if (originalEnv === undefined) delete process.env.PI_HASHLINE_GDSCRIPT;
+    else process.env.PI_HASHLINE_GDSCRIPT = originalEnv;
+    __resetHashlineSettingsPathsForTest();
+    vi.restoreAllMocks();
+    vi.resetModules();
+    await Promise.all(cleanup.map((path) => rm(path, { recursive: true, force: true })));
+    cleanup.length = 0;
+  });
+
+  it("does not invoke the dedicated mapper when JSON explicitly disables GDScript", async () => {
+    delete process.env.PI_HASHLINE_GDSCRIPT;
+    const root = tempRoot("gdscript-disabled-gate");
+    cleanup.push(root);
+    await mkdir(root, { recursive: true });
+    const filePath = join(root, "Player.gd");
+    await writeFile(filePath, "func _ready():\n\tpass\n");
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ gdscript: { enabled: false } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+    const gdscriptMapper = vi.fn(async () => { throw new Error("GDScript backend should not be invoked"); });
+    vi.doMock("../src/readmap/mappers/gdscript.js", () => ({ MAPPER_VERSION: 1, gdscriptMapper }));
+
+    const { generateMapWithIdentity } = await import("../src/readmap/mapper.js");
+    const result = await generateMapWithIdentity(filePath);
+
+    expect(gdscriptMapper).not.toHaveBeenCalled();
+    expect(["ctags", "fallback"]).toContain(result.mapperName);
+  });
+});

--- a/tests/gdscript-helper.test.ts
+++ b/tests/gdscript-helper.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const fixture = resolve("tests/fixtures/gdscript/Player.gd");
+
+async function fakeGdtoolkitRoot(): Promise<string> {
+  const root = join(tmpdir(), `fake-gdtoolkit-${randomBytes(6).toString("hex")}`);
+  await mkdir(join(root, "gdtoolkit"), { recursive: true });
+  await writeFile(join(root, "gdtoolkit", "__init__.py"), "");
+  await writeFile(join(root, "gdtoolkit", "parser.py"), `
+class Node:
+    def __init__(self, data, children=None, line=1, end_line=None, value=None):
+        self.data = data
+        self.children = children or []
+        self.line = line
+        self.end_line = end_line or line
+        self.value = value
+
+class Parser:
+    def parse(self, source):
+        return Node("file", [
+            Node("class_name", value="Player", line=1, end_line=17),
+            Node("signal_stmt", value="health_changed", line=3),
+            Node("enum_stmt", value="State", line=4),
+            Node("const_stmt", value="MAX_HEALTH", line=6),
+            Node("var_stmt", value="health", line=7),
+            Node("var_stmt", value="weapon", line=8),
+            Node("preload", value="res://weapons/sword.gd", line=8),
+            Node("load", value="res://enemies/enemy.gd", line=9),
+            Node("requires", value="res://shared/constants.gd", line=10),
+            Node("func_def", value="func _ready() -> void:", line=12, end_line=13),
+            Node("func_def", value="func take_damage(amount: int) -> void:", line=15, end_line=17),
+        ])
+
+def parse(source):
+    return Parser().parse(source)
+`);
+  return root;
+}
+
+describe("scripts/gdscript_outline.py", () => {
+  it("walks gdtoolkit.parser AST output for symbols and imports", async () => {
+    const root = await fakeGdtoolkitRoot();
+    try {
+      const { stdout } = await execFileAsync("python3", ["scripts/gdscript_outline.py", fixture], {
+        env: { ...process.env, PYTHONPATH: root },
+      });
+      const parsed = JSON.parse(stdout) as { imports: string[]; symbols: Array<{ name: string; kind: string; startLine: number; endLine: number; signature?: string }> };
+      expect(parsed.imports).toEqual(["res://weapons/sword.gd", "res://enemies/enemy.gd", "res://shared/constants.gd"]);
+      expect(parsed.symbols).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: "Player", kind: "class", startLine: 1, endLine: 17 }),
+        expect.objectContaining({ name: "health_changed", kind: "signal", startLine: 3, endLine: 3 }),
+        expect.objectContaining({ name: "State", kind: "enum", startLine: 4, endLine: 4 }),
+        expect.objectContaining({ name: "MAX_HEALTH", kind: "constant", startLine: 6, endLine: 6 }),
+        expect.objectContaining({ name: "health", kind: "variable", startLine: 7, endLine: 7 }),
+        expect.objectContaining({ name: "weapon", kind: "variable", startLine: 8, endLine: 8 }),
+        expect.objectContaining({ name: "_ready", kind: "function", startLine: 12, endLine: 13, signature: "func _ready() -> void:" }),
+        expect.objectContaining({ name: "take_damage", kind: "function", startLine: 15, endLine: 17, signature: "func take_damage(amount: int) -> void:" }),
+      ]));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the packaged helper and representative GDScript fixture covered", async () => {
+    const packageJson = JSON.parse(await readFile("package.json", "utf8")) as { files?: string[] };
+    expect(packageJson.files).toEqual(expect.arrayContaining(["scripts/gdscript_outline.py"]));
+
+    const source = await readFile(fixture, "utf8");
+    expect(source).toContain("class_name Player");
+    expect(source).toContain("signal health_changed");
+    expect(source).toContain("enum State");
+    expect(source).toContain("const MAX_HEALTH");
+    expect(source).toContain("var health");
+    expect(source).toContain("var weapon");
+    expect(source).toContain("preload(\"res://weapons/sword.gd\")");
+    expect(source).toContain("load(\"res://enemies/enemy.gd\")");
+    expect(source).toContain("requires(\"res://shared/constants.gd\")");
+    expect(source).toContain("func _ready() -> void:");
+    expect(source).toContain("func take_damage(amount: int) -> void:");
+  });
+});

--- a/tests/gdscript-language-detect.test.ts
+++ b/tests/gdscript-language-detect.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { detectLanguage, getSupportedExtensions, isSupported } from "../src/readmap/language-detect.js";
+
+describe("GDScript language detection", () => {
+  it("detects .gd paths as GDScript", () => {
+    expect(detectLanguage("Player.gd")).toEqual({ id: "gdscript", name: "GDScript" });
+    expect(detectLanguage("res://scripts/player.GD")).toEqual({ id: "gdscript", name: "GDScript" });
+    expect(isSupported("addons/example/plugin.gd")).toBe(true);
+    expect(getSupportedExtensions()).toContain(".gd");
+  });
+});

--- a/tests/gdscript-mapper.test.ts
+++ b/tests/gdscript-mapper.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import { SymbolKind } from "../src/readmap/enums.js";
+
+function tempRoot(prefix: string): string {
+  return join(tmpdir(), `${prefix}-${randomBytes(6).toString("hex")}`);
+}
+
+describe("gdscriptMapper", () => {
+  const cleanup: string[] = [];
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    await Promise.all(cleanup.map((path) => rm(path, { recursive: true, force: true })));
+    cleanup.length = 0;
+  });
+
+  it("invokes the Python helper with execFile args and maps helper JSON", async () => {
+    const execFile = vi.fn((file: string, args: readonly string[], options: unknown, callback: (error: Error | null, stdout: string, stderr: string) => void) => {
+      callback(null, JSON.stringify({
+        imports: ["res://enemy.gd"],
+        symbols: [
+          { name: "Player", kind: "class", startLine: 1, endLine: 9 },
+          { name: "health_changed", kind: "signal", startLine: 3, endLine: 3 },
+          { name: "MAX_SPEED", kind: "constant", startLine: 4, endLine: 4 },
+          { name: "velocity", kind: "variable", startLine: 5, endLine: 5 },
+          { name: "_ready", kind: "function", startLine: 7, endLine: 9, signature: "func _ready() -> void" },
+        ],
+      }), "");
+    });
+    vi.doMock("node:child_process", () => ({ execFile }));
+
+    const root = tempRoot("gdscript-mapper");
+    cleanup.push(root);
+    await mkdir(root, { recursive: true });
+    const filePath = join(root, "Player.gd");
+    await writeFile(filePath, "class_name Player\nsignal health_changed\nconst MAX_SPEED = 100\nvar velocity\n\nfunc _ready() -> void:\n\tpass\n");
+
+    const { gdscriptMapper, MAPPER_VERSION } = await import("../src/readmap/mappers/gdscript.js");
+    const map = await gdscriptMapper(filePath);
+
+    expect(MAPPER_VERSION).toBeGreaterThanOrEqual(1);
+    expect(execFile).toHaveBeenCalledTimes(1);
+    expect(execFile.mock.calls[0][0]).toBe("python3");
+    expect(execFile.mock.calls[0][1]).toEqual([expect.stringContaining("gdscript_outline.py"), filePath]);
+    expect(map).toMatchObject({
+      path: filePath,
+      totalLines: 8,
+      language: "GDScript",
+      imports: ["res://enemy.gd"],
+    });
+    expect(map?.symbols.map((symbol) => [symbol.name, symbol.kind, symbol.startLine, symbol.endLine, symbol.signature])).toEqual([
+      ["Player", SymbolKind.Class, 1, 9, undefined],
+      ["health_changed", SymbolKind.Signal, 3, 3, undefined],
+      ["MAX_SPEED", SymbolKind.Constant, 4, 4, undefined],
+      ["velocity", SymbolKind.Variable, 5, 5, undefined],
+      ["_ready", SymbolKind.Function, 7, 9, "func _ready() -> void"],
+    ]);
+  });
+
+
+  it("returns null when helper stdout is not JSON", async () => {
+    const execFile = vi.fn((_file: string, _args: readonly string[], _options: unknown, callback: (error: Error | null, stdout: string, stderr: string) => void) => callback(null, "not json", ""));
+    vi.doMock("node:child_process", () => ({ execFile }));
+    const root = tempRoot("gdscript-json-failure");
+    cleanup.push(root);
+    await mkdir(root, { recursive: true });
+    const filePath = join(root, "Player.gd");
+    await writeFile(filePath, "func _ready():\n\tpass\n");
+
+    const { gdscriptMapper } = await import("../src/readmap/mappers/gdscript.js");
+    await expect(gdscriptMapper(filePath)).resolves.toBeNull();
+  });
+});

--- a/tests/gdscript-missing-backend-diagnostic.test.ts
+++ b/tests/gdscript-missing-backend-diagnostic.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+function tempRoot(prefix: string): string {
+  return join(tmpdir(), `${prefix}-${randomBytes(6).toString("hex")}`);
+}
+
+describe("GDScript missing backend diagnostic", () => {
+  const cleanup: string[] = [];
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    await Promise.all(cleanup.map((path) => rm(path, { recursive: true, force: true })));
+    cleanup.length = 0;
+  });
+
+  it("returns null and emits install guidance when helper reports missing gdtoolkit", async () => {
+    const execFile = vi.fn((_file: string, _args: readonly string[], _options: unknown, callback: (error: Error | null, stdout: string, stderr: string) => void) => {
+      callback(null, JSON.stringify({ error: "missing gdtoolkit.parser" }), "");
+    });
+    vi.doMock("node:child_process", () => ({ execFile }));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const root = tempRoot("gdscript-missing-backend");
+    cleanup.push(root);
+    await mkdir(root, { recursive: true });
+    const filePath = join(root, "Player.gd");
+    await writeFile(filePath, "func _ready():\n\tpass\n");
+
+    const { gdscriptMapper } = await import("../src/readmap/mappers/gdscript.js");
+    await expect(gdscriptMapper(filePath)).resolves.toBeNull();
+    expect(error.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
+      "GDScript support requires pip install gdtoolkit or disabling PI_HASHLINE_GDSCRIPT",
+    );
+  });
+});

--- a/tests/gdscript-read-map.test.ts
+++ b/tests/gdscript-read-map.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import { ensureHashInit } from "../src/hashline.js";
+import { __resetHashlineSettingsPathsForTest, __setHashlineSettingsPathsForTest } from "../src/hashline-settings.js";
+import { DetailLevel, SymbolKind } from "../src/readmap/enums.js";
+
+function tempRoot(prefix: string): string { return join(tmpdir(), `${prefix}-${randomBytes(6).toString("hex")}`); }
+function text(result: any): string { return result.content?.find((entry: any) => entry.type === "text")?.text ?? ""; }
+async function readTool(params: { path: string; map?: boolean; symbol?: string }) {
+  let capturedTool: any = null;
+  const { registerReadTool } = await import("../src/read.js");
+  registerReadTool({ registerTool(def: any) { capturedTool = def; } } as any);
+  return capturedTool.execute("test-call", params, new AbortController().signal, () => {}, { cwd: process.cwd() });
+}
+
+describe("GDScript read workflows", () => {
+  const cleanup: string[] = [];
+  beforeAll(async () => { await ensureHashInit(); });
+  afterEach(async () => {
+    __resetHashlineSettingsPathsForTest();
+    vi.restoreAllMocks();
+    vi.resetModules();
+    await Promise.all(cleanup.map((path) => rm(path, { recursive: true, force: true })));
+    cleanup.length = 0;
+  });
+
+  it("renders maps and reads GDScript symbols through the registered mapper", async () => {
+    const root = tempRoot("gdscript-read-map");
+    cleanup.push(root);
+    await mkdir(root, { recursive: true });
+    const filePath = join(root, "Player.gd");
+    await writeFile(filePath, [
+      "class_name Player",
+      "signal health_changed(new_value: int)",
+      "func _ready() -> void:",
+      "\tpass",
+      "func take_damage(amount: int) -> void:",
+      "\tpass",
+      "",
+    ].join("\n"));
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ gdscript: { enabled: true } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+    const gdscriptMapper = vi.fn(async (path: string) => ({
+      path,
+      totalLines: 7,
+      totalBytes: 132,
+      language: "GDScript",
+      imports: ["res://weapons/sword.gd"],
+      symbols: [
+        { name: "Player", kind: SymbolKind.Class, startLine: 1, endLine: 6 },
+        { name: "health_changed", kind: SymbolKind.Signal, startLine: 2, endLine: 2 },
+        { name: "_ready", kind: SymbolKind.Function, startLine: 3, endLine: 4, signature: "func _ready() -> void:" },
+        { name: "take_damage", kind: SymbolKind.Function, startLine: 5, endLine: 6, signature: "func take_damage(amount: int) -> void:" },
+      ],
+      detailLevel: DetailLevel.Full,
+    }));
+    vi.doMock("../src/readmap/mappers/gdscript.js", () => ({ MAPPER_VERSION: 1, gdscriptMapper }));
+    const { clearMapCache } = await import("../src/map-cache.js");
+
+    const mapResult = await readTool({ path: filePath, map: true });
+    const mapOutput = text(mapResult);
+    expect(gdscriptMapper).toHaveBeenCalledTimes(1);
+    expect(mapResult.isError).not.toBe(true);
+    expect(mapOutput).toContain("File Map: Player.gd");
+    expect(mapOutput).toContain("GDScript");
+    expect(mapOutput).toContain("imports: res://weapons/sword.gd");
+    expect(mapOutput).toContain("func take_damage(amount: int) -> void:");
+
+    clearMapCache();
+    const signalResult = await readTool({ path: filePath, symbol: "health_changed" });
+    expect(text(signalResult)).toMatch(/^\[Symbol: health_changed \(signal\), lines 2-2 of 7\]/);
+    expect(text(signalResult)).toContain("signal health_changed(new_value: int)");
+
+    clearMapCache();
+    const functionResult = await readTool({ path: filePath, symbol: "take_damage" });
+    expect(text(functionResult)).toMatch(/^\[Symbol: take_damage \(function\), lines 5-6 of 7\]/);
+    expect(text(functionResult)).toContain("func take_damage(amount: int) -> void:");
+
+    vi.resetModules();
+    const fallbackRoot = tempRoot("gdscript-read-unavailable");
+    cleanup.push(fallbackRoot);
+    await mkdir(fallbackRoot, { recursive: true });
+    const fallbackPath = join(fallbackRoot, "Player.gd");
+    await writeFile(fallbackPath, "func _ready():\n\tpass\n");
+    const fallbackSettingsPath = join(fallbackRoot, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(fallbackSettingsPath, ".."), { recursive: true });
+    await writeFile(fallbackSettingsPath, JSON.stringify({ gdscript: { enabled: true } }));
+    const { __setHashlineSettingsPathsForTest: setFallbackSettingsPathsForTest } = await import("../src/hashline-settings.js");
+    setFallbackSettingsPathsForTest({ globalSettingsPath: join(fallbackRoot, "missing.json"), projectSettingsPath: fallbackSettingsPath });
+    const nullMapper = vi.fn(async () => null);
+    vi.doMock("../src/readmap/mappers/gdscript.js", () => ({ MAPPER_VERSION: 1, gdscriptMapper: nullMapper }));
+
+    const fallbackResult = await readTool({ path: fallbackPath, map: true });
+    expect(nullMapper).toHaveBeenCalledTimes(1);
+    expect(fallbackResult.isError).not.toBe(true);
+    expect(text(fallbackResult)).toContain("File Map: Player.gd");
+  });
+});

--- a/tests/gdscript-settings-default.test.ts
+++ b/tests/gdscript-settings-default.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import {
+  __resetHashlineSettingsPathsForTest,
+  __setHashlineSettingsPathsForTest,
+  isGdscriptMappingEnabled,
+} from "../src/hashline-settings.js";
+
+function tempRoot(prefix: string): string {
+  return join(tmpdir(), `${prefix}-${randomBytes(6).toString("hex")}`);
+}
+
+describe("isGdscriptMappingEnabled default", () => {
+  const cleanup: string[] = [];
+  afterEach(async () => {
+    delete process.env.PI_HASHLINE_GDSCRIPT;
+    __resetHashlineSettingsPathsForTest();
+    await Promise.all(cleanup.map((path) => rm(path, { recursive: true, force: true })));
+    cleanup.length = 0;
+  });
+
+  it("defaults to disabled when JSON and env are absent", () => {
+    delete process.env.PI_HASHLINE_GDSCRIPT;
+    const root = tempRoot("gdscript-settings-default");
+    cleanup.push(root);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath: join(root, "repo/.pi/hashline-readmap/settings.json"),
+    });
+
+    expect(isGdscriptMappingEnabled()).toBe(false);
+  });
+});

--- a/tests/gdscript-settings-env.test.ts
+++ b/tests/gdscript-settings-env.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import { __resetHashlineSettingsPathsForTest, __setHashlineSettingsPathsForTest, isGdscriptMappingEnabled } from "../src/hashline-settings.js";
+
+function tempRoot(prefix: string): string { return join(tmpdir(), `${prefix}-${randomBytes(6).toString("hex")}`); }
+
+describe("PI_HASHLINE_GDSCRIPT precedence", () => {
+  const cleanup: string[] = [];
+  const originalEnv = process.env.PI_HASHLINE_GDSCRIPT;
+  afterEach(async () => {
+    if (originalEnv === undefined) delete process.env.PI_HASHLINE_GDSCRIPT;
+    else process.env.PI_HASHLINE_GDSCRIPT = originalEnv;
+    __resetHashlineSettingsPathsForTest();
+    await Promise.all(cleanup.map((path) => rm(path, { recursive: true, force: true })));
+    cleanup.length = 0;
+  });
+
+  it("lets PI_HASHLINE_GDSCRIPT=1 override disabled JSON", async () => {
+    process.env.PI_HASHLINE_GDSCRIPT = "1";
+    const root = tempRoot("gdscript-settings-env-over-json");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ gdscript: { enabled: false } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+
+    expect(isGdscriptMappingEnabled()).toBe(true);
+  });
+});

--- a/tests/gdscript-settings-json.test.ts
+++ b/tests/gdscript-settings-json.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import { __resetHashlineSettingsPathsForTest, __setHashlineSettingsPathsForTest, isGdscriptMappingEnabled } from "../src/hashline-settings.js";
+
+function tempRoot(prefix: string): string {
+  return join(tmpdir(), `${prefix}-${randomBytes(6).toString("hex")}`);
+}
+
+describe("isGdscriptMappingEnabled JSON settings", () => {
+  const cleanup: string[] = [];
+  afterEach(async () => {
+    delete process.env.PI_HASHLINE_GDSCRIPT;
+    __resetHashlineSettingsPathsForTest();
+    await Promise.all(cleanup.map((path) => rm(path, { recursive: true, force: true })));
+    cleanup.length = 0;
+  });
+
+  it("uses project gdscript.enabled over global gdscript.enabled", async () => {
+    delete process.env.PI_HASHLINE_GDSCRIPT;
+    const root = tempRoot("gdscript-settings-project-over-global");
+    cleanup.push(root);
+    const globalSettingsPath = join(root, "home/.pi/agent/hashline-readmap/settings.json");
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(globalSettingsPath, ".."), { recursive: true });
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(globalSettingsPath, JSON.stringify({ gdscript: { enabled: false } }));
+    await writeFile(projectSettingsPath, JSON.stringify({ gdscript: { enabled: true } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath, projectSettingsPath });
+
+    expect(isGdscriptMappingEnabled()).toBe(true);
+  });
+});

--- a/tests/gdscript-signal-rendering.test.ts
+++ b/tests/gdscript-signal-rendering.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { formatFileMap } from "../src/readmap/formatter.js";
+import { DetailLevel, SymbolKind } from "../src/readmap/enums.js";
+
+describe("GDScript signal symbol rendering", () => {
+  it("renders signal symbols through the generic symbol formatter", () => {
+    expect(SymbolKind.Signal).toBe("signal");
+
+    const rendered = formatFileMap({
+      path: "/tmp/Player.gd",
+      totalLines: 4,
+      totalBytes: 64,
+      language: "GDScript",
+      symbols: [
+        { name: "health_changed", kind: SymbolKind.Signal, startLine: 2, endLine: 2 },
+      ],
+      imports: [],
+      detailLevel: DetailLevel.Full,
+    });
+
+    expect(rendered).toContain("health_changed: [2]");
+    expect(rendered).not.toContain("undefined");
+  });
+});

--- a/tests/hashline-settings.test.ts
+++ b/tests/hashline-settings.test.ts
@@ -237,4 +237,38 @@ describe("resolveHashlineJsonSettings", () => {
     expect(result.settings.grep?.maxLines).toBe(10);
     expect(result.warnings[0].message).toContain("Invalid JSON");
   });
+
+
+  it("accepts boolean gdscript.enabled settings", async () => {
+    const root = tempRoot("hashline-settings-gdscript-enabled");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ gdscript: { enabled: true } }));
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+
+    expect(resolveHashlineJsonSettings()).toEqual({
+      settings: { gdscript: { enabled: true } },
+      warnings: [],
+    });
+  });
+
+  it("ignores invalid gdscript.enabled values with a settings warning", async () => {
+    const root = tempRoot("hashline-settings-gdscript-invalid");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ gdscript: { enabled: "yes" } }));
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+
+    const result = resolveHashlineJsonSettings();
+    expect(result.settings).toEqual({});
+    expect(result.warnings.map((warning) => warning.path)).toEqual(["gdscript.enabled"]);
+  });
 });

--- a/tests/map-cache.test.ts
+++ b/tests/map-cache.test.ts
@@ -142,4 +142,31 @@ describe("map-cache", () => {
 
 		spy.mockRestore();
 	});
+
+
+	it("does not reuse a stale GDScript map when enablement changes", async () => {
+		const mapperModule = await import("../src/readmap/mapper.js");
+		const spy = vi.spyOn(mapperModule, "generateMap");
+		const originalEnv = process.env.PI_HASHLINE_GDSCRIPT;
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+		const p = createTempFile("", ".gd");
+		await writeFile(p, "func _ready():\n\tpass\n");
+		try {
+			delete process.env.PI_HASHLINE_GDSCRIPT;
+			const first = await getOrGenerateMap(p);
+			const callsAfterFirst = spy.mock.calls.length;
+			process.env.PI_HASHLINE_GDSCRIPT = "1";
+			const second = await getOrGenerateMap(p);
+
+			expect(first).not.toBeNull();
+			expect(second).not.toBeNull();
+			expect(spy.mock.calls.length).toBe(callsAfterFirst + 1);
+			expect(second).not.toBe(first);
+		} finally {
+			if (originalEnv === undefined) delete process.env.PI_HASHLINE_GDSCRIPT;
+			else process.env.PI_HASHLINE_GDSCRIPT = originalEnv;
+			error.mockRestore();
+			spy.mockRestore();
+		}
+	});
 });

--- a/tests/mapper-versions.test.ts
+++ b/tests/mapper-versions.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 const modules = [
   "../src/readmap/mappers/python.js",
   "../src/readmap/mappers/go.js",
+  "../src/readmap/mappers/gdscript.js",
   "../src/readmap/mappers/typescript.js",
   "../src/readmap/mappers/markdown.js",
   "../src/readmap/mappers/rust.js",

--- a/tests/readmap-mappers-files.test.ts
+++ b/tests/readmap-mappers-files.test.ts
@@ -11,6 +11,7 @@ describe("required read-map mapper files (AC11)", () => {
     "typescript.ts",
     "python.ts",
     "go.ts",
+    "gdscript.ts",
     "rust.ts",
     "json.ts",
     "markdown.ts",


### PR DESCRIPTION
Closes #195.

## Problem

GDScript (`.gd`) files were detected as unsupported/read through the generic ctags/fallback path only. PR #109 by @cosmicnag explored a dedicated `gdtoolkit`-backed GDScript mapper, but shipping that path directly would have made an optional/niche backend feel like a default dependency surface.

This PR keeps existing users safe by making GDScript structural maps explicitly opt-in while preserving the current fallback behavior for everyone else.

## What changed

- Detect `.gd` files as `{ id: "gdscript", name: "GDScript" }`.
- Add JSON config support for `gdscript.enabled` with boolean-only validation and settings warnings for invalid values.
- Add `PI_HASHLINE_GDSCRIPT=1` as the highest-precedence one-off enablement override.
- Add an opt-in TypeScript GDScript mapper wrapper that invokes a packaged Python helper with `execFile("python3", [helper, filePath])` — no shell interpolation.
- Add `scripts/gdscript_outline.py`, which imports `gdtoolkit.parser`, walks the parsed AST, and emits JSON symbols/imports for classes, functions, variables/properties, constants, enums, signals, and `load`/`preload`/`requires` references.
- Keep `gdtoolkit` out of npm dependencies and package only the helper script, not the parser/backend.
- Fall back safely to ctags/fallback mapping when GDScript support is disabled or when Python, `gdtoolkit`, parsing, subprocess execution, or helper JSON decoding fails.
- Add a concise missing-backend diagnostic: install `gdtoolkit` or disable `PI_HASHLINE_GDSCRIPT`.
- Add generic `signal` symbol rendering support without a GDScript-specific formatter path.
- Bypass map caching for `.gd` files so toggling GDScript enablement cannot reuse stale fallback/dedicated maps generated under a previous setting.
- Document niche opt-in setup, manual `pip install gdtoolkit`, JSON enablement, env override, and fallback behavior.

## Credit

Thanks to @cosmicnag for PR #109 (`feat: add GDScript mapper using gdtoolkit`), which established the original direction of using `gdtoolkit.parser` for regex-free GDScript structural extraction. This implementation reuses that core idea within the opt-in/fallback constraints for this repo.

## Verification

- `npm run typecheck`
- `npm test` — 368 files / 1557 tests
- `npx vitest run tests/hashline-settings.test.ts tests/gdscript-*.test.ts tests/mapper-versions.test.ts tests/readmap-mappers-files.test.ts` — 13 files / 52 tests
- `npx vitest run tests/map-cache.test.ts` — 1 file / 8 tests
- `npm pack --dry-run` — confirms `scripts/gdscript_outline.py` is included and package remains under 1 MB
- Dependency check confirms `gdtoolkit` is absent from `dependencies`, `devDependencies`, `peerDependencies`, and `optionalDependencies`

## Notes

- Default behavior is unchanged: without JSON enablement or `PI_HASHLINE_GDSCRIPT=1`, `.gd` files use the existing ctags/fallback path and do not invoke Python.
- Users who opt in must provide a Python environment where `gdtoolkit.parser` is importable by `python3`.
- This intentionally does not add automatic backend installation, network fetching, a CLI/TUI for toggling GDScript, or ast-grep custom-language support.
