### PR TITLE
chore(release): 0.8.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.8.16] - 2026-05-28
+
+### Changed
+- Tree-sitter mappers (`rust`, `cpp`, `java`) now share their low-level helpers (`normalizeWhitespace`, `getNodeText`, `getLineRange`, `findFirstDescendant`, `finalizeSignature`) via `src/readmap/mappers/tree-sitter-helpers.ts`. Behavior-preserving refactor; structural-map output shape is unchanged. `MAPPER_VERSION` bumped (rust 2→3, cpp 2→3, java 3→4), which invalidates persistent-map cache entries for the affected languages on first read (#202, PR #135).
+- `write` tool now carries an explicit inline `ptc` policy (mutating, not safe by default) and is registered in `HashlineToolName` and `HASHLINE_TOOL_PTC_POLICY`. The PTC drift guard test was replaced with a mechanical check that cross-references each live tool's inline `ptc` against the exported policy and emitted executor map, so a tool added without a policy entry now fails CI (#201, PR #134).
+
+### Removed
+- Dead `BASH_FILTER_ENABLED = true` constant and its unreachable branch in `index.ts`; the live `filterBashOutput` path is unchanged (#200, PR #133).
+
+### Fixed
+- TUI renderer tests for the collapsed-diff default (`edit-render-tui.test.ts`, `edit-pending-diff-render-success.test.ts`) are now isolated from the user's real `~/.pi/agent/hashline-readmap/settings.json`, so a machine configured with `edit.diffDisplay: "expanded"` no longer produces false test failures (#200, PR #133).
+
+## [0.8.15] - 2026-05-25
+
 ### Changed
 - Release 0.8.13: Rust, C++, Java, and edit syntax validation now use `web-tree-sitter` with packaged `tree-sitter-wasms` grammars instead of native `tree-sitter*` packages. Native grammar dependencies were removed and unsupported Clojure mapper support was dropped (#192).
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.8.15",
+      "version": "0.8.16",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/cli": "0.42.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {

--- a/tests/package-version.test.ts
+++ b/tests/package-version.test.ts
@@ -5,9 +5,9 @@ const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
 const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
 
 describe("package version", () => {
-  it("is bumped for the issue #199 edit/read UX hardening release", () => {
-    expect(packageJson.version).toBe("0.8.15");
-    expect(packageLock.version).toBe("0.8.15");
-    expect(packageLock.packages[""].version).toBe("0.8.15");
+  it("is bumped for the 0.8.16 release", () => {
+    expect(packageJson.version).toBe("0.8.16");
+    expect(packageLock.version).toBe("0.8.16");
+    expect(packageLock.packages[""].version).toBe("0.8.16");
   });
 });


### PR DESCRIPTION
## Summary

Release 0.8.16. Bundles three small PRs that have been sitting on `main` since 0.8.15:

- **#135 — refactor: extract shared tree-sitter mapper helpers** (closes #202). The Rust, C++, and Java mappers now share `normalizeWhitespace`, `getNodeText`, `getLineRange`, `findFirstDescendant`, and `finalizeSignature` via a new `src/readmap/mappers/tree-sitter-helpers.ts`. Behavior-preserving; the only observable effect is `MAPPER_VERSION` bumps (rust 2→3, cpp 2→3, java 3→4) that invalidate persistent-map cache entries for those languages on first read.
- **#134 — fix: consolidate PTC tool policy to a single guarded source** (closes #201). The `write` tool now carries an inline `ptc` policy and is registered in `HashlineToolName` and `HASHLINE_TOOL_PTC_POLICY`. The PTC drift guard was replaced with a mechanical cross-check, so a tool added without a policy entry now fails CI.
- **#133 — chore: hygiene sweep** (closes #200). Removes the dead `BASH_FILTER_ENABLED = true` branch in `index.ts` and isolates two TUI renderer tests from the user's real `~/.pi/agent/hashline-readmap/settings.json` (a machine with `edit.diffDisplay: "expanded"` no longer produces false test failures).

No user-facing breakage. The only observable change is the persistent-map cache invalidation from the `MAPPER_VERSION` bumps, which is the intended effect.

## Changes in this PR

- `package.json` and `package-lock.json` → `0.8.16`
- `tests/package-version.test.ts` → assertions updated to `0.8.16`
- `CHANGELOG.md` → add `[0.8.16] - 2026-05-28` section; relabel the previously-stale `[Unreleased]` block as `[0.8.15]` (its content shipped with that release; not backfilling 0.8.3–0.8.14 history in this PR)

## Verification

- `npm test` — 377 files / 1612 tests pass
- `npm run typecheck` — exit 0
- `npm pack --dry-run` — clean tarball: `pi-hashline-readmap-0.8.16.tgz`, package size 190.3 kB, 112 files
