### PR TITLE
fix: consolidate PTC tool policy to a single guarded source (#201)

### DIFF
--- a/docs/structured-output.md
+++ b/docs/structured-output.md
@@ -77,6 +77,7 @@ Current policy summary:
 | `grep` | `grep` | Yes | `read-only` | `safe-by-default` |
 | `ast_search` | `ast_search` | No | `read-only` | `opt-in` |
 | `edit` | `edit` | Yes | `mutating` | `not-safe-by-default` |
+| `write` | `write` | Yes | `mutating` | `not-safe-by-default` |
 | `ls` | `ls` | Yes | `read-only` | `safe-by-default` |
 | `find` | `find` | Yes | `read-only` | `safe-by-default` |
 | `nu` | `nu` | No | `read-only` | `opt-in` |
@@ -86,4 +87,4 @@ Current policy summary:
 - Treat `ptcValue` as additive metadata, not a replacement for rendered text.
 - Use stable fields such as `tool`, `path`, `lines`, `anchor`, `warnings`, and `error.code` when available.
 - Avoid parsing rendered text when the same data exists in `ptcValue`.
-- Mutating consumers should honor the exported policy: `edit` is not safe-by-default, while `read`, `grep`, `ls`, and `find` are read-only.
+- Mutating consumers should honor the exported policy: `edit` and `write` are mutating and not safe-by-default, while `read`, `grep`, `ls`, and `find` are read-only.

--- a/src/ptc-tool-policy.ts
+++ b/src/ptc-tool-policy.ts
@@ -3,6 +3,7 @@ export type HashlineToolName =
   | "grep"
   | "ast_search"
   | "edit"
+  | "write"
   | "ls"
   | "find"
   | "nu";
@@ -54,6 +55,13 @@ export const HASHLINE_TOOL_PTC_POLICY: HashlineToolPtcPolicy = {
     edit: {
       toolName: "edit",
       helperName: "edit",
+      overridesBuiltin: true,
+      mutability: "mutating",
+      defaultExposure: "not-safe-by-default",
+    },
+    write: {
+      toolName: "write",
+      helperName: "write",
       overridesBuiltin: true,
       mutability: "mutating",
       defaultExposure: "not-safe-by-default",

--- a/src/write.ts
+++ b/src/write.ts
@@ -314,12 +314,21 @@ export async function executeWrite(opts: {
 }
 
 export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = {}) {
+  const ptc = {
+    callable: true,
+    enabled: true,
+    policy: "mutating" as const,
+    readOnly: false,
+    pythonName: "write",
+    defaultExposure: "not-safe-by-default" as const,
+  };
   const tool = {
     name: "write",
     label: "write",
     description: WRITE_PROMPT_METADATA.description,
     promptSnippet: WRITE_PROMPT_METADATA.promptSnippet,
     promptGuidelines: WRITE_PROMPT_METADATA.promptGuidelines,
+    ptc,
     parameters: Type.Object({
       path: Type.String({ description: "File path" }),
       content: Type.String({ description: "File content" }),
@@ -489,7 +498,7 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
       }
       return new Text(clampLinesToWidth(text.split("\n"), width).join("\n"), 0, 0);
     },
-  };
+  } satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
   pi.registerTool(tool);
   return tool;
 }

--- a/tests/ptc-tool-policy-write-entry.test.ts
+++ b/tests/ptc-tool-policy-write-entry.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { HASHLINE_TOOL_PTC_POLICY } from "../src/ptc-tool-policy.js";
+
+describe("HASHLINE_TOOL_PTC_POLICY write entry", () => {
+  it("includes a write entry classified as mutating / not-safe-by-default", () => {
+    expect(Object.keys(HASHLINE_TOOL_PTC_POLICY.tools)).toContain("write");
+    expect(HASHLINE_TOOL_PTC_POLICY.tools.write).toEqual({
+      toolName: "write",
+      helperName: "write",
+      overridesBuiltin: true,
+      mutability: "mutating",
+      defaultExposure: "not-safe-by-default",
+    });
+  });
+});

--- a/tests/ptc-tool-policy.test.ts
+++ b/tests/ptc-tool-policy.test.ts
@@ -3,103 +3,56 @@ import { registerReadTool } from "../src/read.js";
 import { registerGrepTool } from "../src/grep.js";
 import { registerSgTool } from "../src/sg.js";
 import { registerEditTool } from "../src/edit.js";
+import { registerWriteTool } from "../src/write.js";
 import { registerLsTool } from "../src/ls.js";
 import { registerFindTool } from "../src/find.js";
 import { NU_PTC } from "../src/nu.js";
 import { HASHLINE_TOOL_PTC_POLICY, getHashlineToolPtcPolicy } from "../src/ptc-tool-policy.js";
-function captureTools() {
+
+// Every tool that ends up in the emitted executor map (index.ts toolExecutors),
+// mapped to its live inline ptc. ast_search registers under the "ast_search"
+// tool name via registerSgTool. nu registers conditionally, so its inline ptc
+// (NU_PTC) is supplied directly rather than via registration.
+function captureInlinePtc(): Record<string, any> {
   const tools: Record<string, any> = {};
-  const pi = {
-    registerTool(def: any) {
-      tools[def.name] = def;
-    },
-  };
+  const pi = { registerTool(def: any) { tools[def.name] = def; } };
   registerReadTool(pi as any);
   registerGrepTool(pi as any);
   registerSgTool(pi as any);
   registerEditTool(pi as any);
+  registerWriteTool(pi as any);
   registerLsTool(pi as any);
   registerFindTool(pi as any);
-  return tools;
+  const inline: Record<string, any> = {};
+  for (const [name, def] of Object.entries(tools)) {
+    expect(def.ptc, `tool "${name}" is missing an inline ptc block`).toBeDefined();
+    inline[name] = def.ptc;
+  }
+  inline["nu"] = NU_PTC;
+  return inline;
 }
-describe("hashline tool ptc policy contract", () => {
-  it("mirrors the inline runtime ptc metadata for all exported hashline tools", () => {
-    const tools = captureTools();
+
+describe("hashline tool ptc policy drift guard", () => {
+  it("getHashlineToolPtcPolicy returns the exported singleton", () => {
     expect(getHashlineToolPtcPolicy()).toBe(HASHLINE_TOOL_PTC_POLICY);
-    expect(HASHLINE_TOOL_PTC_POLICY).toEqual({
-      version: 1,
-      tools: {
-        read: {
-          toolName: "read",
-          helperName: "read",
-          overridesBuiltin: true,
-          mutability: "read-only",
-          defaultExposure: "safe-by-default",
-        },
-        grep: {
-          toolName: "grep",
-          helperName: "grep",
-          overridesBuiltin: true,
-          mutability: "read-only",
-          defaultExposure: "safe-by-default",
-        },
-        ast_search: {
-          toolName: "ast_search",
-          helperName: "ast_search",
-          overridesBuiltin: false,
-          mutability: "read-only",
-          defaultExposure: "opt-in",
-        },
-        edit: {
-          toolName: "edit",
-          helperName: "edit",
-          overridesBuiltin: true,
-          mutability: "mutating",
-          defaultExposure: "not-safe-by-default",
-        },
-        ls: {
-          toolName: "ls",
-          helperName: "ls",
-          overridesBuiltin: true,
-          mutability: "read-only",
-          defaultExposure: "safe-by-default",
-        },
-        find: {
-          toolName: "find",
-          helperName: "find",
-          overridesBuiltin: true,
-          mutability: "read-only",
-          defaultExposure: "safe-by-default",
-        },
-        nu: {
-          toolName: "nu",
-          helperName: "nu",
-          overridesBuiltin: false,
-          mutability: "read-only",
-          defaultExposure: "opt-in",
-        },
-      },
-    });
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.read.helperName).toBe(tools.read.ptc.pythonName);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.grep.helperName).toBe(tools.grep.ptc.pythonName);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.ast_search.helperName).toBe(tools.ast_search.ptc.pythonName);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.edit.helperName).toBe(tools.edit.ptc.pythonName);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.ls.helperName).toBe(tools.ls.ptc.pythonName);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.find.helperName).toBe(tools.find.ptc.pythonName);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.nu.helperName).toBe(NU_PTC.pythonName);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.read.mutability).toBe(tools.read.ptc.policy);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.grep.mutability).toBe(tools.grep.ptc.policy);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.ast_search.mutability).toBe(tools.ast_search.ptc.policy);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.edit.mutability).toBe(tools.edit.ptc.policy);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.ls.mutability).toBe(tools.ls.ptc.policy);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.find.mutability).toBe(tools.find.ptc.policy);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.nu.mutability).toBe(NU_PTC.policy);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.read.defaultExposure).toBe(tools.read.ptc.defaultExposure);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.grep.defaultExposure).toBe(tools.grep.ptc.defaultExposure);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.ast_search.defaultExposure).toBe(tools.ast_search.ptc.defaultExposure);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.edit.defaultExposure).toBe(tools.edit.ptc.defaultExposure);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.ls.defaultExposure).toBe(tools.ls.ptc.defaultExposure);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.find.defaultExposure).toBe(tools.find.ptc.defaultExposure);
-    expect(HASHLINE_TOOL_PTC_POLICY.tools.nu.defaultExposure).toBe(NU_PTC.defaultExposure);
+  });
+
+  it("policy key set equals the live runtime tool set (incl. write and nu)", () => {
+    const inline = captureInlinePtc();
+    expect(Object.keys(HASHLINE_TOOL_PTC_POLICY.tools).sort()).toEqual(
+      Object.keys(inline).sort(),
+    );
+  });
+
+  it("each policy entry matches the live tool's inline ptc", () => {
+    const inline = captureInlinePtc();
+    for (const [name, entry] of Object.entries(HASHLINE_TOOL_PTC_POLICY.tools)) {
+      const ptc = inline[name];
+      expect(ptc, `no inline ptc for policy tool "${name}"`).toBeDefined();
+      expect(entry.toolName, `toolName for "${name}"`).toBe(name);
+      expect(entry.helperName, `helperName for "${name}"`).toBe(ptc.pythonName);
+      expect(entry.mutability, `mutability for "${name}"`).toBe(ptc.policy);
+      expect(entry.defaultExposure, `defaultExposure for "${name}"`).toBe(ptc.defaultExposure);
+    }
   });
 });

