### PR TITLE
fix: coerce stringified edits (#208) + word-boundary tsc match (#211)

### DIFF
--- a/src/edit.ts
+++ b/src/edit.ts
@@ -186,9 +186,26 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 						? input.new_text
 						: undefined;
 			const hasLegacyInput = legacyOldText !== undefined || legacyNewText !== undefined;
+
+			// Some models (Opus 4.6, GLM-5.1, qwen3.6) send `edits` as a JSON
+			// string instead of an array. Coerce it back to an array; on parse
+			// failure or non-array result, leave it unchanged so the existing
+			// validation path produces a clear error.
+			if (typeof (parsed as { edits?: unknown }).edits === "string") {
+				try {
+					const reparsed = JSON.parse((parsed as { edits?: unknown }).edits as string);
+					if (Array.isArray(reparsed)) {
+						(parsed as { edits?: unknown }).edits = reparsed;
+						(input as { edits?: unknown }).edits = reparsed;
+					}
+				} catch {
+					// fall through to existing validation error handling
+				}
+			}
+
 			const hasEditsInput = Array.isArray(parsed.edits);
 
-			let edits = parsed.edits ?? [];
+			let edits = Array.isArray(parsed.edits) ? parsed.edits : [];
 			let legacyNormalizationWarning: string | undefined;
 			if (!hasEditsInput && hasLegacyInput) {
 				if (legacyOldText === undefined || legacyNewText === undefined) {

--- a/src/rtk/bash-filter.ts
+++ b/src/rtk/bash-filter.ts
@@ -48,7 +48,8 @@ export function isGitCommand(command: string): boolean {
 
 export function isBuildCommand(command: string): boolean {
   const c = command.toLowerCase();
-  return ["tsc", "cargo build", "cargo check", "cargo test", "npm run build"].some((t) => c.includes(t));
+  if (/\btsc\b/.test(c)) return true;
+  return ["cargo build", "cargo check", "cargo test", "npm run build"].some((t) => c.includes(t));
 }
 
 export function isLinterCommand(command: string): boolean {

--- a/src/rtk/build.ts
+++ b/src/rtk/build.ts
@@ -11,7 +11,6 @@ const BUILD_COMMANDS = [
 	"npm run build",
 	"yarn build",
 	"pnpm build",
-	"tsc",
 	"go build",
 	"go install",
 	"python setup.py build",
@@ -60,6 +59,7 @@ export function isBuildCommand(command: string | undefined | null): boolean {
 	}
 
 	const cmdLower = command.toLowerCase();
+	if (/\btsc\b/.test(cmdLower)) return true;
 	return BUILD_COMMANDS.some((bc) => cmdLower.includes(bc.toLowerCase()));
 }
 

--- a/tests/bash-filter.test.ts
+++ b/tests/bash-filter.test.ts
@@ -36,6 +36,15 @@ describe("command detection", () => {
 
     expect(isTestCommand("echo hello")).toBe(false);
   });
+
+  it("excludes .tscn / typescript via word boundary but keeps tsc (#211)", () => {
+    expect(isBuildCommand("git diff scenes/player/player.tscn")).toBe(false);
+    expect(isBuildCommand("cat typescript-notes.md")).toBe(false);
+    expect(isBuildCommand("tsc")).toBe(true);
+    expect(isBuildCommand("tsc --noEmit")).toBe(true);
+    expect(isBuildCommand("npx tsc")).toBe(true);
+    expect(isBuildCommand("./node_modules/.bin/tsc")).toBe(true);
+  });
 });
 
 
@@ -215,5 +224,16 @@ describe("filterBashOutput routing", () => {
     expect(result.savedChars).toBe(input.length - "test output".length);
 
     spy.mockRestore();
+  });
+});
+
+describe("build.ts gate excludes .tscn (#211)", () => {
+  it("isBuildCommand and filterBuildOutput ignore .tscn but keep tsc", () => {
+    const realDiff = "diff --git a/scenes/player/player.tscn b/scenes/player/player.tscn\n@@ -1 +1 @@\n-old\n+new\n";
+    expect(buildModule.isBuildCommand("git diff scenes/player/player.tscn")).toBe(false);
+    expect(buildModule.filterBuildOutput(realDiff, "git diff scenes/player/player.tscn")).toBeNull();
+    expect(buildModule.isBuildCommand("tsc")).toBe(true);
+    expect(buildModule.isBuildCommand("tsc --noEmit")).toBe(true);
+    expect(buildModule.isBuildCommand("npx tsc")).toBe(true);
   });
 });

--- a/tests/ptc-error-edit-validation.test.ts
+++ b/tests/ptc-error-edit-validation.test.ts
@@ -45,4 +45,29 @@ describe("edit ptcValue.error — validation", () => {
     );
     expect(getPtc(r)?.error?.code).toBe("invalid-edit-variant");
   });
