### PR TITLE
feat(edit): add configurable diff display defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,9 @@ Example project settings:
   },
   "gdscript": {
     "enabled": false
+  },
+  "edit": {
+    "diffDisplay": "collapsed"
   }
 }
 ```
@@ -284,6 +287,7 @@ JSON fields:
 | `bashContextGuard.headLines` | `PI_HASHLINE_BASH_CONTEXT_GUARD_HEAD_LINES` | Tightens the guarded preview head size; default/ceiling `80` |
 | `bashContextGuard.tailLines` | `PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES` | Tightens the guarded preview tail size; default/ceiling `120` |
 | `gdscript.enabled` | `PI_HASHLINE_GDSCRIPT` | Defaults to `false`; exact env value `1` enables the dedicated GDScript mapper and takes precedence over JSON |
+| `edit.diffDisplay` | `PI_HASHLINE_EDIT_DIFF_DISPLAY` | Defaults to `collapsed`; set to `expanded` to render `edit` tool diffs inline without pressing Ctrl+O. Project JSON overrides global JSON. The env override is case-insensitive (`expanded`/`collapsed` in any casing, with surrounding whitespace trimmed); unrecognized env values are ignored and fall through to JSON, then the default. |
 
 Budget fields must be strict positive base-10 integers. Zero, negative, signed, decimal, hexadecimal, exponent notation, separators, empty strings, and whitespace-only values are ignored. Boolean fields must be JSON booleans, and `mapCache.dir` must be a non-empty string. Malformed JSON files and invalid fields degrade safely: valid fields continue to apply where practical, invalid fields are ignored, and the loader emits non-fatal warnings where available.
 

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -21,6 +21,7 @@ import { buildDiffData, type DiffBlockRange } from "./diff-data.js";
 import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, summaryLine } from "./tui-render-utils.js";
 import { DiffPreviewComponent } from "./tui-diff-component.js";
 import { buildContextHygieneMetadata, buildFileResource, type ContextHygieneMetadata } from "./context-hygiene.js";
+import { resolveEditDiffDisplay } from "./hashline-settings.js";
 
 const EDIT_PENDING_PREVIEW_STATE_KEY = "hashline-edit-pending-preview";
 
@@ -642,7 +643,7 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				previewKey,
 				() => buildPendingEditPreviewData(args ?? {}, context.cwd ?? process.cwd()),
 			);
-			const expanded = !!context.expanded;
+			const expanded = !!context.expanded || resolveEditDiffDisplay() === "expanded";
 			const preview2 = pendingPreviewLines(text, preview, expanded);
 			if (preview2.diffData) {
 				const diffComponent = context.lastComponent instanceof DiffPreviewComponent
@@ -692,7 +693,7 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 				semanticClassification: semanticClassification as any,
 			});
 
-			const expanded = isRendererExpanded(options as any, context as any);
+			const expanded = isRendererExpanded(options as any, context as any) || resolveEditDiffDisplay() === "expanded";
 			const width = (context as any).width ?? (options as any)?.width;
 			const diffData = (details as any).diffData;
 			const stats = diffData?.stats ?? { added: 0, removed: 0 };

--- a/src/hashline-settings.ts
+++ b/src/hashline-settings.ts
@@ -7,6 +7,7 @@ export interface HashlineJsonSettings {
   mapCache?: { dir?: string; enabled?: boolean };
   bashContextGuard?: { enabled?: boolean; maxLines?: number; maxBytes?: number; headLines?: number; tailLines?: number };
   gdscript?: { enabled?: boolean };
+  edit?: { diffDisplay?: "collapsed" | "expanded" };
 }
 export interface HashlineSettingsWarning { source: string; message: string; path?: string }
 export interface HashlineSettingsResult { settings: HashlineJsonSettings; warnings: HashlineSettingsWarning[] }
@@ -172,6 +173,16 @@ function validateSettings(raw: unknown, source: string, rawText: string): Hashli
     if (enabled !== undefined) gdscript.enabled = enabled;
     if (Object.keys(gdscript).length > 0) settings.gdscript = gdscript;
   }
+  if (isRecord(raw.edit)) {
+    const edit: NonNullable<HashlineJsonSettings["edit"]> = {};
+    if ("diffDisplay" in raw.edit) {
+      const value = raw.edit.diffDisplay;
+      // Accept both "collapsed" and "expanded" literals (AC 2 + AC 3); other values warn.
+      if (value === "collapsed" || value === "expanded") edit.diffDisplay = value;
+      else warnings.push(invalid(source, "edit.diffDisplay"));
+    }
+    if (Object.keys(edit).length > 0) settings.edit = edit;
+  }
   return { settings, warnings };
 }
 function readSettingsFile(path: string): HashlineSettingsResult {
@@ -193,6 +204,8 @@ function mergeSettings(base: HashlineJsonSettings, override: HashlineJsonSetting
   if (Object.keys(bashContextGuard).length > 0) merged.bashContextGuard = bashContextGuard;
   const gdscript = { ...(base.gdscript ?? {}), ...(override.gdscript ?? {}) };
   if (Object.keys(gdscript).length > 0) merged.gdscript = gdscript;
+  const edit = { ...(base.edit ?? {}), ...(override.edit ?? {}) };
+  if (Object.keys(edit).length > 0) merged.edit = edit;
   return merged;
 }
 export function resolveHashlineJsonSettings(): HashlineSettingsResult {
@@ -206,4 +219,15 @@ export function isGdscriptMappingEnabled(env: NodeJS.ProcessEnv = process.env): 
     return env.PI_HASHLINE_GDSCRIPT === "1";
   }
   return resolveHashlineJsonSettings().settings.gdscript?.enabled === true;
+}
+
+export function resolveEditDiffDisplay(env: NodeJS.ProcessEnv = process.env): "collapsed" | "expanded" {
+  const raw = env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+  if (typeof raw === "string") {
+    const normalized = raw.trim().toLowerCase();
+    if (normalized === "expanded" || normalized === "collapsed") return normalized;
+  }
+  const json = resolveHashlineJsonSettings().settings.edit?.diffDisplay;
+  if (json === "expanded" || json === "collapsed") return json;
+  return "collapsed";
 }

--- a/tests/edit-diff-display-renderer.test.ts
+++ b/tests/edit-diff-display-renderer.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { registerEditTool } from "../src/edit.js";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { vi } from "vitest";
+import { __resetHashlineSettingsPathsForTest, __setHashlineSettingsPathsForTest } from "../src/hashline-settings.js";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+
+const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
+
+function textOf(component: any, width = 120): string {
+  return component?.text ?? component?.render?.(width)?.join("\n") ?? "";
+}
+
+function getEditTool(): any {
+  let registered: any;
+  registerEditTool({ registerTool(def: any) { registered = def; } } as any, { wasReadInSession: () => true } as any);
+  if (!registered) throw new Error("edit tool was not registered");
+  return registered;
+}
+
+describe("edit final-result renderer with edit.diffDisplay = expanded", () => {
+  const originalEnv = process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+    else process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY = originalEnv;
+  });
+
+  it("renders the diff body inline when context.expanded is false but the env says expanded", () => {
+    process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY = "expanded";
+    const result: any = {
+      content: [{ type: "text", text: "1:abc|one\n2:def|TWO" }],
+      details: {
+        diff: "-2 two\n+2 TWO",
+        diffData: {
+          version: 1,
+          stats: { added: 1, removed: 1, context: 0 },
+          entries: [
+            { kind: "remove", oldLine: 2, text: "two" },
+            { kind: "add", newLine: 2, text: "TWO" },
+          ],
+        },
+        ptcValue: { warnings: [], noopEdits: [] },
+      },
+    };
+    const rendered = textOf(
+      getEditTool().renderResult(result, { expanded: false, width: 80 }, theme, { expanded: false, width: 80 }),
+      80,
+    );
+    expect(rendered).toContain("↳ diff +1 -1");
+    expect(rendered).toContain("▌+ 2 │ TWO");
+  });
+});
+describe("edit pending-preview renderer with edit.diffDisplay = expanded", () => {
+  const originalEnv = process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+    else process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY = originalEnv;
+  });
+
+  it("renders pending preview diff inline when context.expanded is false but the env says expanded", async () => {
+    process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY = "expanded";
+    const cwd = mkdtempSync(resolve(tmpdir(), "pi-edit-pending-setting-"));
+    const filePath = resolve(cwd, "sample.ts");
+    writeFileSync(filePath, "const unique = 1;\n", "utf-8");
+    const tool = getEditTool();
+    const context: any = { argsComplete: false, executionStarted: false, cwd, state: {}, invalidate: vi.fn(), lastComponent: undefined, expanded: false };
+    const args = { path: filePath, edits: [{ replace: { old_text: "const unique = 1;", new_text: "const unique = 2;" } }] };
+
+    const first = tool.renderCall(args, theme, context);
+    await Promise.resolve();
+    const second = tool.renderCall(args, theme, { ...context, lastComponent: first });
+    const rendered = textOf(second);
+
+    expect(rendered).toContain("pending edit");
+    expect(rendered).toContain("↳ diff +1 -1");
+    expect(rendered).toContain("▌+ 1 │ const unique = 2;");
+  });
+});
+
+describe("edit renderer default behavior is unchanged with no setting and no env", () => {
+  const originalEnv = process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+    else process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY = originalEnv;
+    __resetHashlineSettingsPathsForTest();
+  });
+
+  it("keeps the final-result diff hidden when nothing requests expansion", () => {
+    delete process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+    const root = join(tmpdir(), `edit-diff-renderer-default-${randomBytes(6).toString("hex")}`);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath: join(root, "repo/.pi/hashline-readmap/settings.json"),
+    });
+    const result: any = {
+      content: [{ type: "text", text: "1:abc|one\n2:def|TWO" }],
+      details: {
+        diff: "-2 two\n+2 TWO",
+        diffData: {
+          version: 1,
+          stats: { added: 1, removed: 1, context: 0 },
+          entries: [
+            { kind: "remove", oldLine: 2, text: "two" },
+            { kind: "add", newLine: 2, text: "TWO" },
+          ],
+        },
+        ptcValue: { warnings: [], noopEdits: [] },
+      },
+    };
+    const rendered = textOf(
+      getEditTool().renderResult(result, { expanded: false, width: 80 }, theme, { expanded: false, width: 80 }),
+      80,
+    );
+    expect(rendered).not.toContain("↳ diff +1 -1");
+    expect(rendered).not.toContain("▌+ 2 │ TWO");
+  });
+
+  it("still expands the final-result diff when context.expanded is true", () => {
+    delete process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+    const root = join(tmpdir(), `edit-diff-renderer-ctx-${randomBytes(6).toString("hex")}`);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath: join(root, "repo/.pi/hashline-readmap/settings.json"),
+    });
+    const result: any = {
+      content: [{ type: "text", text: "1:abc|one\n2:def|TWO" }],
+      details: {
+        diff: "-2 two\n+2 TWO",
+        diffData: {
+          version: 1,
+          stats: { added: 1, removed: 1, context: 0 },
+          entries: [
+            { kind: "remove", oldLine: 2, text: "two" },
+            { kind: "add", newLine: 2, text: "TWO" },
+          ],
+        },
+        ptcValue: { warnings: [], noopEdits: [] },
+      },
+    };
+    const rendered = textOf(
+      getEditTool().renderResult(result, { expanded: true, width: 80 }, theme, { expanded: true, width: 80 }),
+      80,
+    );
+    expect(rendered).toContain("↳ diff +1 -1");
+    expect(rendered).toContain("▌+ 2 │ TWO");
+  });
+});

--- a/tests/edit-diff-display-scope.test.ts
+++ b/tests/edit-diff-display-scope.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) walk(full, acc);
+    else if (stat.isFile() && /\.(ts|tsx)$/.test(entry)) acc.push(full);
+  }
+  return acc;
+}
+
+describe("edit.diffDisplay scope guard", () => {
+  it("only src/hashline-settings.ts and src/edit.ts reference PI_HASHLINE_EDIT_DIFF_DISPLAY or resolveEditDiffDisplay", () => {
+    const root = "src";
+    const allowed = new Set([
+      join(root, "hashline-settings.ts"),
+      join(root, "edit.ts"),
+    ]);
+    const offenders: { file: string; pattern: string }[] = [];
+    for (const file of walk(root)) {
+      const rel = relative(".", file);
+      if (allowed.has(rel)) continue;
+      const text = readFileSync(file, "utf8");
+      if (text.includes("PI_HASHLINE_EDIT_DIFF_DISPLAY")) offenders.push({ file: rel, pattern: "PI_HASHLINE_EDIT_DIFF_DISPLAY" });
+      if (text.includes("resolveEditDiffDisplay")) offenders.push({ file: rel, pattern: "resolveEditDiffDisplay" });
+      if (/\.edit\?\s*\.diffDisplay\b/.test(text) || /\.edit\b[^"]*\.diffDisplay\b/.test(text)) {
+        offenders.push({ file: rel, pattern: "edit.diffDisplay" });
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/edit-diff-display-settings.test.ts
+++ b/tests/edit-diff-display-settings.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import {
+  __resetHashlineSettingsPathsForTest,
+  __setHashlineSettingsPathsForTest,
+  resolveEditDiffDisplay,
+} from "../src/hashline-settings.js";
+
+function tempRoot(prefix: string): string {
+  return join(tmpdir(), `${prefix}-${randomBytes(6).toString("hex")}`);
+}
+
+describe("resolveEditDiffDisplay", () => {
+  const cleanup: string[] = [];
+  const originalEnv = process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+
+  afterEach(async () => {
+    if (originalEnv === undefined) delete process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+    else process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY = originalEnv;
+    __resetHashlineSettingsPathsForTest();
+    await Promise.all(cleanup.map((path) => rm(path, { recursive: true, force: true })));
+    cleanup.length = 0;
+  });
+
+  it("defaults to \"collapsed\" when no JSON setting and no env override are present", () => {
+    delete process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+    const root = tempRoot("edit-diff-display-default");
+    cleanup.push(root);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath: join(root, "repo/.pi/hashline-readmap/settings.json"),
+    });
+
+    expect(resolveEditDiffDisplay()).toBe("collapsed");
+  });
+
+  it("returns the JSON-resolved value when PI_HASHLINE_EDIT_DIFF_DISPLAY is unset", async () => {
+    delete process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+    const root = tempRoot("edit-diff-display-json-only");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ edit: { diffDisplay: "expanded" } }));
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+
+    expect(resolveEditDiffDisplay()).toBe("expanded");
+  });
+
+  it("lets PI_HASHLINE_EDIT_DIFF_DISPLAY override the JSON-resolved value", async () => {
+    process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY = "collapsed";
+    const root = tempRoot("edit-diff-display-env-over-json");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ edit: { diffDisplay: "expanded" } }));
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+
+    expect(resolveEditDiffDisplay()).toBe("collapsed");
+  });
+
+  it("returns \"expanded\" when only PI_HASHLINE_EDIT_DIFF_DISPLAY=expanded is set", () => {
+    process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY = "expanded";
+    const root = tempRoot("edit-diff-display-env-only");
+    cleanup.push(root);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath: join(root, "repo/.pi/hashline-readmap/settings.json"),
+    });
+
+    expect(resolveEditDiffDisplay()).toBe("expanded");
+  });
+
+  it.each([
+    ["expanded", "expanded"],
+    ["EXPANDED", "expanded"],
+    ["Expanded", "expanded"],
+    ["  expanded  ", "expanded"],
+    ["collapsed", "collapsed"],
+    ["COLLAPSED", "collapsed"],
+    ["  Collapsed\n", "collapsed"],
+  ])("normalizes PI_HASHLINE_EDIT_DIFF_DISPLAY=%j to %s", (raw, expected) => {
+    process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY = raw;
+    const root = tempRoot("edit-diff-display-env-case");
+    cleanup.push(root);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath: join(root, "repo/.pi/hashline-readmap/settings.json"),
+    });
+
+    expect(resolveEditDiffDisplay()).toBe(expected);
+  });
+
+  it.each(["1", "0", "true", "false", "auto", "", "yes", "no"])(
+    "ignores unrecognized PI_HASHLINE_EDIT_DIFF_DISPLAY=%j and falls through to JSON then default",
+    async (raw) => {
+      process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY = raw;
+      const root1 = tempRoot("edit-diff-display-env-unknown-default");
+      cleanup.push(root1);
+      __setHashlineSettingsPathsForTest({
+        globalSettingsPath: join(root1, "home/.pi/agent/hashline-readmap/settings.json"),
+        projectSettingsPath: join(root1, "repo/.pi/hashline-readmap/settings.json"),
+      });
+      expect(resolveEditDiffDisplay()).toBe("collapsed");
+
+      const root2 = tempRoot("edit-diff-display-env-unknown-json");
+      cleanup.push(root2);
+      const projectSettingsPath = join(root2, "repo/.pi/hashline-readmap/settings.json");
+      await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+      await writeFile(projectSettingsPath, JSON.stringify({ edit: { diffDisplay: "expanded" } }));
+      __setHashlineSettingsPathsForTest({
+        globalSettingsPath: join(root2, "home/.pi/agent/hashline-readmap/settings.json"),
+        projectSettingsPath,
+      });
+      expect(resolveEditDiffDisplay()).toBe("expanded");
+    },
+  );
+});

--- a/tests/hashline-settings.test.ts
+++ b/tests/hashline-settings.test.ts
@@ -271,4 +271,88 @@ describe("resolveHashlineJsonSettings", () => {
     expect(result.settings).toEqual({});
     expect(result.warnings.map((warning) => warning.path)).toEqual(["gdscript.enabled"]);
   });
+
+  it("accepts edit.diffDisplay = \"expanded\" from JSON without warnings", async () => {
+    const root = tempRoot("hashline-settings-edit-diff-expanded");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ edit: { diffDisplay: "expanded" } }));
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+
+    expect(resolveHashlineJsonSettings()).toEqual({
+      settings: { edit: { diffDisplay: "expanded" } },
+      warnings: [],
+    });
+  });
+  it("accepts edit.diffDisplay = \"collapsed\" from JSON without warnings", async () => {
+    const root = tempRoot("hashline-settings-edit-diff-collapsed");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ edit: { diffDisplay: "collapsed" } }));
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+
+    expect(resolveHashlineJsonSettings()).toEqual({
+      settings: { edit: { diffDisplay: "collapsed" } },
+      warnings: [],
+    });
+  });
+
+  it("rejects invalid edit.diffDisplay values with a warning", async () => {
+    const root = tempRoot("hashline-settings-edit-diff-invalid");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ edit: { diffDisplay: "auto" } }));
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+
+    const result = resolveHashlineJsonSettings();
+    expect(result.settings).toEqual({});
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toEqual({
+      source: projectSettingsPath,
+      path: "edit.diffDisplay",
+      message: `Invalid hashline setting at edit.diffDisplay`,
+    });
+  });
+
+  it("rejects non-string edit.diffDisplay values with a warning", async () => {
+    const root = tempRoot("hashline-settings-edit-diff-nonstring");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ edit: { diffDisplay: 42 } }));
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+
+    const result = resolveHashlineJsonSettings();
+    expect(result.settings).toEqual({});
+    expect(result.warnings.map((warning) => warning.path)).toEqual(["edit.diffDisplay"]);
+  });
+
+  it("lets project edit.diffDisplay override global edit.diffDisplay", async () => {
+    const root = tempRoot("hashline-settings-edit-diff-merge");
+    cleanup.push(root);
+    const globalSettingsPath = join(root, "home/.pi/agent/hashline-readmap/settings.json");
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(globalSettingsPath, ".."), { recursive: true });
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(globalSettingsPath, JSON.stringify({ edit: { diffDisplay: "collapsed" } }));
+    await writeFile(projectSettingsPath, JSON.stringify({ edit: { diffDisplay: "expanded" } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath, projectSettingsPath });
+
+    expect(resolveHashlineJsonSettings().settings.edit).toEqual({ diffDisplay: "expanded" });
+  });
 });

--- a/tests/package-version.test.ts
+++ b/tests/package-version.test.ts
@@ -6,8 +6,8 @@ const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
 
 describe("package version", () => {
   it("is bumped for the WASM tree-sitter migration release", () => {
-    expect(packageJson.version).toBe("0.8.13");
-    expect(packageLock.version).toBe("0.8.13");
-    expect(packageLock.packages[""].version).toBe("0.8.13");
+    expect(packageJson.version).toBe("0.8.14");
+    expect(packageLock.version).toBe("0.8.14");
+    expect(packageLock.packages[""].version).toBe("0.8.14");
   });
 });

--- a/tests/readme-content.test.ts
+++ b/tests/readme-content.test.ts
@@ -51,4 +51,13 @@ describe("README.md content (AC-1, AC-2)", () => {
     expect(readme).toContain("Rust, C++, and Java structural maps use `web-tree-sitter` with packaged `tree-sitter-wasms` grammars");
     expect(readme).toContain("no native tree-sitter packages are installed for those mappers");
   });
+
+  it("documents the edit.diffDisplay setting and PI_HASHLINE_EDIT_DIFF_DISPLAY env override", () => {
+    expect(readme).toContain("edit.diffDisplay");
+    expect(readme).toContain("PI_HASHLINE_EDIT_DIFF_DISPLAY");
+    expect(readme).toContain("`collapsed`");
+    expect(readme).toContain("`expanded`");
+    expect(readme).toContain("Defaults to `collapsed`");
+    expect(readme).toMatch(/case-insensitive/i);
+  });
 });


### PR DESCRIPTION
Closes #198.

## Problem

Hashline `edit` diffs currently default to collapsed output unless the renderer context is expanded with Ctrl+O. Users who prefer inline diffs had no durable JSON setting or env override to opt into expanded edit diffs by default.

## What changed

- Add `edit.diffDisplay` to Hashline JSON settings with allowed values `collapsed` and `expanded`.
- Validate invalid `edit.diffDisplay` values strictly, drop them from settings, and emit the existing invalid-setting warning shape at `edit.diffDisplay`.
- Preserve field-by-field project-over-global JSON precedence for the new `edit` settings block.
- Add `resolveEditDiffDisplay(env = process.env): "collapsed" | "expanded"` with env-over-JSON precedence and a `collapsed` default.
- Support `PI_HASHLINE_EDIT_DIFF_DISPLAY` as a case-insensitive, whitespace-trimmed env override; unrecognized values fall through to JSON/default.
- Use the resolved value as an expansion floor in both final-result and pending-preview `edit` renderers.
- Keep existing collapsed behavior when no setting/env is configured and do not rebind Ctrl+O or alter non-`edit` renderers.
- Document the JSON setting and env override in README alongside existing hashline settings.

## Acceptance criteria

- [x] AC1: `HashlineJsonSettings` exposes optional `edit.diffDisplay` and it round-trips through `resolveHashlineJsonSettings()`.
- [x] AC2: JSON `edit.diffDisplay = "expanded"` parses with no warnings.
- [x] AC3: JSON `edit.diffDisplay = "collapsed"` parses with no warnings.
- [x] AC4: invalid JSON values are dropped with exactly one `edit.diffDisplay` warning.
- [x] AC5: project JSON overrides global JSON for `edit.diffDisplay`.
- [x] AC6: missing `edit` settings leave `settings.edit` undefined with no warnings.
- [x] AC7: `resolveEditDiffDisplay()` is exported and defaults to `collapsed`.
- [x] AC8: resolver returns JSON value when env is unset.
- [x] AC9: recognized env value overrides JSON.
- [x] AC10: env parsing is case-insensitive and whitespace-tolerant.
- [x] AC11: unrecognized env values fall through to JSON/default.
- [x] AC12: final-result renderer expands inline when setting resolves to `expanded`.
- [x] AC13: pending-preview renderer expands inline when setting resolves to `expanded`.
- [x] AC14: default collapsed/expanded context behavior is unchanged when unset.
- [x] AC15: expanded setting acts as a floor and does not rebind Ctrl+O.
- [x] AC16: only `src/hashline-settings.ts` and `src/edit.ts` read the new setting/env; non-`edit` renderers are unchanged.
- [x] AC17: README documents JSON setting, env override, defaults, precedence, and ignored invalid env values.
- [x] AC18: tests cover JSON parsing, warnings, merge precedence, resolver precedence/normalization/fallback, renderer behavior, default behavior, and scope guard.

## Verification

- `npm test` — 371 files passed, 1588 tests passed.
- `npm run typecheck` — passed.
- Focused tests: `npx vitest run tests/hashline-settings.test.ts tests/edit-diff-display-settings.test.ts tests/edit-diff-display-renderer.test.ts tests/edit-diff-display-scope.test.ts tests/readme-content.test.ts --reporter verbose` — 5 files passed, 52 tests passed.

## Notes

- Codex review/adversarial review were attempted during code review but failed due Codex auth token refresh errors, so there were no advisory findings to adopt or reject.