--- a/tests/public-api-ptc-policy.test.ts
+++ b/tests/public-api-ptc-policy.test.ts
@@ -21,3 +21,32 @@ describe("public API ptc policy export", () => {
     expect(mod.HASHLINE_TOOL_PTC_POLICY.tools.edit.defaultExposure).toBe("not-safe-by-default");
   });
 });
+
+describe("executor map is covered by the exported policy", () => {
+  it("every emitted executor tool (except debug-only) has a policy entry", async () => {
+    const { default: init } = await import("../index.ts");
+    const { HASHLINE_TOOL_PTC_POLICY } = await import("../src/ptc-tool-policy.ts");
+    const emitted: Record<string, any>[] = [];
+    const pi: any = {
+      registeredTools: {} as Record<string, any>,
+      registerTool(def: any) { this.registeredTools[def.name] = def; },
+      on() {},
+      events: { emit(_channel: string, payload: any) { emitted.push(payload); } },
+    };
+    init(pi);
+    const map =
+      (globalThis as any).__hashlineToolExecutors ??
+      emitted[emitted.length - 1] ??
+      {};
+    // context_hygiene_report is a debug-only tool intentionally excluded from
+    // the cross-extension ptc policy contract.
+    const DEBUG_ONLY = new Set(["context_hygiene_report"]);
+    const policyKeys = new Set(Object.keys(HASHLINE_TOOL_PTC_POLICY.tools));
+    const uncovered = Object.keys(map).filter(
+      (name) => !DEBUG_ONLY.has(name) && !policyKeys.has(name),
+    );
+    expect(uncovered).toEqual([]);
+    // write specifically must be covered (the original drift).
+    expect(policyKeys.has("write")).toBe(true);
+  });
+});

