### PR TITLE
fix: normalize hashline imports

### DIFF
--- a/src/edit-diff.ts
+++ b/src/edit-diff.ts
@@ -1,5 +1,5 @@
 import * as Diff from "diff";
-import { computeLineHash } from "./hashline";
+import { computeLineHash } from "./hashline.js";
 
 // ─── Line ending normalization ──────────────────────────────────────────
 

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -4,7 +4,7 @@ import type { Static } from "@sinclair/typebox";
 import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 import { readFile as fsReadFile, writeFile as fsWriteFile } from "fs/promises";
 import { detectLineEnding, generateCompactOrFullDiff, normalizeToLF, replaceText, restoreLineEndings, stripBom } from "./edit-diff";
-import { HashlineMismatchError, applyHashlineEdits, computeLineHash, ensureHashInit, parseLineRef, type HashlineEditItem, escapeControlCharsForDisplay } from "./hashline";
+import { HashlineMismatchError, applyHashlineEdits, computeLineHash, ensureHashInit, parseLineRef, type HashlineEditItem, escapeControlCharsForDisplay } from "./hashline.js";
 import { resolveToCwd } from "./path-utils";
 import { throwIfAborted } from "./runtime";
 import { buildEditOutput } from "./edit-output.js";

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -6,7 +6,7 @@ import path from "path";
 import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 import { normalizeToLF, stripBom, hasBareCarriageReturn } from "./edit-diff";
 import { looksLikeBinary } from "./binary-detect";
-import { ensureHashInit, formatHashlineDisplay, escapeControlCharsForDisplay } from "./hashline";
+import { ensureHashInit, formatHashlineDisplay, escapeControlCharsForDisplay } from "./hashline.js";
 import { buildPtcError, buildPtcLine } from "./ptc-value.js";
 import { buildGrepOutput } from "./grep-output.js";
 import { buildGrepRehydrateDescriptor } from "./context-hygiene.js";

--- a/src/read.ts
+++ b/src/read.ts
@@ -10,7 +10,7 @@ import { Type } from "@sinclair/typebox";
 import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
 import { readFile as fsReadFile } from "fs/promises";
 import { normalizeToLF, stripBom, hasBareCarriageReturn } from "./edit-diff";
-import { ensureHashInit, formatHashlineDisplay } from "./hashline";
+import { ensureHashInit, formatHashlineDisplay } from "./hashline.js";
 import { buildPtcError, buildPtcWarning, buildPtcLines, type PtcWarning } from "./ptc-value.js";
 import { looksLikeBinary } from "./binary-detect";
 import { resolveToCwd } from "./path-utils";


### PR DESCRIPTION
Fix Windows runtime loading for core tools.

It works fine on Linux, but on Win10 i had same problems as described in #137.

I also noticed there is kinda mess with imports in general, but i didnt wanted to touch it more than necessary to work for me.

Fixes #137