+
+  it("coerces JSON-stringified edits array (#208)", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-208-"));
+    const f = resolve(dir, "f.ts"); writeFileSync(f, "const a = 1;\n", "utf-8");
+    const lines = readFileSync(f, "utf-8").split("\n");
+    const anchor = `1:${computeLineHash(1, lines[0])}`;
+    const editsArr = [{ set_line: { anchor, new_text: "const a = 2;" } }];
+    const r = await callEdit(
+      { path: f, edits: JSON.stringify(editsArr) },
+      { wasReadInSession: () => true },
+    );
+    expect(r.isError).toBeFalsy();
+    expect(readFileSync(f, "utf-8")).toBe("const a = 2;\n");
+  });
+
+  it("non-array/invalid edits string still yields clear validation error (#208)", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-edit-208b-"));
+    const f = resolve(dir, "f.ts"); writeFileSync(f, "const a = 1;\n", "utf-8");
+    const r = await callEdit(
+      { path: f, edits: '{"not":"an array"}' },
+      { wasReadInSession: () => true },
+    );
+    expect(r.isError).toBe(true);
+    expect(getPtc(r)?.error?.code).toBe("invalid-edit-variant");
+  });
 });


### PR DESCRIPTION
## Summary

Batch bugfix (#213) bundling two independent, source-confirmed defects. **Source + test changes only — no `package-lock.json` churn.**

| Issue | One-liner |
|-------|-----------|
| **#208** | `edit` tool crashed with a `TypeError` when a model sent `edits` as a JSON **string** instead of an array. |
| **#211** | The bash-output build filter misclassified Godot `.tscn` paths as `tsc` builds, swallowing real `git diff` output. |

---

## #208 — `edit` crash on JSON-stringified `edits`

### Problem
Several models (Opus 4.6, GLM-5.1, local qwen3.6) emit the `edit` tool's `edits` parameter as a JSON-encoded **string**:

```
edits: "[{\"set_line\": {\"anchor\": \"…\", \"new_text\": \"…\"}}]"
```

This extension **replaces** pi's built-in `edit` tool and, in doing so, dropped the built-in's coercion safety net. The permissive TypeBox schema (`Type.Optional(Type.Array(...))` + `additionalProperties: true`) let the string slip past validation into `execute()`, where the variant loop iterated it **character-by-character** and applied the `in` operator to a one-char string primitive:

```
TypeError: Cannot use 'in' operator to search for 'old_text' in [
```

For weaker models this triggered an unrecoverable failure spiral.

### Fix
In `src/edit.ts` `execute()`, before `edits` is consumed, coerce a string back to an array (mirroring pi's built-in `edit.js`):

```ts
if (typeof (parsed as { edits?: unknown }).edits === "string") {
  try {
    const reparsed = JSON.parse((parsed as { edits?: unknown }).edits as string);
    if (Array.isArray(reparsed)) {
      (parsed as { edits?: unknown }).edits = reparsed;
      (input as { edits?: unknown }).edits = reparsed;
    }
  } catch { /* fall through to existing validation */ }
}
```

The `edits` assignment was also hardened to `Array.isArray(parsed.edits) ? parsed.edits : []` so a non-coerced (invalid/non-array) string falls through to the existing clear `invalid-edit-variant` error instead of being mis-iterated.

- ✅ Stringified array applies the edit identically to the array form.
- ✅ Invalid/non-array strings still produce the clear validation error — no `TypeError`.
- ✅ Array-form and legacy `old_text`/`new_text` paths untouched.

---

## #211 — `.tscn` paths misclassified as `tsc` builds

### Problem
Both build-command gates matched `"tsc"` with substring `includes("tsc")`. Godot scene files use the `.tscn` extension, so `git diff scenes/player/player.tscn` was treated as a TypeScript build — and the build filter then **swallowed the real diff**, returning a bogus `✓ Build successful (0 units compiled)`. That is silent data loss for the agent.

### Fix
Replaced substring matching with a word-boundary regex `/\btsc\b/` in **both** gates:

- `src/rtk/bash-filter.ts` — routing gate (dropped `"tsc"` from the substring list).
- `src/rtk/build.ts` — internal gate (added the regex, removed bare `"tsc"` from `BUILD_COMMANDS`).

`/\btsc\b/` still matches `tsc`, `tsc --noEmit`, `npx tsc`, `./node_modules/.bin/tsc` (the `/` is a word boundary) but **not** `player.tscn` or `typescript`.

- ✅ `isBuildCommand("git diff scenes/player/player.tscn")` → `false` (both gates).
- ✅ `filterBuildOutput(realDiff, "…player.tscn")` → `null`.
- ✅ `tsc`, `tsc --noEmit`, `npx tsc` remain `true`.

> Note: PR #148 (the original #211 fix) also deleted ~9 unrelated `package-lock.json` entries. This PR deliberately **excludes** that lockfile churn — source + tests only.

---

## Files changed

```
 src/edit.ts                             | 19 +++++++++++++++++--
 src/rtk/bash-filter.ts                  |  3 ++-
 src/rtk/build.ts                        |  2 +-
 tests/bash-filter.test.ts               | 20 ++++++++++++++++++++
 tests/ptc-error-edit-validation.test.ts | 25 +++++++++++++++++++++++++
```

## Testing

- **New regression tests** (TDD red→green):
  - `tests/ptc-error-edit-validation.test.ts` — coercion success + invalid-string error (#208).
  - `tests/bash-filter.test.ts` — both gates, both directions (#211).
- **Full suite:** `npm test` → **1631 passed**. The single failing test (`tests/package-version.test.ts`, expects `0.9.0` vs current `0.9.1`) is **pre-existing and unrelated** — confirmed by stashing this branch's changes and re-running (still fails).
- **Typecheck:** `npm run typecheck` clean.
- **Runtime repro:** both original symptoms independently confirmed gone (stringified `edits` applies the edit; `.tscn` diff returns `null`).

Closes #208, closes #211.