--- a/tests/write-ptc-inline.test.ts
+++ b/tests/write-ptc-inline.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { registerWriteTool } from "../src/write.js";
+
+function captureWrite() {
+  const tools: Record<string, any> = {};
+  const pi = { registerTool(def: any) { tools[def.name] = def; } };
+  registerWriteTool(pi as any);
+  return tools.write;
+}
+
+describe("write tool inline ptc", () => {
+  it("exposes an inline ptc block matching pi-ptc-next's mutating fallback", () => {
+    const write = captureWrite();
+    expect(write.ptc).toBeDefined();
+    expect(write.ptc.pythonName).toBe("write");
+    expect(write.ptc.policy).toBe("mutating");
+    expect(write.ptc.readOnly).toBe(false);
+    expect(write.ptc.callable).toBe(true);
+    expect(write.ptc.enabled).toBe(true);
+    expect(write.ptc.defaultExposure).toBe("not-safe-by-default");
+  });
+});


### PR DESCRIPTION
## Summary

The `write` tool was registered and executor-mapped (`index.ts:213`, emitted on `hashline:tool-executors`) but silently absent from the PTC contract — no inline `ptc`, not in `HashlineToolName`, not in `HASHLINE_TOOL_PTC_POLICY`, not in docs. The guard test passed anyway because it restated the same hand-written literal it was meant to protect.

## Root cause

Two independent, hand-maintained sources of truth (inline `ptc` blocks vs. the exported policy literal) with no mechanical link, and a guard test that mirrored the blind spot.

## Fix

- **`src/write.ts`** — add inline `ptc` (mutating / not-safe-by-default, matching pi-ptc-next's builtin fallback) + `satisfies ... & { ptc: typeof ptc }` type pin so the compiler enforces presence.
- **`src/ptc-tool-policy.ts`** — add `"write"` to `HashlineToolName` and a `write` entry to the policy table.
- **`tests/ptc-tool-policy.test.ts`** — replace the literal snapshot with a mechanical drift guard: registers every live tool, asserts the policy key set equals the runtime tool set, and cross-checks each entry against the live inline `ptc`.
- **`tests/public-api-ptc-policy.test.ts`** — regression test asserting every non-debug emitted executor tool has a policy entry.
- **`docs/structured-output.md`** — add the `write` row + consistent prose.

## Verification

- `npm test` → 375 files / 1598 tests pass
- `npm run typecheck` → exit 0
- Red→green confirmed: reverting the inline `ptc` / policy entry makes the guards fail with `tool "write" is missing an inline ptc block` and uncovered `[ "write" ]`; restoring passes.
- Emitted executor-map shape (keys + channel) unchanged → no runtime behavior change for pi-ptc-next.

Closes #201