### PR TITLE
fix(test): skip POSIX quoted filename fixtures on Windows

### DIFF
--- a/tests/readmap-mappers-ctags-quoting.test.ts
+++ b/tests/readmap-mappers-ctags-quoting.test.ts
@@ -20,23 +20,6 @@ async function ctagsAvailable(): Promise<boolean> {
 }
 
 describe("ctagsMapper subprocess safety (GH #116)", () => {
-  let dir = "";
-  let filePath = "";
-  let available = false;
-
-  beforeAll(async () => {
-    available = await ctagsAvailable();
-    if (!available) return;
-    dir = await mkdtemp(join(tmpdir(), "ctagsmap-quoting-"));
-    filePath = join(dir, 'has"quote$dollar.ts');
-    await writeFile(filePath, "export function hello() {\n  return 1;\n}\n", "utf8");
-  });
-
-  afterAll(async () => {
-    resetCtagsCache();
-    if (dir) await rm(dir, { recursive: true, force: true });
-  });
-
   it("does not import shell exec", async () => {
     const text = await readFile(resolve(__dirname, "../src/readmap/mappers/ctags.ts"), "utf8");
     expect(text).not.toMatch(/import\s*\{[^}]*\bexec\b[^}]*\}\s*from\s*["']node:child_process["']/s);
@@ -48,12 +31,32 @@ describe("ctagsMapper subprocess safety (GH #116)", () => {
     expect(text).not.toContain("wc -l <");
   });
 
-  it("returns a non-null FileMap for quoted path when ctags is installed", async () => {
-    if (!available) return;
-    resetCtagsCache();
-    const fileMap = await ctagsMapper(filePath);
-    expect(fileMap).not.toBeNull();
-    const names = (fileMap?.symbols ?? []).map((s) => s.name);
-    expect(names).toContain("hello");
+  // Windows forbids `"` in filenames. The quoted-filename runtime fixture is POSIX-specific.
+  describe.skipIf(process.platform === "win32")('runtime fixture with `"` in path', () => {
+    let dir: string | undefined;
+    let filePath: string;
+    let available = false;
+
+    beforeAll(async () => {
+      available = await ctagsAvailable();
+      if (!available) return;
+      dir = await mkdtemp(join(tmpdir(), "ctagsmap-quoting-"));
+      filePath = join(dir, 'has"quote$dollar.ts');
+      await writeFile(filePath, "export function hello() {\n  return 1;\n}\n", "utf8");
+    });
+
+    afterAll(async () => {
+      resetCtagsCache();
+      if (dir) await rm(dir, { recursive: true, force: true });
+    });
+
+    it("returns a non-null FileMap for quoted path when ctags is installed", async () => {
+      if (!available) return;
+      resetCtagsCache();
+      const fileMap = await ctagsMapper(filePath);
+      expect(fileMap).not.toBeNull();
+      const names = (fileMap?.symbols ?? []).map((s) => s.name);
+      expect(names).toContain("hello");
+    });
   });
 });

--- a/tests/readmap-mappers-fallback-quoting.test.ts
+++ b/tests/readmap-mappers-fallback-quoting.test.ts
@@ -4,7 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fallbackMapper } from "../src/readmap/mappers/fallback.js";
 
-describe("fallbackMapper with shell metacharacters in path (GH #116)", () => {
+// Windows forbids `"` in filenames. This runtime fixture is POSIX-specific.
+describe.skipIf(process.platform === "win32")('fallbackMapper with `"` in path (GH #116)', () => {
   let dir: string;
   let filePath: string;
 

--- a/tests/readmap-mappers-go-quoting.test.ts
+++ b/tests/readmap-mappers-go-quoting.test.ts
@@ -20,32 +20,35 @@ async function goAvailable(): Promise<boolean> {
 }
 
 describe("goMapper subprocess safety (GH #116)", () => {
-  let dir = "";
-  let filePath = "";
-  let available = false;
-
-  beforeAll(async () => {
-    available = await goAvailable();
-    if (!available) return;
-    dir = await mkdtemp(join(tmpdir(), "gomap-quoting-"));
-    filePath = join(dir, 'has"quote$dollar.go');
-    await writeFile(filePath, "package main\n\nfunc Hello() int {\n\treturn 1\n}\n", "utf8");
-  });
-
-  afterAll(async () => {
-    if (dir) await rm(dir, { recursive: true, force: true });
-  });
-
   it("does not import shell exec", async () => {
     const text = await readFile(resolve(__dirname, "../src/readmap/mappers/go.ts"), "utf8");
     expect(text).not.toMatch(/import\s*\{[^}]*\bexec\b[^}]*\}\s*from\s*["']node:child_process["']/s);
   });
 
-  it("returns a non-null FileMap with the Hello symbol when Go is installed", async () => {
-    if (!available) return;
-    const fileMap = await goMapper(filePath);
-    expect(fileMap).not.toBeNull();
-    const names = (fileMap?.symbols ?? []).map((s) => s.name);
-    expect(names).toContain("Hello");
+  // Windows forbids `"` in filenames. The quoted-filename runtime fixture is POSIX-specific.
+  describe.skipIf(process.platform === "win32")('runtime fixture with `"` in path', () => {
+    let dir: string | undefined;
+    let filePath: string;
+    let available = false;
+
+    beforeAll(async () => {
+      available = await goAvailable();
+      if (!available) return;
+      dir = await mkdtemp(join(tmpdir(), "gomap-quoting-"));
+      filePath = join(dir, 'has"quote$dollar.go');
+      await writeFile(filePath, "package main\n\nfunc Hello() int {\n\treturn 1\n}\n", "utf8");
+    });
+
+    afterAll(async () => {
+      if (dir) await rm(dir, { recursive: true, force: true });
+    });
+
+    it("returns a non-null FileMap with the Hello symbol when Go is installed", async () => {
+      if (!available) return;
+      const fileMap = await goMapper(filePath);
+      expect(fileMap).not.toBeNull();
+      const names = (fileMap?.symbols ?? []).map((s) => s.name);
+      expect(names).toContain("Hello");
+    });
   });
 });

--- a/tests/readmap-mappers-python-quoting.test.ts
+++ b/tests/readmap-mappers-python-quoting.test.ts
@@ -4,7 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pythonMapper } from "../src/readmap/mappers/python.js";
 
-describe("pythonMapper with shell metacharacters in path (GH #116)", () => {
+// Windows forbids `"` in filenames. This runtime fixture is POSIX-specific.
+describe.skipIf(process.platform === "win32")('pythonMapper with `"` in path (GH #116)', () => {
   let dir: string;
   let filePath: string;
 


### PR DESCRIPTION
On Linux "npm test" works fine, but on Win10 several tests are failing. 

Skips quoted-filename fixtures on Windows because `"` is not valid in Windows filenames.