### PR TITLE
refactor: extract shared tree-sitter mapper helpers (#202)

### DIFF
--- a/src/readmap/mappers/cpp.ts
+++ b/src/readmap/mappers/cpp.ts
@@ -11,7 +11,13 @@ import type { FileMap, FileSymbol } from "../types.js";
 import { DetailLevel, SymbolKind } from "../enums.js";
 import { getWasmParser } from "../parser-loader.js";
 import { reportParserError } from "../parser-errors.js";
-export const MAPPER_VERSION = 2;
+import {
+  normalizeWhitespace,
+  getNodeText,
+  getLineRange,
+  finalizeSignature,
+} from "./tree-sitter-helpers.js";
+export const MAPPER_VERSION = 3;
 
 type ScopeKind = "namespace" | "class" | "struct" | "enum";
 type AccessLevel = "public" | "protected" | "private";
@@ -34,14 +40,6 @@ interface InternalSymbol {
   docstring?: string;
 }
 
-function normalizeWhitespace(value: string): string {
-  return value.replaceAll(/\s+/g, " ").trim();
-}
-
-function getNodeText(node: SyntaxNode, source: string): string {
-  return source.slice(node.startIndex, node.endIndex);
-}
-
 function formatSignature(
   node: SyntaxNode,
   source: string,
@@ -52,8 +50,7 @@ function formatSignature(
   if (bodyIndex !== -1) {
     text = text.slice(0, bodyIndex);
   }
-  text = text.replace(/;\s*$/, "");
-  text = normalizeWhitespace(text);
+  text = finalizeSignature(text);
   if (templatePrefix) {
     text = normalizeWhitespace(`${templatePrefix} ${text}`);
   }
@@ -144,16 +141,6 @@ function buildScopeKey(parent: string | null, name: string): string {
 
 function makeAnonymousName(kind: string, line: number): string {
   return `<anonymous@${kind}:${line}>`;
-}
-
-function getLineRange(node: SyntaxNode): {
-  startLine: number;
-  endLine: number;
-} {
-  return {
-    startLine: node.startPosition.row + 1,
-    endLine: node.endPosition.row + 1,
-  };
 }
 
 function isStaticSignature(signature: string): boolean {

--- a/src/readmap/mappers/java.ts
+++ b/src/readmap/mappers/java.ts
@@ -6,8 +6,13 @@ import type { FileMap, FileSymbol } from "../types.js";
 import { DetailLevel, SymbolKind } from "../enums.js";
 import { getWasmParser } from "../parser-loader.js";
 import { reportParserError } from "../parser-errors.js";
+import {
+  normalizeWhitespace,
+  getNodeText,
+  getLineRange,
+} from "./tree-sitter-helpers.js";
 
-export const MAPPER_VERSION = 3;
+export const MAPPER_VERSION = 4;
 
 const TYPE_KINDS: Record<string, SymbolKind> = {
   class_declaration: SymbolKind.Class,
@@ -33,18 +38,6 @@ const MEMBER_METHOD_TYPES = new Set([
   "compact_constructor_declaration",
   "annotation_type_element_declaration",
 ]);
-
-function normalizeWhitespace(value: string): string {
-  return value.replaceAll(/\s+/g, " ").trim();
-}
-
-function getNodeText(node: SyntaxNode, source: string): string {
-  return source.slice(node.startIndex, node.endIndex);
-}
-
-function getLineRange(node: SyntaxNode): { startLine: number; endLine: number } {
-  return { startLine: node.startPosition.row + 1, endLine: node.endPosition.row + 1 };
-}
 
 function extractName(node: SyntaxNode, source: string): string | null {
   const nameNode = node.childForFieldName("name");

--- a/src/readmap/mappers/rust.ts
+++ b/src/readmap/mappers/rust.ts
@@ -11,7 +11,14 @@ import type { FileMap, FileSymbol } from "../types.js";
 import { DetailLevel, SymbolKind } from "../enums.js";
 import { getWasmParser } from "../parser-loader.js";
 import { reportParserError } from "../parser-errors.js";
-export const MAPPER_VERSION = 2;
+import {
+  normalizeWhitespace,
+  getNodeText,
+  getLineRange,
+  findFirstDescendant,
+  finalizeSignature,
+} from "./tree-sitter-helpers.js";
+export const MAPPER_VERSION = 3;
 
 type ScopeKind = "mod" | "struct" | "enum" | "trait" | "impl";
 
@@ -35,14 +42,6 @@ interface InternalSymbol {
   docstring?: string;
 }
 
-function normalizeWhitespace(value: string): string {
-  return value.replaceAll(/\s+/g, " ").trim();
-}
-
-function getNodeText(node: SyntaxNode, source: string): string {
-  return source.slice(node.startIndex, node.endIndex);
-}
-
 function formatSignature(
   node: SyntaxNode,
   source: string,
@@ -58,38 +57,7 @@ function formatSignature(
       text = text.slice(0, parenIndex);
     }
   }
-  text = text.replace(/;\s*$/, "");
-  return normalizeWhitespace(text);
-}
-
-function getLineRange(node: SyntaxNode): {
-  startLine: number;
-  endLine: number;
-} {
-  return {
-    startLine: node.startPosition.row + 1,
-    endLine: node.endPosition.row + 1,
-  };
-}
-
-function findFirstDescendant(
-  node: SyntaxNode,
-  types: string[]
-): SyntaxNode | null {
-  const stack = [...node.namedChildren];
-  while (stack.length > 0) {
-    const current = stack.pop();
-    if (!current) {
-      continue;
-    }
-    if (types.includes(current.type)) {
-      return current;
-    }
-    for (const child of current.namedChildren) {
-      stack.push(child);
-    }
-  }
-  return null;
+  return finalizeSignature(text);
 }
 
 function hasVisibilityModifier(node: SyntaxNode): boolean {

--- a/src/readmap/mappers/tree-sitter-helpers.ts
+++ b/src/readmap/mappers/tree-sitter-helpers.ts
@@ -1,0 +1,53 @@
+import type { Node as SyntaxNode } from "web-tree-sitter";
+
+/**
+ * Shared low-level helpers for tree-sitter-based structural mappers
+ * (rust.ts, cpp.ts, java.ts, and future C/Swift mappers in #194).
+ */
+
+export function normalizeWhitespace(value: string): string {
+  return value.replaceAll(/\s+/g, " ").trim();
+}
+
+export function getNodeText(node: SyntaxNode, source: string): string {
+  return source.slice(node.startIndex, node.endIndex);
+}
+
+export function getLineRange(node: SyntaxNode): {
+  startLine: number;
+  endLine: number;
+} {
+  return {
+    startLine: node.startPosition.row + 1,
+    endLine: node.endPosition.row + 1,
+  };
+}
+
+export function findFirstDescendant(
+  node: SyntaxNode,
+  types: string[]
+): SyntaxNode | null {
+  const stack = [...node.namedChildren];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+    if (types.includes(current.type)) {
+      return current;
+    }
+    for (const child of current.namedChildren) {
+      stack.push(child);
+    }
+  }
+  return null;
+}
+
+/**
+ * Shared signature kernel: strip a single trailing semicolon (with trailing
+ * whitespace) then collapse/trim whitespace. Matches the tail of the current
+ * Rust and C++ formatSignature implementations exactly.
+ */
+export function finalizeSignature(text: string): string {
+  return normalizeWhitespace(text.replace(/;\s*$/, ""));
+}

--- a/tests/cpp-wasm-mapper-lifecycle.test.ts
+++ b/tests/cpp-wasm-mapper-lifecycle.test.ts
@@ -21,7 +21,7 @@ describe("C++ WASM mapper lifecycle", () => {
     vi.doMock("../src/readmap/parser-loader.js", () => ({ getWasmParser: vi.fn(async () => parser) }));
     const { cppMapper, MAPPER_VERSION } = await import("../src/readmap/mappers/cpp.js");
     const map = await cppMapper(file);
-    expect(MAPPER_VERSION).toBe(2);
+    expect(MAPPER_VERSION).toBe(3);
     expect(map).toBeNull();
     expect(parser.parse).toHaveBeenCalledTimes(1);
     expect(deleteTree).toHaveBeenCalledTimes(1);

--- a/tests/java-mapper-basic.test.ts
+++ b/tests/java-mapper-basic.test.ts
@@ -20,7 +20,7 @@ afterEach(async () => {
 });
 
 describe("javaMapper basic tree-sitter extraction", () => {
-  it("exports version 3 and maps a class with package/imports", async () => {
+  it("exports version 4 and maps a class with package/imports", async () => {
     const file = await writeJava("Example.java", [
       "package com.example.demo;",
       "",
@@ -34,7 +34,7 @@ describe("javaMapper basic tree-sitter extraction", () => {
 
     const map = await javaMapper(file);
 
-    expect(MAPPER_VERSION).toBe(3);
+    expect(MAPPER_VERSION).toBe(4);
     expect(map).not.toBeNull();
     expect(map!.language).toBe("Java");
     expect(map!.imports).toEqual([

--- a/tests/java-wasm-mapper-lifecycle.test.ts
+++ b/tests/java-wasm-mapper-lifecycle.test.ts
@@ -13,7 +13,7 @@ describe("Java WASM mapper lifecycle", () => {
     vi.doMock("../src/readmap/parser-loader.js", () => ({ getWasmParser: vi.fn(async () => parser) }));
     const { javaMapperFromContent, MAPPER_VERSION } = await import("../src/readmap/mappers/java.js");
     const map = await javaMapperFromContent("Empty.java", "// no symbols\n");
-    expect(MAPPER_VERSION).toBe(3);
+    expect(MAPPER_VERSION).toBe(4);
     expect(map).toBeNull();
     expect(parser.parse).toHaveBeenCalledTimes(1);
     expect(deleteTree).toHaveBeenCalledTimes(1);

--- a/tests/rust-wasm-mapper-lifecycle.test.ts
+++ b/tests/rust-wasm-mapper-lifecycle.test.ts
@@ -35,7 +35,7 @@ describe("Rust WASM mapper lifecycle", () => {
       "../src/readmap/mappers/rust.js"
     );
     const map = await rustMapperFromContent("virtual.rs", "// no symbols\n");
-    expect(MAPPER_VERSION).toBe(2);
+    expect(MAPPER_VERSION).toBe(3);
     expect(map).toBeNull();
     expect(parser.parse).toHaveBeenCalledTimes(1);
     expect(deleteTree).toHaveBeenCalledTimes(1);

--- a/tests/tree-sitter-helpers-dedup.test.ts
+++ b/tests/tree-sitter-helpers-dedup.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const mapperFiles = [
+  "src/readmap/mappers/rust.ts",
+  "src/readmap/mappers/cpp.ts",
+  "src/readmap/mappers/java.ts",
+] as const;
+
+describe("tree-sitter helper extraction (#202)", () => {
+  for (const rel of mapperFiles) {
+    it(`${rel} no longer defines normalizeWhitespace/getNodeText/getLineRange locally`, () => {
+      const src = readFileSync(resolve(rel), "utf8");
+      expect(src).not.toMatch(/function\s+normalizeWhitespace\s*\(/);
+      expect(src).not.toMatch(/function\s+getNodeText\s*\(/);
+      expect(src).not.toMatch(/function\s+getLineRange\s*\(/);
+    });
+
+    it(`${rel} imports from tree-sitter-helpers.js`, () => {
+      const src = readFileSync(resolve(rel), "utf8");
+      expect(src).toContain("./tree-sitter-helpers.js");
+    });
+  }
+
+  it("parser-loader.ts is unchanged by this refactor (no tree-sitter-helpers import)", () => {
+    const src = readFileSync(resolve("src/readmap/parser-loader.ts"), "utf8");
+    expect(src).not.toContain("tree-sitter-helpers");
+  });
+});

--- a/tests/tree-sitter-helpers.test.ts
+++ b/tests/tree-sitter-helpers.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeWhitespace,
+  getNodeText,
+  getLineRange,
+  findFirstDescendant,
+  finalizeSignature,
+} from "../src/readmap/mappers/tree-sitter-helpers.js";
+
+describe("tree-sitter-helpers core primitives", () => {
+  it("normalizeWhitespace collapses runs of whitespace and trims", () => {
+    expect(normalizeWhitespace("  a   b\t\nc  ")).toBe("a b c");
+    expect(normalizeWhitespace("nochange")).toBe("nochange");
+  });
+
+  it("getNodeText slices source by node byte offsets", () => {
+    const node = { startIndex: 2, endIndex: 5 } as unknown as Parameters<
+      typeof getNodeText
+    >[0];
+    expect(getNodeText(node, "abcdef")).toBe("cde");
+  });
+
+  it("getLineRange converts 0-based rows to 1-based lines", () => {
+    const node = {
+      startPosition: { row: 4 },
+      endPosition: { row: 9 },
+    } as unknown as Parameters<typeof getLineRange>[0];
+    expect(getLineRange(node)).toEqual({ startLine: 5, endLine: 10 });
+  });
+});
+
+type TestNode = { type: string; namedChildren: TestNode[] };
+function n(type: string, children: TestNode[] = []): TestNode {
+  return { type, namedChildren: children };
+}
+
+describe("tree-sitter-helpers findFirstDescendant", () => {
+  it("returns the first descendant matching any requested type", () => {
+    const tree = n("root", [n("a", [n("target", [])]), n("b", [])]);
+    const found = findFirstDescendant(
+      tree as unknown as Parameters<typeof findFirstDescendant>[0],
+      ["target"],
+    );
+    expect(found?.type).toBe("target");
+  });
+
+  it("returns null when no descendant matches", () => {
+    const tree = n("root", [n("a", []), n("b", [])]);
+    const found = findFirstDescendant(
+      tree as unknown as Parameters<typeof findFirstDescendant>[0],
+      ["missing"],
+    );
+    expect(found).toBeNull();
+  });
+});
+
+describe("tree-sitter-helpers finalizeSignature", () => {
+  it("strips a trailing semicolon and normalizes whitespace", () => {
+    expect(finalizeSignature("pub  fn   foo()  ;  ")).toBe("pub fn foo()");
+  });
+
+  it("normalizes whitespace when there is no trailing semicolon", () => {
+    expect(finalizeSignature("class   Foo")).toBe("class Foo");
+  });
+});


### PR DESCRIPTION
## Summary

Mechanical, behavior-preserving cleanup: the Rust, C++, and Java structural mappers each carried their own identical copies of `normalizeWhitespace`, `getNodeText`, and `getLineRange`, plus near-identical signature finalization. This extracts those primitives into a single shared module so the planned C/Swift web-tree-sitter migration (#194) can reuse them instead of copying them again.

Structural-map output (symbols, signatures, ranges, kinds, ordering) for all three languages is byte-for-byte unchanged.

## What changed

- **`src/readmap/mappers/tree-sitter-helpers.ts`** (new) — shared primitives:
  - `normalizeWhitespace(value)` — collapse whitespace runs to single spaces, then trim
  - `getNodeText(node, source)` — `source.slice(node.startIndex, node.endIndex)`
  - `getLineRange(node)` — `{ startLine: row+1, endLine: row+1 }`
  - `findFirstDescendant(node, types)` — stack-based named-child traversal (the Rust variant)
  - `finalizeSignature(text)` — strip a single trailing semicolon, then normalize
- **`src/readmap/mappers/rust.ts`** — imports all five helpers; removed local copies; `formatSignature` delegates its tail to `finalizeSignature`, keeping Rust's brace/`cutAtParen` end-detection. `MAPPER_VERSION` 2 → 3.
- **`src/readmap/mappers/cpp.ts`** — imports the four it needs; removed local copies; `formatSignature` uses `finalizeSignature` then re-normalizes with the template prefix. C++'s recursive type-ordered `findDescendantOfType`/`findFirstDescendant` left local (different semantics from the shared stack-based version). `MAPPER_VERSION` 2 → 3.
- **`src/readmap/mappers/java.ts`** — imports the three primitives; removed local copies. `formatSignature` stays local and unchanged (its semicolon strip must run before annotation stripping). `MAPPER_VERSION` 3 → 4.
- **Tests** — new `tests/tree-sitter-helpers.test.ts` (unit tests for all five primitives) and `tests/tree-sitter-helpers-dedup.test.ts` (structural guard: no mapper redefines the primitives, all import from the shared module, `parser-loader.ts` untouched). Version-literal assertions bumped in the three WASM lifecycle tests + `java-mapper-basic.test.ts`.

`mapKind`/`convertSymbols` remain per-mapper (not consolidated); `parser-loader.ts` is not modified.

## Acceptance criteria

- AC 1–6: shared module exists, exporting `normalizeWhitespace`, `getNodeText`, `getLineRange`, `findFirstDescendant`, and the parameterizable `finalizeSignature` base ✅
- AC 7–9, 12: rust/cpp/java import the primitives; no duplicate local definitions remain ✅
- AC 5, 10, 11: divergent C++ traversal and Java `formatSignature` preserved; signatures byte-for-byte unchanged; `mapKind`/`convertSymbols` left local ✅
- AC 13–14: `MAPPER_VERSION` bumped (rust 2→3, cpp 2→3, java 3→4) with matching exact-version test assertions, no other expectation changes ✅
- AC 15–17: output shape, full mapper suite, and WASM parser/tree lifecycle unchanged ✅
- AC 18: `parser-loader.ts` not modified ✅
- AC 19: `npm test` and `npm run typecheck` both pass ✅

## Verification

- `npm test` → 377 files / 1612 tests pass
- `npm run typecheck` → exit 0
- Snapshot/fixture/from-content tests confirm output shape unchanged for all three languages; WASM lifecycle tests confirm `parser`/`tree` deletion behavior unchanged
- Dedup guard test locks the extraction so the duplication can't silently return

## Behavior change

None. Pure refactor; the only observable effect is the `MAPPER_VERSION` bump, which invalidates stale persistent-map cache entries (intended).

Closes #202
