### PR TITLE
fix: thread pi's shellPath through bash tool (#209)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ Example project settings:
   },
   "edit": {
     "diffDisplay": "collapsed"
+  },
+  "bash": {
+    "shellPath": "C:/Program Files/Git/bin/bash.exe"
   }
 }
 ```
@@ -294,6 +297,7 @@ JSON fields:
 | `bashContextGuard.tailLines` | `PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES` | Tightens the guarded preview tail size; default/ceiling `120` |
 | `gdscript.enabled` | `PI_HASHLINE_GDSCRIPT` | Defaults to `false`; exact env value `1` enables the dedicated GDScript mapper and takes precedence over JSON |
 | `edit.diffDisplay` | `PI_HASHLINE_EDIT_DIFF_DISPLAY` | Defaults to `collapsed`; set to `expanded` to render `edit` tool diffs inline without pressing Ctrl+O. Project JSON overrides global JSON. The env override is case-insensitive (`expanded`/`collapsed` in any casing, with surrounding whitespace trimmed); unrecognized env values are ignored and fall through to JSON, then the default. |
+| `bash.shellPath` | `PI_HASHLINE_SHELL_PATH` | Absolute path to the shell the `bash` tool should spawn (e.g. Git Bash on Windows). When set, this is forwarded to pi's built-in bash tool instead of relying on PATH lookup. Precedence: `PI_HASHLINE_SHELL_PATH` env (whitespace-trimmed, empty ignored) → project/global hashline JSON `bash.shellPath` → pi's own configured `shellPath` (from `~/.pi/agent/settings.json`) → upstream default shell resolution. |
 
 Budget fields must be strict positive base-10 integers. Zero, negative, signed, decimal, hexadecimal, exponent notation, separators, empty strings, and whitespace-only values are ignored. Boolean fields must be JSON booleans, and `mapCache.dir` must be a non-empty string. Malformed JSON files and invalid fields degrade safely: valid fields continue to apply where practical, invalid fields are ignored, and the loader emits non-fatal warnings where available.
 

--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ import { registerWriteTool } from "./src/write.js";
 import { registerLsTool } from "./src/ls.js";
 import { registerFindTool } from "./src/find.js";
 import { registerBashRendererTool } from "./src/bash-renderer.js";
+import { resolveShellPath } from "./src/hashline-settings.js";
 import { filterBashOutput } from "./src/rtk/bash-filter.js";
 import { buildRtkCompaction } from "./src/rtk/rtk-compaction.js";
 import { ensureBashOriginalOutputSnapshot, selectBashOriginalOutput } from "./src/rtk/bash-original-output.js";
@@ -205,7 +206,7 @@ export default function piHashlineReadmapExtension(pi: ExtensionAPI): void {
   const writeTool = registerWriteTool(pi, { onFileAnchored: noteRead });
   const lsTool = registerLsTool(pi);
   const findTool = registerFindTool(pi);
-  registerBashRendererTool(pi, { cwd: process.cwd() });
+  registerBashRendererTool(pi, { cwd: process.cwd(), shellPath: resolveShellPath() });
   const contextHygieneDebugTool = registerContextHygieneDebugTool(pi);
   const toolExecutors = {
     read: readTool,

--- a/src/bash-renderer.ts
+++ b/src/bash-renderer.ts
@@ -3,7 +3,7 @@ import { Text } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine } from "./tui-render-utils.js";
 
-type BuiltInFactory = (cwd: string) => any;
+type BuiltInFactory = (cwd: string, options?: { shellPath?: string }) => any;
 
 const BASH_DESCRIPTION = "Run tests, builds, git, package managers, and external CLIs; do not use for repo file reading/searching/listing/editing (use read, grep, find, ls, edit, or write).";
 const BASH_PROMPT_SNIPPET = "Bash only for tests/builds/git/pkg/external CLIs. Don't use cat/head/tail, grep/rg, find/ls/tree, sed/awk/perl/python rewrites, or > heredocs/tee for repo files; use read/grep/find/ls/edit/write.";
@@ -17,13 +17,13 @@ const BASH_PARAMETERS = Type.Object({
   timeout: Type.Optional(Type.Number({ description: "Timeout seconds" })),
 });
 
-export function registerBashRendererTool(pi: Pick<ExtensionAPI, "registerTool">, options: { cwd?: string; createBuiltInBashTool?: BuiltInFactory } = {}): any {
+export function registerBashRendererTool(pi: Pick<ExtensionAPI, "registerTool">, options: { cwd?: string; shellPath?: string; createBuiltInBashTool?: BuiltInFactory } = {}): any {
   const cache = new Map<string, any>();
-  const createBuiltInBashTool = options.createBuiltInBashTool ?? ((cwd: string) => createBashTool(cwd));
+  const createBuiltInBashTool = options.createBuiltInBashTool ?? ((cwd: string, opts?: { shellPath?: string }) => createBashTool(cwd, { shellPath: opts?.shellPath }));
   const getBuiltIn = (cwd: string) => {
     let tool = cache.get(cwd);
     if (!tool) {
-      tool = createBuiltInBashTool(cwd);
+      tool = createBuiltInBashTool(cwd, { shellPath: options.shellPath });
       cache.set(cwd, tool);
     }
     return tool;

--- a/src/hashline-settings.ts
+++ b/src/hashline-settings.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { SettingsManager } from "@earendil-works/pi-coding-agent";
 
 export interface HashlineJsonSettings {
   grep?: { maxLines?: number; maxBytes?: number };
@@ -8,12 +9,25 @@ export interface HashlineJsonSettings {
   bashContextGuard?: { enabled?: boolean; maxLines?: number; maxBytes?: number; headLines?: number; tailLines?: number };
   gdscript?: { enabled?: boolean };
   edit?: { diffDisplay?: "collapsed" | "expanded" };
+  bash?: { shellPath?: string };
 }
 export interface HashlineSettingsWarning { source: string; message: string; path?: string }
 export interface HashlineSettingsResult { settings: HashlineJsonSettings; warnings: HashlineSettingsWarning[] }
 let pathOverride: { globalSettingsPath?: string; projectSettingsPath?: string } | null = null;
 export function __setHashlineSettingsPathsForTest(paths: { globalSettingsPath?: string; projectSettingsPath?: string }): void { pathOverride = { ...paths }; }
 export function __resetHashlineSettingsPathsForTest(): void { pathOverride = null; }
+type PiShellPathReader = () => string | undefined;
+let piShellPathReaderOverride: PiShellPathReader | null = null;
+export function __setPiShellPathReaderForTest(reader: PiShellPathReader | undefined): void { piShellPathReaderOverride = reader ?? null; }
+function readPiShellPath(): string | undefined {
+  const reader = piShellPathReaderOverride ?? (() => SettingsManager.create(process.cwd()).getShellPath());
+  try {
+    const value = reader();
+    return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
 function defaultGlobalSettingsPath(): string { return join(homedir(), ".pi/agent/hashline-readmap/settings.json"); }
 function defaultProjectSettingsPath(): string { return join(process.cwd(), ".pi/hashline-readmap/settings.json"); }
 function isRecord(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value); }
@@ -183,6 +197,14 @@ function validateSettings(raw: unknown, source: string, rawText: string): Hashli
     }
     if (Object.keys(edit).length > 0) settings.edit = edit;
   }
+  if (isRecord(raw.bash)) {
+    const bash: NonNullable<HashlineJsonSettings["bash"]> = {};
+    if ("shellPath" in raw.bash) {
+      if (typeof raw.bash.shellPath === "string" && raw.bash.shellPath.trim().length > 0) bash.shellPath = raw.bash.shellPath;
+      else warnings.push(invalid(source, "bash.shellPath"));
+    }
+    if (Object.keys(bash).length > 0) settings.bash = bash;
+  }
   return { settings, warnings };
 }
 function readSettingsFile(path: string): HashlineSettingsResult {
@@ -206,6 +228,8 @@ function mergeSettings(base: HashlineJsonSettings, override: HashlineJsonSetting
   if (Object.keys(gdscript).length > 0) merged.gdscript = gdscript;
   const edit = { ...(base.edit ?? {}), ...(override.edit ?? {}) };
   if (Object.keys(edit).length > 0) merged.edit = edit;
+  const bash = { ...(base.bash ?? {}), ...(override.bash ?? {}) };
+  if (Object.keys(bash).length > 0) merged.bash = bash;
   return merged;
 }
 export function resolveHashlineJsonSettings(): HashlineSettingsResult {
@@ -230,4 +254,15 @@ export function resolveEditDiffDisplay(env: NodeJS.ProcessEnv = process.env): "c
   const json = resolveHashlineJsonSettings().settings.edit?.diffDisplay;
   if (json === "expanded" || json === "collapsed") return json;
   return "collapsed";
+}
+
+export function resolveShellPath(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const raw = env.PI_HASHLINE_SHELL_PATH;
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  const json = resolveHashlineJsonSettings().settings.bash?.shellPath;
+  if (typeof json === "string" && json.trim().length > 0) return json;
+  return readPiShellPath();
 }

--- a/tests/bash-renderer-wrapper.test.ts
+++ b/tests/bash-renderer-wrapper.test.ts
@@ -14,7 +14,7 @@ describe("bash renderer wrapper", () => {
 
     expect(textOf(registered.renderCall({ command: "npm test" }, theme))).toBe("bash npm test");
     await expect(registered.execute("call-1", { command: "npm test" }, undefined, undefined, { cwd: "/tmp/work" })).resolves.toMatchObject({ details: { delegated: true } });
-    expect(createBuiltIn).toHaveBeenCalledWith("/tmp/work");
+    expect(createBuiltIn).toHaveBeenCalledWith("/tmp/work", { shellPath: undefined });
     expect(execute).toHaveBeenCalledWith("call-1", { command: "npm test" }, undefined, undefined);
     expect(textOf(registered.renderResult({ content: [{ type: "text", text: "ok\n" }] }, {}, theme, {}))).toBe("↳ 1 line returned • Ctrl+O to expand");
     expect(textOf(registered.renderResult({ content: [{ type: "text", text: "" }] }, {}, theme, {}))).toBe("↳ command completed (no output)");

--- a/tests/index-bash-shellpath-wiring.test.ts
+++ b/tests/index-bash-shellpath-wiring.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+describe("index.ts bash shellPath wiring (issue #209)", () => {
+  it("imports resolveShellPath from hashline-settings", () => {
+    const source = readFileSync(resolve(root, "index.ts"), "utf8");
+    expect(source).toContain("resolveShellPath");
+    expect(source).toContain('from "./src/hashline-settings.js"');
+  });
+
+  it("passes a resolved shellPath into registerBashRendererTool", () => {
+    const source = readFileSync(resolve(root, "index.ts"), "utf8");
+    expect(source).toMatch(/registerBashRendererTool\(pi,\s*\{[^}]*shellPath/s);
+  });
+
+  it("registers the bash tool when loaded", async () => {
+    const modImport = await import(pathToFileURL(resolve(root, "index.ts")).href);
+    const tools: string[] = [];
+    const mockPi = {
+      registerTool(def: any) { tools.push(def.name); },
+      on() {},
+      events: { emit() {}, on() {} },
+    };
+    modImport.default(mockPi as any);
+    expect(tools).toContain("bash");
+  });
+});

--- a/tests/repro-209-shellpath-forwarding.test.ts
+++ b/tests/repro-209-shellpath-forwarding.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerBashRendererTool } from "../src/bash-renderer.js";
+
+// Repro for issue #209: bash tool must thread pi's shellPath through
+// registerBashRendererTool so the built-in bash factory spawns the
+// configured shell instead of falling back to a PATH lookup.
+describe("repro 209: shellPath forwarding", () => {
+  it("forwards a configured shellPath to the built-in bash factory", async () => {
+    const execute = vi.fn(async () => ({ content: [{ type: "text", text: "ok\n" }] }));
+    // The custom factory receives (cwd, options) so we can assert shellPath.
+    const createBuiltIn = vi.fn((_cwd: string, _options?: { shellPath?: string }) => ({
+      name: "bash",
+      label: "bash",
+      description: "bash",
+      parameters: {},
+      execute,
+    }));
+
+    let registered: any;
+    registerBashRendererTool(
+      { registerTool(def: any) { registered = def; } } as any,
+      { createBuiltInBashTool: createBuiltIn as any, cwd: "/tmp/work", shellPath: "/custom/git/bin/bash" } as any,
+    );
+
+    await registered.execute("call-1", { command: "echo hi" }, undefined, undefined, { cwd: "/tmp/work" });
+
+    // BUG: today the factory is only ever called with cwd; shellPath is dropped.
+    expect(createBuiltIn).toHaveBeenCalledWith("/tmp/work", { shellPath: "/custom/git/bin/bash" });
+  });
+});

--- a/tests/shellpath-pi-fallback.test.ts
+++ b/tests/shellpath-pi-fallback.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import {
+  __resetHashlineSettingsPathsForTest,
+  __setHashlineSettingsPathsForTest,
+  __setPiShellPathReaderForTest,
+  resolveShellPath,
+} from "../src/hashline-settings.js";
+
+function tempRoot(prefix: string): string { return join(tmpdir(), `${prefix}-${randomBytes(6).toString("hex")}`); }
+
+describe("resolveShellPath (pi SettingsManager fallback)", () => {
+  const originalEnv = process.env.PI_HASHLINE_SHELL_PATH;
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.PI_HASHLINE_SHELL_PATH;
+    else process.env.PI_HASHLINE_SHELL_PATH = originalEnv;
+    __resetHashlineSettingsPathsForTest();
+    __setPiShellPathReaderForTest(undefined);
+  });
+
+  function withEmptyJson(prefix: string): void {
+    const root = tempRoot(prefix);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "missing-global.json"),
+      projectSettingsPath: join(root, "missing-project.json"),
+    });
+  }
+
+  it("uses pi's shellPath when env and JSON are unset", () => {
+    delete process.env.PI_HASHLINE_SHELL_PATH;
+    withEmptyJson("shellpath-pi-only");
+    __setPiShellPathReaderForTest(() => "/pi/git/bin/bash");
+    expect(resolveShellPath({})).toBe("/pi/git/bin/bash");
+  });
+
+  it("prefers env over pi's shellPath", () => {
+    withEmptyJson("shellpath-env-over-pi");
+    __setPiShellPathReaderForTest(() => "/pi/git/bin/bash");
+    expect(resolveShellPath({ PI_HASHLINE_SHELL_PATH: "/env/git/bin/bash" })).toBe("/env/git/bin/bash");
+  });
+
+  it("returns undefined when pi reader throws", () => {
+    delete process.env.PI_HASHLINE_SHELL_PATH;
+    withEmptyJson("shellpath-pi-throws");
+    __setPiShellPathReaderForTest(() => { throw new Error("boom"); });
+    expect(resolveShellPath({})).toBeUndefined();
+  });
+});

--- a/tests/shellpath-settings.test.ts
+++ b/tests/shellpath-settings.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import {
+  __resetHashlineSettingsPathsForTest,
+  __setHashlineSettingsPathsForTest,
+  resolveShellPath,
+} from "../src/hashline-settings.js";
+
+function tempRoot(prefix: string): string { return join(tmpdir(), `${prefix}-${randomBytes(6).toString("hex")}`); }
+
+describe("resolveShellPath (env + JSON)", () => {
+  const cleanup: string[] = [];
+  const originalEnv = process.env.PI_HASHLINE_SHELL_PATH;
+  afterEach(async () => {
+    if (originalEnv === undefined) delete process.env.PI_HASHLINE_SHELL_PATH;
+    else process.env.PI_HASHLINE_SHELL_PATH = originalEnv;
+    __resetHashlineSettingsPathsForTest();
+    await Promise.all(cleanup.map((path) => rm(path, { recursive: true, force: true })));
+    cleanup.length = 0;
+  });
+
+  it("returns undefined when nothing is configured", () => {
+    delete process.env.PI_HASHLINE_SHELL_PATH;
+    const root = tempRoot("shellpath-none");
+    cleanup.push(root);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath: join(root, "repo/.pi/hashline-readmap/settings.json"),
+    });
+    expect(resolveShellPath({})).toBeUndefined();
+  });
+
+  it("reads bash.shellPath from project JSON", async () => {
+    const root = tempRoot("shellpath-json");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ bash: { shellPath: "/json/git/bin/bash" } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+    expect(resolveShellPath({})).toBe("/json/git/bin/bash");
+  });
+
+  it("lets PI_HASHLINE_SHELL_PATH override JSON", async () => {
+    const root = tempRoot("shellpath-env-over-json");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ bash: { shellPath: "/json/git/bin/bash" } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+    expect(resolveShellPath({ PI_HASHLINE_SHELL_PATH: "/env/git/bin/bash" })).toBe("/env/git/bin/bash");
+  });
+
+  it("ignores empty/whitespace env values and falls through to JSON", async () => {
+    const root = tempRoot("shellpath-empty-env");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ bash: { shellPath: "/json/git/bin/bash" } }));
+    __setHashlineSettingsPathsForTest({ globalSettingsPath: join(root, "missing.json"), projectSettingsPath });
+    expect(resolveShellPath({ PI_HASHLINE_SHELL_PATH: "   " })).toBe("/json/git/bin/bash");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #209. The `bash` tool dropped pi's configured `shellPath` before constructing the built-in bash tool, so upstream `getShellConfig(undefined)` fell back to a PATH lookup. On Windows with a non-default Git Bash install and WSL present, that PATH lookup resolved WSL's broken `/bin/bash` and crashed with `execvpe(/bin/bash) failed: No such file or directory`.

This is a plumbing defect — every layer below the extension already supports `shellPath`. The fix threads a resolved shell path through the registration boundary.

## Changes

- **`src/bash-renderer.ts`** — `registerBashRendererTool` accepts a `shellPath?: string` option; `BuiltInFactory` widened to `(cwd, options?)`; default factory forwards `createBashTool(cwd, { shellPath })`.
- **`src/hashline-settings.ts`** — new `bash.shellPath` JSON field (interface + validation + merge) and a `resolveShellPath(env)` resolver following the existing `resolveEditDiffDisplay` pattern.
- **`index.ts`** — resolves and passes `shellPath` at registration time.
- **`README.md`** — documents `bash.shellPath` / `PI_HASHLINE_SHELL_PATH` and the precedence chain.

## Precedence

`PI_HASHLINE_SHELL_PATH` env (trimmed, empty ignored) → hashline JSON `bash.shellPath` → pi's own `SettingsManager.getShellPath()` → upstream default resolution. When nothing is configured, `shellPath` stays `undefined` and behavior is unchanged (regression-safe).

## Why the symptom is gone

Upstream `getShellConfig` resolution order is: (1) user-specified shellPath, (2) Windows Git Bash known locations then PATH, (3) Unix defaults. With a configured shellPath now threaded to `createBashTool(cwd, { shellPath })`, resolution stops at step #1 and never reaches the PATH lookup that selected WSL's broken `/bin/bash`.

## Tests

- `tests/repro-209-shellpath-forwarding.test.ts` — forwarding repro (the original failing test)
- `tests/shellpath-settings.test.ts` — env + JSON precedence (4 cases)
- `tests/shellpath-pi-fallback.test.ts` — pi SettingsManager fallback (3 cases)
- `tests/index-bash-shellpath-wiring.test.ts` — index.ts wiring (3 cases)
- `tests/bash-renderer-wrapper.test.ts` — updated to the two-arg factory contract

Full suite: 1642 passing. The one failing test (`tests/package-version.test.ts`, expects `0.9.0` vs actual `0.9.1`) is **pre-existing on `main`** and unrelated to this change — flagged for a separate follow-up. Typecheck clean.