### PR TITLE
Fix read image parity and refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![npm](https://img.shields.io/npm/v/pi-hashline-readmap)](https://www.npmjs.com/package/pi-hashline-readmap)
 
-Upgrade pi's local coding workflow with hash-anchored reads and edits, structural file maps, symbol-aware navigation, structural search, agent-friendly file exploration, and compressed `bash` output.
+Upgrade pi's local coding workflow with hash-anchored text reads and edits, stock-pi-compatible image reads, structural file maps, symbol-aware navigation, structural search, agent-friendly file exploration, and compressed `bash` output.
 
 `pi-hashline-readmap` is a drop-in [pi](https://github.com/mariozechner/pi-coding-agent) extension. It replaces the stock `read`, `edit`, `grep`, `ls`, and `find` tools, provides an enhanced `ast_search` tool, registers `write`, adds an optional `nu` tool for structured exploration via Nushell, and post-processes `bash` output so more context budget goes to signal instead of noise.
 
@@ -15,6 +15,7 @@ It also reduces extension conflict risk by replacing several overlapping tool pa
 
 - Keep edits tied to stable `LINE:HASH` anchors instead of fragile line numbers.
 - Navigate large files with structural maps and direct symbol reads.
+- Read supported images and screenshots through pi-compatible image attachments instead of ad hoc OCR/tooling.
 - Turn search results into edit anchors without an extra read step.
 - Search code structurally with `ast_search` when text search is too brittle.
 - Keep readmap subprocesses safe for paths containing shell metacharacters such as `"` and `$`.
@@ -71,7 +72,7 @@ brew install difftastic        # optional, improves semantic edit summaries
 brew install shellcheck yq scc # optional, improves some bash-output compression paths
 ```
 
-Dedicated readmap mappers handle TypeScript, Python, Rust, Go, Java, C, C++, Swift, shell, SQL, Markdown, and several data formats (JSON/JSONL/YAML/TOML/CSV) with the highest-quality structural maps. Rust, C++, and Java structural maps use `web-tree-sitter` with packaged `tree-sitter-wasms` grammars; no native tree-sitter packages are installed for those mappers. For files outside that set, the read tool's structural map falls back to universal-ctags when it is installed, and to a generic regex-based extractor when it is not. Installing universal-ctags is therefore only worthwhile if you regularly read files in languages without a dedicated mapper (for example Ruby, PHP, Lua, Kotlin) and want symbol-aware maps for them.
+Dedicated readmap mappers handle TypeScript, JavaScript, Python, Rust, Go, Java, C, C++, Swift, shell, SQL, Markdown, JSON/JSONL, YAML, TOML, CSV/TSV, and opt-in GDScript with the highest-quality structural maps. Rust, C++, and Java structural maps use `web-tree-sitter` with packaged `tree-sitter-wasms` grammars; C/C++ headers share the C++ mapper, and no native tree-sitter packages are installed for those mappers. For files outside that set, the read tool's structural map falls back to universal-ctags when it is installed, and to a generic regex-based extractor when it is not. Installing universal-ctags is therefore only worthwhile if you regularly read files in languages without a dedicated mapper (for example Ruby, PHP, Lua, Kotlin) and want symbol-aware maps for them.
 
 ### Bash output contract
 
@@ -142,7 +143,7 @@ read({ path: "tests/fixtures/small.ts", symbol: "createDemoDirectory" })
 read({ path: "tests/fixtures/small.ts", symbol: "UserDirectory.addUser" })
 ```
 
-Structural maps are appended automatically when large reads are truncated. The readmap supports 18 mapped language/file kinds, including TypeScript, JavaScript, Python, Rust, Go, Java, Swift, Shell, C/C++, SQL, JSON/JSONL, Markdown, YAML, TOML, and CSV/TSV. Direct symbol reads can target functions, classes, methods, interfaces, type aliases, constants, and enums when the file type is supported.
+Structural maps are appended automatically when large text reads are truncated. The readmap supports TypeScript, JavaScript, Python, Rust, Go, Java, Swift, Shell, C/C++, SQL, JSON/JSONL, Markdown, YAML, TOML, CSV/TSV, and opt-in GDScript. Direct symbol reads can target functions, classes, methods, interfaces, type aliases, constants, and enums when the file type is supported.
 
 ### Read a symbol with local support
 
@@ -151,6 +152,14 @@ read({ path: "tests/fixtures/small.ts", symbol: "createDemoDirectory", bundle: "
 ```
 
 Use `bundle: "local"` when you want the requested symbol plus direct same-file local support.
+
+### Read an image or screenshot
+
+```text
+read({ path: "screenshot.png" })
+```
+
+Supported images (`jpg`, `jpeg`, `png`, `gif`, and `webp`) are delegated to pi's stock image reader and return image attachments, not `LINE:HASH` edit anchors. Hashline also detects supported image magic bytes for extensionless or misnamed files before falling back to binary/text handling.
 
 ### Search and patch
 
@@ -254,6 +263,9 @@ Example project settings:
     "maxBytes": 40960,
     "headLines": 60,
     "tailLines": 100
+  },
+  "gdscript": {
+    "enabled": false
   }
 }
 ```
@@ -272,7 +284,8 @@ JSON fields:
 | `bashContextGuard.headLines` | `PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES` | Tightens the guarded preview head size; default/ceiling `80` |
 | `bashContextGuard.tailLines` | `PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES` | Tightens the guarded preview tail size; default/ceiling `120` |
 | `gdscript.enabled` | `PI_HASHLINE_GDSCRIPT` | Defaults to `false`; exact env value `1` enables the dedicated GDScript mapper and takes precedence over JSON |
-Budget fields must be strict positive base-10 integers. Zero, negative, signed, decimal, hexadecimal, exponent notation, separators, empty strings, and whitespace-only values are ignored. Malformed JSON files and invalid fields degrade safely: valid fields continue to apply where practical, invalid fields are ignored, and the loader emits non-fatal warnings where available.
+
+Budget fields must be strict positive base-10 integers. Zero, negative, signed, decimal, hexadecimal, exponent notation, separators, empty strings, and whitespace-only values are ignored. Boolean fields must be JSON booleans, and `mapCache.dir` must be a non-empty string. Malformed JSON files and invalid fields degrade safely: valid fields continue to apply where practical, invalid fields are ignored, and the loader emits non-fatal warnings where available.
 
 ### Optional GDScript maps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.8.13",
+      "version": "0.8.14",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/cli": "0.42.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {

--- a/src/read.ts
+++ b/src/read.ts
@@ -29,9 +29,10 @@ import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabe
 
 const READ_PROMPT_METADATA = defineToolPromptMetadata({
 	promptUrl: new URL("../prompts/read.md", import.meta.url),
-	promptSnippet: "Read files with hashline anchors and optional maps/symbol lookup",
+	promptSnippet: "Read text files or images; text reads include hashline anchors and optional maps/symbol lookup",
 	promptGuidelines: [
 		"Use read instead of bash cat/head/tail/sed for file inspection.",
+		"Use read for images/screenshots; supported images return attachments like stock pi read.",
 		"Use read offset/limit, symbol, or map to keep large files focused.",
 		"Use read anchors as fresh inputs for edit.",
 	],
@@ -49,6 +50,55 @@ interface ReadParams {
 interface ReadToolOptions {
 	onSuccessfulRead?: (absolutePath: string) => void;
 }
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+function startsWithBytes(buffer: Buffer, bytes: number[]): boolean {
+	return buffer.length >= bytes.length && bytes.every((byte, index) => buffer[index] === byte);
+}
+
+function startsWithAscii(buffer: Buffer, offset: number, text: string): boolean {
+	if (buffer.length < offset + text.length) return false;
+	for (let index = 0; index < text.length; index++) {
+		if (buffer[offset + index] !== text.charCodeAt(index)) return false;
+	}
+	return true;
+}
+
+function readUint32BE(buffer: Buffer, offset: number): number {
+	return (
+		((buffer[offset] ?? 0) * 0x1000000) +
+		((buffer[offset + 1] ?? 0) << 16) +
+		((buffer[offset + 2] ?? 0) << 8) +
+		(buffer[offset + 3] ?? 0)
+	);
+}
+
+function isPng(buffer: Buffer): boolean {
+	return buffer.length >= 16 && readUint32BE(buffer, PNG_SIGNATURE.length) === 13 && startsWithAscii(buffer, 12, "IHDR");
+}
+
+function isAnimatedPng(buffer: Buffer): boolean {
+	let offset = PNG_SIGNATURE.length;
+	while (offset + 8 <= buffer.length) {
+		const chunkLength = readUint32BE(buffer, offset);
+		const chunkTypeOffset = offset + 4;
+		if (startsWithAscii(buffer, chunkTypeOffset, "acTL")) return true;
+		if (startsWithAscii(buffer, chunkTypeOffset, "IDAT")) return false;
+		const nextOffset = offset + 8 + chunkLength + 4;
+		if (nextOffset <= offset || nextOffset > buffer.length) return false;
+		offset = nextOffset;
+	}
+	return false;
+}
+
+function isSupportedImageBuffer(buffer: Buffer): boolean {
+	if (startsWithBytes(buffer, [0xff, 0xd8, 0xff])) return buffer[3] !== 0xf7;
+	if (startsWithBytes(buffer, PNG_SIGNATURE)) return isPng(buffer) && !isAnimatedPng(buffer);
+	if (startsWithAscii(buffer, 0, "GIF")) return true;
+	return startsWithAscii(buffer, 0, "RIFF") && startsWithAscii(buffer, 8, "WEBP");
+}
+
 
 export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}) {
 	const ptc = {
@@ -250,7 +300,7 @@ export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}
 			// Delegate images to the built-in read tool
 			throwIfAborted(signal);
 			const ext = rawPath.split(".").pop()?.toLowerCase() ?? "";
-			if (["jpg", "jpeg", "png", "gif", "webp", "bmp", "svg"].includes(ext)) {
+			if (["jpg", "jpeg", "png", "gif", "webp"].includes(ext)) {
 				const builtinRead = createReadTool(ctx.cwd);
 				return succeed(await builtinRead.execute(_toolCallId, p, signal, _onUpdate));
 			}
@@ -326,6 +376,11 @@ export function registerReadTool(pi: ExtensionAPI, options: ReadToolOptions = {}
 						},
 					},
 				};
+			}
+
+			if (isSupportedImageBuffer(rawBuffer)) {
+				const builtinRead = createReadTool(ctx.cwd);
+				return succeed(await builtinRead.execute(_toolCallId, p, signal, _onUpdate));
 			}
 			const hasBinaryContent = looksLikeBinary(rawBuffer);
 			throwIfAborted(signal);

--- a/src/tool-prompt-metadata.ts
+++ b/src/tool-prompt-metadata.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 
 
 const COMPACT_DESCRIPTIONS: Record<string, string> = {
-  "read.md": "Read file contents by path, range, or symbol; returns LINE:HASH anchors for edits.",
+  "read.md": "Read text files/images by path; text has LINE:HASH anchors, images return attachments.",
   "edit.md": "Edit existing text files using fresh LINE:HASH anchors from read, grep, ast_search, or write.",
   "grep.md": "Search file contents; non-summary results include LINE:HASH anchors for edits.",
   "find.md": "Find files by glob, respecting .gitignore.",
@@ -16,8 +16,8 @@ const COMPACT_DESCRIPTIONS: Record<string, string> = {
 
 const COMPACT_GUIDELINES: Record<string, string[]> = {
   "read.md": [
-    "Use read for file contents, ranges, symbols, and edit anchors.",
-    "Use read map or symbol options to keep reads focused.",
+    "Use read for file contents, images/screenshots, ranges, symbols, and edit anchors.",
+    "Use read for images; it returns attachments, so avoid OCR tools unless explicitly needed.",
   ],
   "edit.md": [
     "Use edit with fresh LINE:HASH anchors for existing files.",

--- a/tests/read-integration.test.ts
+++ b/tests/read-integration.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
 import { clearMapCache } from "../src/map-cache.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixturesDir = resolve(__dirname, "fixtures");
@@ -115,6 +116,28 @@ describe("read integration — combined output", () => {
 		expect(text).toMatch(/^\d+:[0-9a-f]{3}\|/m);
 		expect(text).not.toContain("File Map:");
 		expect(text).not.toContain("[Output truncated:");
+	});
+
+
+	it("extensionless PNG files return stock pi image attachments", async () => {
+		const tempDir = mkdtempSync(resolve(tmpdir(), "hashline-read-image-"));
+		try {
+			const imagePath = resolve(tempDir, "screenshot");
+			writeFileSync(
+				imagePath,
+				Buffer.from(
+					"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lBBkGQAAAABJRU5ErkJggg==",
+					"base64",
+				),
+			);
+
+			const result = await callReadTool({ path: imagePath });
+
+			expect(getTextContent(result)).toContain("Read image file [image/png]");
+			expect(getTextContent(result)).not.toContain("LINE:HASH");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	it("map generation failure still returns hashlines without error", async () => {

--- a/tests/readme-license.test.ts
+++ b/tests/readme-license.test.ts
@@ -34,7 +34,8 @@ describe("README.md (AC-1, AC-2)", () => {
 
   it("mentions supported languages", () => {
     const readme = readFileSync(resolve(root, "README.md"), "utf8");
-    expect(readme).toContain("18 mapped language/file kinds");
+    expect(readme).toContain("TypeScript, JavaScript, Python");
+    expect(readme).toContain("opt-in GDScript");
   });
 
   it("credits upstream projects", () => {

--- a/tests/tool-prompt-metadata.test.ts
+++ b/tests/tool-prompt-metadata.test.ts
@@ -134,7 +134,7 @@ describe("compact provider-visible descriptions", () => {
       nu: registerNuTool(pi as any),
     };
 
-    expect(tools.read.description).toBe("Read file contents by path, range, or symbol; returns LINE:HASH anchors for edits.");
+    expect(tools.read.description).toBe("Read text files/images by path; text has LINE:HASH anchors, images return attachments.");
     expect(tools.edit.description).toBe("Edit existing text files using fresh LINE:HASH anchors from read, grep, ast_search, or write.");
     expect(tools.grep.description).toBe("Search file contents; non-summary results include LINE:HASH anchors for edits.");
     expect(tools.find.description).toBe("Find files by glob, respecting .gitignore.");


### PR DESCRIPTION
## Summary

This PR cleans up the user-facing docs and tool metadata after the recent settings/GDScript work, and fixes a gap in read image handling parity with stock pi.

### Read image parity

Hashline's replacement read tool now makes image support explicit and delegates supported images to stock pi behavior:

- advertises image/screenshot support in the read prompt snippet and guidelines
- delegates jpg, jpeg, png, gif, and webp to pi's built-in image reader
- detects supported image magic bytes for extensionless or misnamed image files before binary/text fallback
- documents that image reads return attachments, not LINE:HASH edit anchors

This should prevent agents from inventing OCR/Tesseract workflows when read can already pass the image to a vision-capable model.

### README refresh

The README is updated to reflect recent PRs and current code behavior:

- documents native hashline JSON settings from #125 / #196, including global/project paths and env override precedence
- documents opt-in GDScript support from #127 / #195, including gdscript.enabled, PI_HASHLINE_GDSCRIPT=1, and the gdtoolkit backend requirement
- refreshes supported language/readmap coverage, including JavaScript and opt-in GDScript
- clarifies the web-tree-sitter migration from #123 / #192: Rust, C++, and Java use packaged tree-sitter-wasms, with no native tree-sitter install caveats
- adds image-read behavior to the README so the docs match the tool contract

### Version

- bumps package version to 0.8.14

## Validation

- npm test -- tests/readme-content.test.ts tests/readme-license.test.ts tests/prompts-files.test.ts tests/tool-prompt-metadata.test.ts tests/read-integration.test.ts
- npm run typecheck
