### PR TITLE
fix: edit/read UX hardening for weaker LLMs (#199)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ edit({
 
 `read`, `grep`, `ast_search`, and `write` all return hashlined output that can feed follow-up edits.
 
+### Editing notes
+
+- `new_text` is plain file content — never include `LINE:HASH|`, hash-only (`a1b|`), or `+` diff prefixes. `edit` strips them defensively when they dominate the replacement, but you should omit them.
+- Set `new_text` to `""` to delete the anchored line(s); use `"\n"` for an intentionally blank line.
+- `replace` is exact-only by default. `fuzzy: true` only normalizes whitespace and confusable Unicode after an exact match fails — it is not approximate or semantic matching.
+
 ### Create a new file with `write`
 
 ```text

--- a/docs/context-hygiene.md
+++ b/docs/context-hygiene.md
@@ -47,9 +47,9 @@ Maskable stale tools are:
 Rendered placeholders include:
 
 ```text
-[Stale read context: file content changed after this result. Re-run read to refresh.]
-[Stale grep context: matched file content changed after this result. Re-run grep to refresh.]
-[Stale ast_search context: matched file content changed after this result. Re-run ast_search to refresh.]
+[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]
+[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Run grep again for current matches.]
+[Stale ast_search result — this earlier ast_search was superseded by a later file change; nothing is wrong with ast_search. Run ast_search again for current matches.]
 [Stale bash context: mutation-after-read. Re-run the Bash command to refresh. Command: npm test]
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.8.14",
+      "version": "0.8.15",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/cli": "0.42.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {

--- a/prompts/edit.md
+++ b/prompts/edit.md
@@ -12,9 +12,10 @@ Surgically edit existing text files. Prefer hash-verified anchored edits from fr
 | `replace_symbol` | Replace one function/class/method/etc. | 0 (`symbol`) |
 | `replace` | String replacement escape hatch; one match by default, all with `all: true` | 0 |
 
+Set `new_text` (or `replace_lines` `new_text`) to `""` to delete the anchored line(s). For an intentionally blank line, use `"\n"` or whitespace content, not `""`.
 Prefer `set_line`, `replace_lines`, and `insert_after`: they verify the file still matches the anchored content. Use `replace` only when anchors are impractical, such as repeated text across many unrelated lines.
 
-`replace` is exact-only by default: missing `old_text` fails with `text-not-found`. Fuzzy replacement requires explicit `fuzzy: true`; when used, the response warns that exact text was not found and fuzzy matching was used.
+`replace` is exact-only by default: missing `old_text` fails with `text-not-found`. Wrap old_text/new_text in {replace: ...} — a bare top-level `{old_text, new_text}` inside `edits[]` is rejected with guidance. `fuzzy: true` is a narrow fallback that only normalizes whitespace and confusable Unicode (e.g. smart hyphens) after exact matching fails; it is **not approximate or Levenshtein/semantic matching** and will not find renamed or reworded text. When fuzzy matching is used, the response warns that exact text was not found.
 
 ## Input shape
 

--- a/src/context-hygiene.ts
+++ b/src/context-hygiene.ts
@@ -207,15 +207,15 @@ export function buildStaleContextRecord(input: BuildStaleContextRecordInput): Co
 }
 
 export function renderStaleReadPlaceholder(): string {
-  return "[Stale read context: file content changed after this result. Re-run read to refresh.]";
+  return "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]";
 }
 
 export function renderStaleGrepPlaceholder(): string {
-  return "[Stale grep context: matched file content changed after this result. Re-run grep to refresh.]";
+  return "[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Run grep again for current matches.]";
 }
 
 export function renderStaleAstSearchPlaceholder(): string {
-  return "[Stale ast_search context: matched file content changed after this result. Re-run ast_search to refresh.]";
+  return "[Stale ast_search result — this earlier ast_search was superseded by a later file change; nothing is wrong with ast_search. Run ast_search again for current matches.]";
 }
 
 export function renderStaleBashPlaceholder(record: ContextHygieneStaleRecord): string {

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -63,7 +63,10 @@ const hashlineEditItemSchema = Type.Union([
 	),
 	Type.Object(
 		{ old_text: Type.String(), new_text: Type.String() },
-		{ additionalProperties: true },
+		{
+			additionalProperties: true,
+			description: "Do not use — Wrap as { replace: {old_text, new_text} }.",
+		},
 	),
 ]);
 

--- a/src/hashline.ts
+++ b/src/hashline.ts
@@ -61,6 +61,7 @@ const DICT = Array.from({ length: HASH_MOD }, (_, i) => i.toString(RADIX).padSta
 
 const HASHLINE_PREFIX_RE = /^\d+:[0-9a-zA-Z]{1,16}\|/;
 const DIFF_PLUS_RE = /^\+(?!\+)/;
+const HASH_ONLY_PREFIX_RE = /^[0-9a-f]{3}\|/;
 const CONFUSABLE_HYPHENS_RE = /[\u2010\u2011\u2012\u2013\u2014\u2212\uFE63\uFF0D]/g;
 const HASH_RELOCATION_WINDOW_BASE = 20;
 const HASH_RELOCATION_WINDOW_CAP = 100;
@@ -193,6 +194,7 @@ function formatMismatchError(
 	}
 	const sorted = [...displayLines].sort((a, b) => a - b);
 	const out: string[] = [
+		"Edit rejected — nothing was written. The anchor hash did not match the current file content.",
 		`${mismatches.length} line${mismatches.length > 1 ? "s have" : " has"} changed since last read. Auto-relocation checks only within ±${relocationWindow} lines of each anchor. Use the updated LINE:HASH references shown below (>>> marks changed lines).`,
 		"",
 	];
@@ -234,6 +236,7 @@ function splitDst(dst: string): string[] {
 
 function stripNewLinePrefixes(lines: string[]): string[] {
 	let hashCount = 0;
+	let hashOnlyCount = 0;
 	let plusCount = 0;
 	let nonEmpty = 0;
 
@@ -241,16 +244,24 @@ function stripNewLinePrefixes(lines: string[]): string[] {
 		if (!l.length) continue;
 		nonEmpty++;
 		if (HASHLINE_PREFIX_RE.test(l)) hashCount++;
+		else if (HASH_ONLY_PREFIX_RE.test(l)) hashOnlyCount++;
 		if (DIFF_PLUS_RE.test(l)) plusCount++;
 	}
 
 	if (!nonEmpty) return lines;
 	const stripHash = hashCount > 0 && hashCount >= nonEmpty * 0.5;
-	const stripPlus = !stripHash && plusCount > 0 && plusCount >= nonEmpty * 0.5;
-	if (!stripHash && !stripPlus) return lines;
+	const stripHashOnly = !stripHash && nonEmpty >= 2 && hashOnlyCount > 0 && hashOnlyCount >= nonEmpty * 0.5;
+	const stripPlus = !stripHash && !stripHashOnly && plusCount > 0 && plusCount >= nonEmpty * 0.5;
+	if (!stripHash && !stripHashOnly && !stripPlus) return lines;
 
 	return lines.map((l) =>
-		stripHash ? l.replace(HASHLINE_PREFIX_RE, "") : stripPlus ? l.replace(DIFF_PLUS_RE, "") : l,
+		stripHash
+			? l.replace(HASHLINE_PREFIX_RE, "")
+			: stripHashOnly
+				? l.replace(HASH_ONLY_PREFIX_RE, "")
+				: stripPlus
+					? l.replace(DIFF_PLUS_RE, "")
+					: l,
 	);
 }
 

--- a/tests/context-hygiene-context-application.test.ts
+++ b/tests/context-hygiene-context-application.test.ts
@@ -40,7 +40,7 @@ describe("context hygiene context application", () => {
     expect(applied).not.toBe(messages);
     expect(applied[0]).not.toBe(staleRead);
     expect(applied[0].content).toEqual([
-      { type: "text", text: "[Stale read context: file content changed after this result. Re-run read to refresh.]" },
+      { type: "text", text: "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]" },
     ]);
     expect(applied[0].details).toMatchObject({
       ptcValue: { tool: "read" },
@@ -82,7 +82,7 @@ describe("context hygiene context application", () => {
     );
 
     expect(applied[0].content).toEqual([
-      { type: "text", text: "[Stale read context: file content changed after this result. Re-run read to refresh.]" },
+      { type: "text", text: "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]" },
     ]);
     expect(applied[1]).toBe(liveWrite);
     expect(applied[2]).toBe(freshRead);
@@ -105,7 +105,7 @@ describe("context hygiene context application", () => {
     const applied = applyContextHygieneStaleContext([staleGrep, liveEdit], tracker.generateReport());
 
     expect(applied[0].content).toEqual([
-      { type: "text", text: "[Stale grep context: matched file content changed after this result. Re-run grep to refresh.]" },
+      { type: "text", text: "[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Run grep again for current matches.]" },
     ]);
     expect(applied[0].details).toMatchObject({
       contextHygieneStale: {
@@ -136,7 +136,7 @@ describe("context hygiene context application", () => {
     const applied = applyContextHygieneStaleContext([staleGrep, liveWrite], tracker.generateReport());
 
     expect(applied[0].content).toEqual([
-      { type: "text", text: "[Stale grep context: matched file content changed after this result. Re-run grep to refresh.]" },
+      { type: "text", text: "[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Run grep again for current matches.]" },
     ]);
     expect(applied[1]).toBe(liveWrite);
   });
@@ -164,10 +164,10 @@ describe("context hygiene context application", () => {
     ], tracker.generateReport());
 
     expect(applied[0].content).toEqual([
-      { type: "text", text: "[Stale grep context: matched file content changed after this result. Re-run grep to refresh.]" },
+      { type: "text", text: "[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Run grep again for current matches.]" },
     ]);
     expect(applied[1].content).toEqual([
-      { type: "text", text: "[Stale read context: file content changed after this result. Re-run read to refresh.]" },
+      { type: "text", text: "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]" },
     ]);
     expect(applied[2].content).toEqual([{ type: "text", text: "chain edit output" }]);
   });
@@ -189,7 +189,7 @@ describe("context hygiene context application", () => {
     const applied = applyContextHygieneStaleContext([staleAst, liveEdit], tracker.generateReport());
 
     expect(applied[0].content).toEqual([
-      { type: "text", text: "[Stale ast_search context: matched file content changed after this result. Re-run ast_search to refresh.]" },
+      { type: "text", text: "[Stale ast_search result — this earlier ast_search was superseded by a later file change; nothing is wrong with ast_search. Run ast_search again for current matches.]" },
     ]);
     expect(applied[0].details).toMatchObject({
       contextHygieneStale: {
@@ -220,7 +220,7 @@ describe("context hygiene context application", () => {
     const applied = applyContextHygieneStaleContext([staleAst, liveWrite], tracker.generateReport());
 
     expect(applied[0].content).toEqual([
-      { type: "text", text: "[Stale ast_search context: matched file content changed after this result. Re-run ast_search to refresh.]" },
+      { type: "text", text: "[Stale ast_search result — this earlier ast_search was superseded by a later file change; nothing is wrong with ast_search. Run ast_search again for current matches.]" },
     ]);
     expect(applied[1]).toBe(liveWrite);
   });
@@ -248,7 +248,7 @@ describe("context hygiene context application", () => {
     const staleRead = toolResult("read-before-edit", "read", "old read output");
     const staleApplied = applyContextHygieneStaleContext([staleRead], tracker.generateReport());
     expect(staleApplied[0].content).toEqual([
-      { type: "text", text: "[Stale read context: file content changed after this result. Re-run read to refresh.]" },
+      { type: "text", text: "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]" },
     ]);
     expect(staleApplied[0].content[0].text.toLowerCase()).toContain("stale");
     expect(staleApplied[0].content[0].text.toLowerCase()).not.toContain("retired");

--- a/tests/context-hygiene-context-handler.test.ts
+++ b/tests/context-hygiene-context-handler.test.ts
@@ -75,7 +75,7 @@ describe("context hygiene provider context handler", () => {
     const result = handlers.context({ type: "context", messages: providerContextCopy }, {});
 
     expect(result.messages[0].content).toEqual([
-      { type: "text", text: "[Stale read context: file content changed after this result. Re-run read to refresh.]" },
+      { type: "text", text: "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]" },
     ]);
     expect(result.messages[0].details).toMatchObject({
       ptcValue: { tool: "read" },

--- a/tests/context-hygiene-stale-placeholders.test.ts
+++ b/tests/context-hygiene-stale-placeholders.test.ts
@@ -30,9 +30,9 @@ describe("context hygiene stale placeholders", () => {
     const secondRender = records.map(renderStaleContextPlaceholder);
 
     expect(firstRender).toEqual([
-      "[Stale read context: file content changed after this result. Re-run read to refresh.]",
-      "[Stale grep context: matched file content changed after this result. Re-run grep to refresh.]",
-      "[Stale ast_search context: matched file content changed after this result. Re-run ast_search to refresh.]",
+      "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]",
+      "[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Run grep again for current matches.]",
+      "[Stale ast_search result — this earlier ast_search was superseded by a later file change; nothing is wrong with ast_search. Run ast_search again for current matches.]",
     ]);
     expect(secondRender).toEqual(firstRender);
 

--- a/tests/edit-prompt-coverage.test.ts
+++ b/tests/edit-prompt-coverage.test.ts
@@ -16,6 +16,9 @@ describe("prompts/edit.md coverage", () => {
     expect(content.toLowerCase()).toContain("escape hatch");
     expect(content).toContain("exact-only");
     expect(content).toContain("fuzzy: true");
+    expect(content).toContain("to delete the anchored line");
+    expect(content).toContain("not approximate or Levenshtein");
+    expect(content).toContain("Wrap old_text/new_text in {replace: ...}");
     expect(content).toContain("read");
     expect(content).toContain("grep");
     expect(content).toContain("ast_search");

--- a/tests/package-version.test.ts
+++ b/tests/package-version.test.ts
@@ -5,9 +5,9 @@ const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
 const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
 
 describe("package version", () => {
-  it("is bumped for the WASM tree-sitter migration release", () => {
-    expect(packageJson.version).toBe("0.8.14");
-    expect(packageLock.version).toBe("0.8.14");
-    expect(packageLock.packages[""].version).toBe("0.8.14");
+  it("is bumped for the issue #199 edit/read UX hardening release", () => {
+    expect(packageJson.version).toBe("0.8.15");
+    expect(packageLock.version).toBe("0.8.15");
+    expect(packageLock.packages[""].version).toBe("0.8.15");
   });
 });

--- a/tests/readme-content.test.ts
+++ b/tests/readme-content.test.ts
@@ -60,4 +60,10 @@ describe("README.md content (AC-1, AC-2)", () => {
     expect(readme).toContain("Defaults to `collapsed`");
     expect(readme).toMatch(/case-insensitive/i);
   });
+
+  it("documents edit new_text safety, deletion, and fuzzy semantics", () => {
+    expect(readme).toContain("never include `LINE:HASH|`");
+    expect(readme).toContain('Set `new_text` to `""` to delete');
+    expect(readme).toContain("not approximate or semantic matching");
+  });
 });

--- a/tests/repro-144-stale-read-edit-guard.test.ts
+++ b/tests/repro-144-stale-read-edit-guard.test.ts
@@ -85,7 +85,7 @@ describe("issue 144 — stale-masked read must not satisfy edit's must-read guar
       ],
     }, {});
     expect(ctxResult.messages[0].content[0].text)
-      .toContain("[Stale read context: file content changed after this result. Re-run read to refresh.]");
+      .toContain("[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]");
 
     // 4. Edit with a structurally-valid LINE:HASH whose hash matches a *different*
     //    line — adaptive relocation would silently land it. The fix must intercept

--- a/tests/repro-177-core-edit-input-correctness-edge-cases.test.ts
+++ b/tests/repro-177-core-edit-input-correctness-edge-cases.test.ts
@@ -80,6 +80,11 @@ describe("repro 177 — core edit input correctness edge cases", () => {
     await writeTool.execute("write", { path: filePath, content: "const a = 1;\n" }, new AbortController().signal, () => {}, { cwd: process.cwd() });
 
     expect(Value.Check(editTool.parameters, commonMistake)).toBe(true);
+    // #199: the bare member stays valid (so the guard runs) but is now annotated to reduce exposure.
+    const bareMember = (editTool.parameters as any).properties?.edits?.items?.anyOf?.find(
+      (m: any) => m.properties?.old_text && m.properties?.new_text && !m.properties?.replace,
+    );
+    expect(bareMember?.description).toContain("Wrap as { replace");
     const result = await editTool.execute("edit", commonMistake, new AbortController().signal, () => {}, { cwd: process.cwd() });
     expect(result.isError).toBe(true);
     expect(textOf(result)).toContain("edits[0] has top-level 'old_text'/'new_text'");

--- a/tests/repro-199-hash-mismatch-rejection.test.ts
+++ b/tests/repro-199-hash-mismatch-rejection.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { ensureHashInit, applyHashlineEdits, computeLineHash, HashlineMismatchError } from "../src/hashline.js";
+
+describe("repro 199 — hash-mismatch message leads with explicit rejection", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("states the edit was rejected and nothing written, before the churn detail", () => {
+    const orig = ["const a = 1;", "const b = 22;", "const c = 3;"].join("\n");
+    const staleAnchor = `2:${computeLineHash(2, "const b = 2;")}`;
+    let caught: unknown;
+    try {
+      applyHashlineEdits(
+        orig,
+        [{ set_line: { anchor: staleAnchor, new_text: "const b = 222;" } }],
+        new AbortController().signal,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(HashlineMismatchError);
+    const message = (caught as HashlineMismatchError).message;
+    expect(message.startsWith("Edit rejected")).toBe(true);
+    expect(message).toContain("nothing was written");
+    expect(message).toContain("anchor hash did not match");
+    // Backward-compatible: existing churn phrasing and >>> markers remain.
+    expect(message).toContain("changed since last read");
+    expect(message).toContain(">>>");
+  });
+});

--- a/tests/repro-199-hash-only-prefix-strip.test.ts
+++ b/tests/repro-199-hash-only-prefix-strip.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { ensureHashInit, applyHashlineEdits, computeLineHash } from "../src/hashline.js";
+
+describe("repro 199 — hash-only prefixes are stripped from new_text", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("strips dominant hash-only prefixes (033|, d05|) in set_line new_text", () => {
+    const orig = ["alpha", "beta", "gamma"].join("\n");
+    const anchor = `2:${computeLineHash(2, "beta")}`;
+    const res = applyHashlineEdits(
+      orig,
+      [{ set_line: { anchor, new_text: "033|beta-modified\nd05|extra-line" } }],
+      new AbortController().signal,
+    );
+    expect(res.content.split("\n")).toEqual(["alpha", "beta-modified", "extra-line", "gamma"]);
+  });
+
+  it("strips dominant hash-only prefixes in replace_lines new_text", () => {
+    const orig = ["alpha", "beta", "gamma"].join("\n");
+    const start = `1:${computeLineHash(1, "alpha")}`;
+    const end = `2:${computeLineHash(2, "beta")}`;
+    const res = applyHashlineEdits(
+      orig,
+      [{ replace_lines: { start_anchor: start, end_anchor: end, new_text: "abc|one\ndef|two" } }],
+      new AbortController().signal,
+    );
+    expect(res.content.split("\n")).toEqual(["one", "two", "gamma"]);
+  });
+
+  it("preserves a single legitimate pipe-prefixed line (no false-positive strip)", () => {
+    const orig = ["alpha", "beta", "gamma"].join("\n");
+    const anchor = `2:${computeLineHash(2, "beta")}`;
+    const res = applyHashlineEdits(
+      orig,
+      [{ set_line: { anchor, new_text: "abc|payload" } }],
+      new AbortController().signal,
+    );
+    expect(res.content.split("\n")).toEqual(["alpha", "abc|payload", "gamma"]);
+  });
+});


### PR DESCRIPTION
Closes #126.

## Problem

Six edit/read UX defects disproportionately confuse weaker LLMs. Only one (#6) is a functional defect that writes wrong bytes to disk; the rest are correct-behavior/confusing-presentation issues rooted in fixed string literals and schema/doc shape.

1. **#6 (functional):** Hash-only prefixes (`033|`, `d05|`) pasted into anchored `new_text` were written verbatim — `stripNewLinePrefixes` only matched the full `LINE:HASH|` prefix, not the bare `HASH|` (3 hex + `|`) column shown in mismatch output.
2. **#1:** Hash-mismatch errors led with a neutral churn sentence ("N lines changed since last read…"), never stating the edit was rejected — weaker models read it as a passive warning.
3. **#2:** The published schema advertised the bare `{old_text, new_text}` trap shape with no annotation.
4. **#3:** `new_text: ""` deletes the anchored line(s) (intended) but was undocumented.
5. **#4:** `replace.fuzzy` reads like approximate/Levenshtein matching; it is actually a narrow whitespace/confusable-Unicode normalize-only fallback.
6. **#5:** Stale `read`/`grep`/`ast_search` placeholders read like a freshly failed call rather than a retired prior result.

## What changed

- Add `HASH_ONLY_PREFIX_RE = /^[0-9a-f]{3}\|/` and a `stripHashOnly` branch to `stripNewLinePrefixes`, reusing the existing ≥50% dominance gate plus a `nonEmpty >= 2` guard so a single legitimate `abc|payload` line is never stripped. Covers all three anchored variants (`set_line`/`replace_lines`/`insert_after`); the `replace` escape hatch intentionally stays verbatim.
- Prepend an explicit `Edit rejected — nothing was written. The anchor hash did not match the current file content.` line to `formatMismatchError`, preserving the existing `changed since last read` phrasing and `>>>` anchor markers.
- Annotate the bare `{old_text, new_text}` edit-item schema member with a do-not-use `description` without changing validation, so the friendly runtime guard still fires for the bare shape (kept ≤58 chars to satisfy the existing param-description cap).
- Document `new_text: ""` line-deletion semantics in `prompts/edit.md`.
- Clarify in `prompts/edit.md` that `fuzzy` is a whitespace/confusable-Unicode normalize-only fallback, **not** approximate/Levenshtein/semantic matching.
- Reword the three stale `read`/`grep`/`ast_search` placeholders as superseded prior results (retains the codebase-required "stale" vocabulary), updating the doc and four pinning test files.
- Add a README "Editing notes" subsection and bump the version `0.8.14 → 0.8.15`.

## Acceptance criteria

- [x] AC1 (#6): Dominant hash-only-prefixed `new_text` (`033|…`, `d05|…`) is stripped before write for all anchored variants; regression test asserts no `HASH|` lands in the file; `replace` policy (verbatim) decided and documented.
- [x] AC2 (#6 false-positive guard): Legitimate single-line `abc|payload` is preserved.
- [x] AC3 (#1): Hash-mismatch message leads with explicit rejection; `updatedAnchors` and `>>>`-marked lines remain; existing substring tests pass.
- [x] AC4 (#2): Bare `{old_text, new_text}` is annotated as invalid in the schema while the friendly guard still fires; existing invalid-variant tests pass.
- [x] AC5 (#3): `prompts/edit.md` states `new_text: ""` deletes the line; behavior pinned by test.
- [x] AC6 (#4): `prompts/edit.md` states `fuzzy` is a normalize-only fallback, not approximate/Levenshtein/semantic.
- [x] AC7 (#5): Stale read/grep/ast_search placeholders reworded as superseded prior results; pinning tests updated.
- [x] AC8 (Release): `package.json` + `package-lock.json` bumped, `tests/package-version.test.ts` updated, README refreshed; `npm test` and `npm run typecheck` green.

## Verification

- `npm run typecheck` → exit 0.
- `npm test` → 1591 passed; the only 2 failures (`edit-render-tui.test.ts`, `edit-pending-diff-render-success.test.ts`) are pre-existing #198 TUI render failures, confirmed unrelated by stashing this branch's changes and reproducing identical failures on baseline.
- Targeted regression set (repro-199 hash-only-strip / mismatch-rejection, context-hygiene placeholders, edit-prompt-coverage, repro-177 edge-cases, readme-content, package-version, tool-prompt-metadata, repro-018 deletion) → 30 passed.
- Runtime repro at the real `applyHashlineEdits` entry: `new_text:"033|x\nd05|y"` now yields `x`/`y` (no `HASH|` leak); `abc|payload` preserved; mismatch message starts with "Edit rejected".
