### PR TITLE
fix: make @ast-grep/cli an optional dependency (#210)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Start a new pi session after installation. Running sessions do not hot-reload ex
 
 Normal npm installs of `pi-hashline-readmap` include npm-managed CLI packages for the tools this extension wraps:
 
-- `@ast-grep/cli` provides the `sg` binary used by `ast_search`.
+- `@ast-grep/cli` (an **optional dependency**) provides the `sg` binary used by `ast_search`. It ships prebuilt native binaries for common platforms. On platforms without a prebuilt binary (for example Termux/Android, or musl-based Linux), npm skips this optional package and the rest of the extension (`read`/`edit`/`grep`/`bash`/`ls`/`find`/`nu`) still installs and works normally.
 - `nushell` provides the `nu` binary used by the optional `nu` tool.
 
-The extension resolves those bundled binaries first. If `@ast-grep/cli` cannot be resolved, `ast_search` falls back to `ast-grep` on `PATH` rather than `sg`, avoiding Linux util-linux `sg` collisions. The optional `nu` tool falls back to `nu` on `PATH` when the bundled `nushell` package or bin entry is unavailable. If troubleshooting a broken platform package, a system install can still be useful after repairing/removing the broken npm package or as a fallback in environments without the bundled binary:
+The extension resolves those bundled binaries first. If `@ast-grep/cli` cannot be resolved (for example when npm skipped the optional package on Termux/Android/musl), `ast_search` falls back to `ast-grep` on `PATH` rather than `sg`, avoiding Linux util-linux `sg` collisions. If no `ast-grep` is available at all, `ast_search` returns a clear "ast-grep not available" message instead of crashing, and every other tool is unaffected. The optional `nu` tool falls back to `nu` on `PATH` when the bundled `nushell` package or bin entry is unavailable. To enable `ast_search` on a platform without a prebuilt binary, or when troubleshooting a broken platform package, install `ast-grep` on your `PATH`:
 
 ```bash
 brew install ast-grep          # fallback for ast_search if @ast-grep/cli cannot run

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
-        "@ast-grep/cli": "0.42.2",
         "diff": "^8.0.3",
         "ignore": "^7.0.5",
         "nushell": "0.108.0",
@@ -18,6 +17,9 @@
         "ts-morph": "^27.0.2",
         "web-tree-sitter": "0.25.10",
         "xxhash-wasm": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "@ast-grep/cli": "0.42.2"
       },
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.78.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {
@@ -41,7 +41,6 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@ast-grep/cli": "0.42.2",
     "diff": "^8.0.3",
     "ignore": "^7.0.5",
     "nushell": "0.108.0",
@@ -50,6 +49,9 @@
     "ts-morph": "^27.0.2",
     "web-tree-sitter": "0.25.10",
     "xxhash-wasm": "^1.1.0"
+  },
+  "optionalDependencies": {
+    "@ast-grep/cli": "0.42.2"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",

--- a/tests/package-ast-grep-optional.test.ts
+++ b/tests/package-ast-grep-optional.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { describe, it, expect } from "vitest";
+
+const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+
+describe("@ast-grep/cli packaging", () => {
+  it("is not a hard dependency (its failing postinstall must not abort the parent install)", () => {
+    expect(pkg.dependencies?.["@ast-grep/cli"]).toBeUndefined();
+  });
+
+  it("is declared under optionalDependencies so npm tolerates a missing prebuilt binary", () => {
+    expect(pkg.optionalDependencies?.["@ast-grep/cli"]).toBe("0.42.2");
+  });
+});

--- a/tests/package-version.test.ts
+++ b/tests/package-version.test.ts
@@ -5,9 +5,9 @@ const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
 const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
 
 describe("package version", () => {
-  it("is bumped for the 0.9.0 release", () => {
-    expect(packageJson.version).toBe("0.9.0");
-    expect(packageLock.version).toBe("0.9.0");
-    expect(packageLock.packages[""].version).toBe("0.9.0");
+  it("is bumped for the 0.9.2 release", () => {
+    expect(packageJson.version).toBe("0.9.2");
+    expect(packageLock.version).toBe("0.9.2");
+    expect(packageLock.packages[""].version).toBe("0.9.2");
   });
 });

--- a/tests/repro-210-ast-grep-absent-fallback.test.ts
+++ b/tests/repro-210-ast-grep-absent-fallback.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { resolveBundledBin } from "../src/binary-resolution.js";
+import { resolveSgBinary } from "../src/sg.js";
+
+describe("repro #210 — @ast-grep/cli absent (Termux/musl) PATH fallback", () => {
+  it("falls back to the ast-grep PATH command when @ast-grep/cli cannot be resolved", () => {
+    const resolved = resolveBundledBin("@ast-grep/cli", "sg", "ast-grep", {
+      resolvePackageJson: () => {
+        throw Object.assign(new Error("Cannot find module '@ast-grep/cli/package.json'"), {
+          code: "MODULE_NOT_FOUND",
+        });
+      },
+      readPackageJson: () => {
+        throw new Error("should not read package.json after resolution failed");
+      },
+      existsSync: () => false,
+    });
+
+    expect(resolved).toBe("ast-grep");
+  });
+
+  it("resolveSgBinary uses 'ast-grep' (not 'sg') as the PATH fallback name", () => {
+    // Sanity: the PATH fallback name must be `ast-grep` to avoid the util-linux
+    // `sg` collision on Linux (GH #112). With the package present this returns a
+    // bundled path; the contract we pin here is just that it returns a non-empty
+    // string and never throws when the package may be missing.
+    const result = resolveSgBinary();
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #210 — installing \`pi-hashline-readmap\` aborts on platforms without a prebuilt \`@ast-grep/cli\` native binary (Termux/Android musl, unsupported arch).

**Root cause:** \`@ast-grep/cli\` was a hard \`dependency\`. Its \`postinstall.js\` calls \`process.exit(1)\` when no prebuilt binary exists, and npm treats a failing postinstall of a *hard* dependency as a fatal install error.

**Fix:** Move \`@ast-grep/cli\` to \`optionalDependencies\`. npm then tolerates the failing postinstall and continues. The runtime already falls back to a PATH \`ast-grep\` (\`resolveSgBinary\` → \`resolveBundledBin\`) and degrades gracefully when none is present, so no \`src/\` change is required.

## Changes

- **package.json** — \`@ast-grep/cli\` moved \`dependencies\` → \`optionalDependencies\`; version bump \`0.9.1\` → \`0.9.2\`
- **package-lock.json** — root node reflects the move (surgical, dependency-only edit)
- **tests/package-ast-grep-optional.test.ts** (new) — packaging-contract test
- **tests/repro-210-ast-grep-absent-fallback.test.ts** (new) — PATH-fallback regression guard
- **tests/package-version.test.ts** — pin \`0.9.2\`
- **README.md** — document optional \`@ast-grep/cli\` install behavior

## Verification

- Full suite: **388 files / 1647 tests, 0 failures**
- Live proof of the fix mechanism: an identical failing \`postinstall\` aborts install as a HARD dep (exit 1) but is tolerated as an OPTIONAL dep (exit 0)
- Runtime absent-package fallback returns \`ast-grep\` (PATH); pinned by regression test
- Supported platform: bundled \`ast-grep 0.42.2\` present and runs out-of-the-box

## Notes for reviewers

1. **Lockfile handling:** a full \`npm install\` in this repo prunes 14 unrelated packages (pre-existing lockfile drift, incl. top-level \`jiti\`). I applied a surgical dependency-only lockfile edit instead and verified via \`npm install --package-lock-only\` that npm produces the identical \`@ast-grep/cli\` placement. The committed diff is minimal (version + dep move only).
2. **Pre-existing/out-of-scope:** the committed lockfile declares a top-level \`node_modules/jiti\` that current npm dedups to a nested path, so 2 \`dual-module-*\` suites fail on a pristine \`npm ci\`. Independent of #210; flagged as a possible separate follow-up.