### PR TITLE
chore: hygiene sweep — dead code removal + test isolation (#200)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,6 @@ import { filterBashOutput } from "./src/rtk/bash-filter.js";
 import { buildRtkCompaction } from "./src/rtk/rtk-compaction.js";
 import { ensureBashOriginalOutputSnapshot, selectBashOriginalOutput } from "./src/rtk/bash-original-output.js";
 import { applyBashContextGuard, resolveBashContextGuardConfig, type BashContextGuardConfig } from "./src/rtk/bash-context-guard.js";
-import { stripAnsi } from "./src/rtk/ansi.js";
 import { applyContextHygieneStaleContext } from "./src/context-application.js";
 import { buildBashCommandState } from "./src/bash-command-state.js";
 import {
@@ -139,9 +138,6 @@ export type {
   HashlineToolPtcPolicy,
   HashlineToolPtcPolicyEntry,
 } from "./src/ptc-tool-policy.js";
-
-const BASH_FILTER_ENABLED = true;
-
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   return `${(bytes / 1024).toFixed(1)} KB`;
@@ -353,34 +349,6 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
       const prefix = `${formatDoomLoopMessage(doomLoop)}\n\n---\n`;
       return `${prefix}${body}`;
     };
-    if (!BASH_FILTER_ENABLED) {
-      const stripped = stripAnsi(originalText);
-      const finalText = applyWarning(stripped);
-      const originalMetadataForGuard = willBashContextGuardTrim(finalText, bashContextGuardConfig)
-        ? ensureBashOriginalOutputSnapshot({
-            visibleText: originalText,
-            metadata: originalSelection.metadata,
-            enabled: bashContextGuardConfig.enabled,
-          })
-        : originalSelection.metadata;
-      const guarded = applyBashContextGuard({
-        text: finalText,
-        command,
-        originalMetadata: originalMetadataForGuard,
-        config: bashContextGuardConfig,
-      });
-      const bashOriginalOutput = guarded.metadata.trimmed ? originalMetadataForGuard : originalSelection.metadata;
-      if (guarded.text === originalText && !bashOriginalOutput) return undefined;
-      return {
-        content: [{ type: "text" as const, text: guarded.text }, ...nonTextContent],
-        details: {
-          ...existingDetails,
-          contextHygiene: contextHygieneForDetails,
-          bashContextGuard: guarded.metadata,
-          ...(bashOriginalOutput ? { bashOriginalOutput } : {}),
-        },
-      };
-    }
     const { output, savedChars, info } = filterBashOutput(command, originalSelection.inputForRtk);
     if (process.env.PI_RTK_SAVINGS === "1") {
       process.stderr.write(`[RTK] Saved ${savedChars} chars (${command})\n`);

--- a/tests/edit-pending-diff-render-success.test.ts
+++ b/tests/edit-pending-diff-render-success.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { registerEditTool } from "../src/edit.js";
+import { __resetHashlineSettingsPathsForTest, __setHashlineSettingsPathsForTest } from "../src/hashline-settings.js";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
 
 function getEditTool(): any {
 	let tool: any;
@@ -21,6 +24,20 @@ const theme = {
 };
 
 describe("edit renderCall pending diff preview", () => {
+	const originalEnv = process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+	beforeEach(() => {
+		delete process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+		const root = join(tmpdir(), `edit-pending-render-${randomBytes(6).toString("hex")}`);
+		__setHashlineSettingsPathsForTest({
+			globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+			projectSettingsPath: join(root, "repo/.pi/hashline-readmap/settings.json"),
+		});
+	});
+	afterEach(() => {
+		if (originalEnv === undefined) delete process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+		else process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY = originalEnv;
+		__resetHashlineSettingsPathsForTest();
+	});
 	it("renders a collapsed pending edit preview by default", async () => {
 		const cwd = mkdtempSync(resolve(tmpdir(), "pi-edit-pending-success-"));
 		const filePath = resolve(cwd, "sample.ts");

--- a/tests/edit-render-tui.test.ts
+++ b/tests/edit-render-tui.test.ts
@@ -1,14 +1,31 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { registerEditTool } from "../src/edit.js";
+import { __resetHashlineSettingsPathsForTest, __setHashlineSettingsPathsForTest } from "../src/hashline-settings.js";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
 
 const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
 function textOf(component: any, width = 120): string { return component?.text ?? component?.render?.(width)?.join("\n") ?? ""; }
 function tool(): any { let registered: any; registerEditTool({ registerTool(def: any) { registered = def; } } as any, { wasReadInSession: () => true } as any); return registered; }
 
 describe("edit TUI renderer", () => {
+  const originalEnv = process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+  beforeEach(() => {
+    delete process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+    const root = join(tmpdir(), `edit-render-tui-${randomBytes(6).toString("hex")}`);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath: join(root, "repo/.pi/hashline-readmap/settings.json"),
+    });
+  });
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY;
+    else process.env.PI_HASHLINE_EDIT_DIFF_DISPLAY = originalEnv;
+    __resetHashlineSettingsPathsForTest();
+  });
   it("shows edit summary before final diff and preserves model-facing data", () => {
     const result: any = { content: [{ type: "text", text: "1:abc|one\n2:def|TWO" }], details: { diff: "-2 two\n+2 TWO", diffData: { version: 1, stats: { added: 1, removed: 1, context: 0 }, entries: [{ kind: "remove", oldLine: 2, text: "two" }, { kind: "add", newLine: 2, text: "TWO" }] }, ptcValue: { warnings: [], noopEdits: [], semanticSummary: { classification: "semantic" }, diffData: { sentinel: true } } } };
     const before = JSON.stringify(result.details);


### PR DESCRIPTION
## Summary
Wave 1 hygiene sweep (issue #200). Two of the three originally-scoped items ship; the third was found to be a non-bug and withdrawn.

### Shipped
- **Dead code removal (`index.ts`):** delete the `BASH_FILTER_ENABLED = true` constant, its unreachable `if (!BASH_FILTER_ENABLED)` branch (~28 lines), and the now-orphaned `stripAnsi` import. The live `filterBashOutput` path is unchanged; all helpers used by the dead branch remain used by the live path.
- **Test isolation (2 renderer tests):** `tests/edit-render-tui.test.ts` and `tests/edit-pending-diff-render-success.test.ts` asserted the collapsed diff default but read the real machine settings file, so a developer whose `~/.pi/agent/hashline-readmap/settings.json` sets `edit.diffDisplay: "expanded"` saw false failures. Now isolated via `__setHashlineSettingsPathsForTest` + env delete + `afterEach` reset (the canonical pattern already used by `edit-diff-display-renderer.test.ts`). **Assertions unchanged.**

### Withdrawn (not a bug)
- The `.ts` relative import specifiers in `src/rtk/` are **intentional** — required for `node --experimental-strip-types`, which strips types but does not rewrite specifiers (issue #048, locked by `tests/repro-050-bugs.test.ts`). The original review mislabeled them as inconsistent; converting to `.js` broke #048's tests, so this item was reverted.

## Verification
- `npm run typecheck` — clean
- `npm test` — **1593/1593 pass** (was 2 failing on a machine with `diffDisplay: expanded`)
- Repro condition resolved: with env unset and machine config still `expanded`, the two renderer tests now pass
- #048 regression intact (`repro-050-bugs.test.ts` 11/11)

## Behavior change
None. Task 1's branch never executed; Task 3 is test-only.

Closes #200
