### PR TITLE
feat: collapsed tool-result tail preview + 0.10.0 (display.previewLines) (#214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-18
+
+### Added
+- Collapsed `bash`, `read`, and `grep` TUI results now show a tail preview instead of being content-free: the existing summary line is followed by the last N visual lines of output (default 5), with a muted `… (K earlier line(s) • Ctrl+O to expand)` hint when earlier lines are hidden. Controlled by the new `display.previewLines` setting (env `PI_HASHLINE_PREVIEW_LINES`; precedence env → JSON → default 5); set to `0` to restore the previous content-free collapsed summaries. The change is display-only — model-facing tool text, `details.ptcValue`, RTK bash compression, and the Bash context guard are unchanged. `grep` keeps its expand affordance when the expanded per-file count list adds detail beyond the preview (#214, PR #152).
+
 ## [0.8.16] - 2026-05-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It also reduces extension conflict risk by replacing several overlapping tool pa
 - Read pending write/edit diffs without color thanks to textual `+`/`-`/space gutter markers.
 - Explore files with agent-oriented `ls`, `find`, and optional `nu` tools.
 - Compress noisy test, build, Git, Docker, linter, package-manager, HTTP, transfer, and generic command output.
+- See a tail preview of collapsed `bash`, `read`, and `grep` results instead of a content-free summary — configurable via `display.previewLines` (default 5, `0` to disable).
 - Use one extension instead of stacking overlapping `read`, `grep`, `edit`, and Bash-output packages.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -276,6 +276,9 @@ Example project settings:
   "edit": {
     "diffDisplay": "collapsed"
   },
+  "display": {
+    "previewLines": 5
+  },
   "bash": {
     "shellPath": "C:/Program Files/Git/bin/bash.exe"
   }
@@ -297,9 +300,10 @@ JSON fields:
 | `bashContextGuard.tailLines` | `PI_HASHLINE_BASH_CONTEXT_GUARD_TAIL_LINES` | Tightens the guarded preview tail size; default/ceiling `120` |
 | `gdscript.enabled` | `PI_HASHLINE_GDSCRIPT` | Defaults to `false`; exact env value `1` enables the dedicated GDScript mapper and takes precedence over JSON |
 | `edit.diffDisplay` | `PI_HASHLINE_EDIT_DIFF_DISPLAY` | Defaults to `collapsed`; set to `expanded` to render `edit` tool diffs inline without pressing Ctrl+O. Project JSON overrides global JSON. The env override is case-insensitive (`expanded`/`collapsed` in any casing, with surrounding whitespace trimmed); unrecognized env values are ignored and fall through to JSON, then the default. |
+| `display.previewLines` | `PI_HASHLINE_PREVIEW_LINES` | Defaults to `5`; controls how many trailing (tail) lines of `bash`, `read`, and `grep` output appear in the collapsed result preview. Set to `0` to restore fully content-free collapsed summaries. Must be a non-negative base-10 integer (env values are whitespace-trimmed; invalid values are ignored and fall through to JSON, then the default). Project JSON overrides global JSON. |
 | `bash.shellPath` | `PI_HASHLINE_SHELL_PATH` | Absolute path to the shell the `bash` tool should spawn (e.g. Git Bash on Windows). When set, this is forwarded to pi's built-in bash tool instead of relying on PATH lookup. Precedence: `PI_HASHLINE_SHELL_PATH` env (whitespace-trimmed, empty ignored) → project/global hashline JSON `bash.shellPath` → pi's own configured `shellPath` (from `~/.pi/agent/settings.json`) → upstream default shell resolution. |
 
-Budget fields must be strict positive base-10 integers. Zero, negative, signed, decimal, hexadecimal, exponent notation, separators, empty strings, and whitespace-only values are ignored. Boolean fields must be JSON booleans, and `mapCache.dir` must be a non-empty string. Malformed JSON files and invalid fields degrade safely: valid fields continue to apply where practical, invalid fields are ignored, and the loader emits non-fatal warnings where available.
+Budget fields must be strict positive base-10 integers, except `display.previewLines`, which also accepts `0` to fully suppress the collapsed preview. For the strict-positive budget fields, zero is rejected; for every field above, negative, signed, decimal, hexadecimal, exponent notation, separators, empty strings, and whitespace-only values are ignored. Boolean fields must be JSON booleans, and `mapCache.dir` must be a non-empty string. Malformed JSON files and invalid fields degrade safely: valid fields continue to apply where practical, invalid fields are ignored, and the loader emits non-fatal warnings where available.
 
 ### Optional GDScript maps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {

--- a/src/bash-renderer.ts
+++ b/src/bash-renderer.ts
@@ -1,7 +1,8 @@
 import { createBashTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
-import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine } from "./tui-render-utils.js";
+import { buildCollapsedPreview, clampLineToWidth, clampLinesToWidth, isRendererExpanded, renderToolLabel, summaryLine } from "./tui-render-utils.js";
+import { resolvePreviewLines } from "./hashline-settings.js";
 
 type BuiltInFactory = (cwd: string, options?: { shellPath?: string }) => any;
 
@@ -55,9 +56,14 @@ export function registerBashRendererTool(pi: Pick<ExtensionAPI, "registerTool">,
       }
       if (!text.trim()) return new Text(summaryLine("command completed (no output)"), 0, 0);
       const lineCount = text.split("\n").filter(Boolean).length;
-      let rendered = summaryLine(`${lineCount} ${lineCount === 1 ? "line" : "lines"} returned`, { hidden: !expanded });
-      if (expanded) rendered += `\n${text}`;
-      return new Text(clampLinesToWidth(rendered.split("\n"), width).join("\n"), 0, 0);
+      if (expanded) {
+        const rendered = `${summaryLine(`${lineCount} ${lineCount === 1 ? "line" : "lines"} returned`)}\n${text}`;
+        return new Text(clampLinesToWidth(rendered.split("\n"), width).join("\n"), 0, 0);
+      }
+      const preview = buildCollapsedPreview(text, resolvePreviewLines(), width);
+      const summary = summaryLine(`${lineCount} ${lineCount === 1 ? "line" : "lines"} returned`, { hidden: preview.lines.length === 0 });
+      const out = [summary, ...(preview.hint ? [preview.hint] : []), ...preview.lines];
+      return new Text(clampLinesToWidth(out, width).join("\n"), 0, 0);
     },
   };
   pi.registerTool(tool as any);

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -17,7 +17,8 @@ import { throwIfAborted } from "./runtime.js";
 import { Text } from "@earendil-works/pi-tui";
 import { formatGrepCallText, formatGrepResultText } from "./grep-render-helpers.js";
 import { coerceObviousBase10Int } from "./coerce-obvious-int.js";
-import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, linkToolPath, renderToolLabel, summaryLine } from "./tui-render-utils.js";
+import { buildCollapsedPreview, clampLineToWidth, clampLinesToWidth, isRendererExpanded, linkToolPath, renderToolLabel, summaryLine } from "./tui-render-utils.js";
+import { resolvePreviewLines } from "./hashline-settings.js";
 
 const GREP_PROMPT_METADATA = defineToolPromptMetadata({
 	promptUrl: new URL("../prompts/grep.md", import.meta.url),
@@ -772,8 +773,17 @@ if (p.scope === "symbol" && !summary) {
 			if (info.noMatches && !hasBinaryWarning) return new Text(summaryLine("no matches"), 0, 0);
 			const matchCount = ptcValue?.totalMatches ?? 0;
 			const matchWord = matchCount === 1 ? "match" : "matches";
-			let text = summaryLine(`${matchCount} ${matchWord} returned`, { hidden: !!textContent && !expanded });
+			const collapsedPreview = expanded ? { hint: null, lines: [] } : buildCollapsedPreview(textContent, resolvePreviewLines(), width);
+			// Grep's expanded view reveals a per-file count list (distinct from the collapsed match preview), so keep the
+			// expand affordance discoverable whenever that detail exists and the earlier-lines hint isn't already carrying it.
+			const hasExpandableDetail = !!ptcValue?.records?.some((r) => r.path && r.kind === "match");
+			const showExpandAffordance = !!textContent && !expanded && (collapsedPreview.lines.length === 0 || (hasExpandableDetail && !collapsedPreview.hint));
+			let text = summaryLine(`${matchCount} ${matchWord} returned`, { hidden: showExpandAffordance });
 			for (const badge of info.badges) text += theme.fg(badge.startsWith("⚠") ? "warning" : "dim", `  ${badge}`);
+			if (!expanded) {
+				if (collapsedPreview.hint) text += "\n" + collapsedPreview.hint;
+				for (const line of collapsedPreview.lines) text += "\n" + line;
+			}
 			if (expanded && ptcValue?.records) {
 				const fileCounts = new Map<string, number>();
 				for (const r of ptcValue.records) if (r.path && r.kind === "match") fileCounts.set(r.path, (fileCounts.get(r.path) ?? 0) + 1);

--- a/src/hashline-settings.ts
+++ b/src/hashline-settings.ts
@@ -9,6 +9,7 @@ export interface HashlineJsonSettings {
   bashContextGuard?: { enabled?: boolean; maxLines?: number; maxBytes?: number; headLines?: number; tailLines?: number };
   gdscript?: { enabled?: boolean };
   edit?: { diffDisplay?: "collapsed" | "expanded" };
+  display?: { previewLines?: number };
   bash?: { shellPath?: string };
 }
 export interface HashlineSettingsWarning { source: string; message: string; path?: string }
@@ -143,6 +144,16 @@ function readPositive(raw: Record<string, unknown>, key: string, path: string, s
   warnings.push(invalid(source, path));
   return undefined;
 }
+function isStrictJsonNonNegativeInteger(rawText: string, path: string, value: unknown): value is number {
+  const tokens = rawFieldTokens(rawText, path);
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 && tokens.length === 1 && /^(0|[1-9][0-9]*)$/.test(tokens[0]);
+}
+function readNonNegative(raw: Record<string, unknown>, key: string, path: string, source: string, rawText: string, warnings: HashlineSettingsWarning[]): number | undefined {
+  if (!(key in raw)) return undefined;
+  if (isStrictJsonNonNegativeInteger(rawText, path, raw[key])) return raw[key];
+  warnings.push(invalid(source, path));
+  return undefined;
+}
 function readBoolean(raw: Record<string, unknown>, key: string, path: string, source: string, warnings: HashlineSettingsWarning[]): boolean | undefined {
   if (!(key in raw)) return undefined;
   if (typeof raw[key] === "boolean") return raw[key];
@@ -205,6 +216,12 @@ function validateSettings(raw: unknown, source: string, rawText: string): Hashli
     }
     if (Object.keys(bash).length > 0) settings.bash = bash;
   }
+  if (isRecord(raw.display)) {
+    const display: NonNullable<HashlineJsonSettings["display"]> = {};
+    const previewLines = readNonNegative(raw.display, "previewLines", "display.previewLines", source, rawText, warnings);
+    if (previewLines !== undefined) display.previewLines = previewLines;
+    if (Object.keys(display).length > 0) settings.display = display;
+  }
   return { settings, warnings };
 }
 function readSettingsFile(path: string): HashlineSettingsResult {
@@ -228,6 +245,8 @@ function mergeSettings(base: HashlineJsonSettings, override: HashlineJsonSetting
   if (Object.keys(gdscript).length > 0) merged.gdscript = gdscript;
   const edit = { ...(base.edit ?? {}), ...(override.edit ?? {}) };
   if (Object.keys(edit).length > 0) merged.edit = edit;
+  const display = { ...(base.display ?? {}), ...(override.display ?? {}) };
+  if (Object.keys(display).length > 0) merged.display = display;
   const bash = { ...(base.bash ?? {}), ...(override.bash ?? {}) };
   if (Object.keys(bash).length > 0) merged.bash = bash;
   return merged;
@@ -254,6 +273,21 @@ export function resolveEditDiffDisplay(env: NodeJS.ProcessEnv = process.env): "c
   const json = resolveHashlineJsonSettings().settings.edit?.diffDisplay;
   if (json === "expanded" || json === "collapsed") return json;
   return "collapsed";
+}
+
+const DEFAULT_PREVIEW_LINES = 5;
+export function resolvePreviewLines(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.PI_HASHLINE_PREVIEW_LINES;
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (/^(0|[1-9][0-9]*)$/.test(trimmed)) {
+      const parsed = Number.parseInt(trimmed, 10);
+      if (Number.isSafeInteger(parsed) && parsed >= 0) return parsed;
+    }
+  }
+  const json = resolveHashlineJsonSettings().settings.display?.previewLines;
+  if (typeof json === "number" && Number.isSafeInteger(json) && json >= 0) return json;
+  return DEFAULT_PREVIEW_LINES;
 }
 
 export function resolveShellPath(env: NodeJS.ProcessEnv = process.env): string | undefined {

--- a/src/read.ts
+++ b/src/read.ts
@@ -25,7 +25,8 @@ import { buildLocalBundle } from "./read-local-bundle.js";
 import { coerceObviousBase10Int } from "./coerce-obvious-int.js";
 import { Text } from "@earendil-works/pi-tui";
 import { formatReadCallText, formatReadResultText } from "./read-render-helpers.js";
-import { clampLineToWidth, clampLinesToWidth, isRendererExpanded, linkToolPath, renderToolLabel, summaryLine, wrapReadHashlinesForWidth } from "./tui-render-utils.js";
+import { buildCollapsedPreview, clampLineToWidth, clampLinesToWidth, isRendererExpanded, linkToolPath, renderToolLabel, summaryLine, wrapReadHashlinesForWidth } from "./tui-render-utils.js";
+import { resolvePreviewLines } from "./hashline-settings.js";
 
 const READ_PROMPT_METADATA = defineToolPromptMetadata({
 	promptUrl: new URL("../prompts/read.md", import.meta.url),
@@ -691,9 +692,14 @@ return succeed({
 			if (info.symbolBadge) summaryParts.push(info.symbolBadge);
 			for (const badge of info.badges) summaryParts.push(badge);
 			const summary = summaryParts.join(" • ");
-			let text = summaryLine(summary, { hidden: !!textContent && !expanded });
-			if (expanded && textContent) text += "\n" + wrapReadHashlinesForWidth(textContent, width);
-			return new Text(clampLinesToWidth(text.split("\n"), width).join("\n"), 0, 0);
+			if (expanded && textContent) {
+				const text = summaryLine(summary) + "\n" + wrapReadHashlinesForWidth(textContent, width);
+				return new Text(clampLinesToWidth(text.split("\n"), width).join("\n"), 0, 0);
+			}
+			const preview = buildCollapsedPreview(textContent, resolvePreviewLines(), width, { hashlines: true });
+			const summaryRow = summaryLine(summary, { hidden: !!textContent && preview.lines.length === 0 });
+			const out = [summaryRow, ...(preview.hint ? [preview.hint] : []), ...preview.lines];
+			return new Text(clampLinesToWidth(out, width).join("\n"), 0, 0);
 		},
 	} satisfies Parameters<ExtensionAPI["registerTool"]>[0] & { ptc: typeof ptc };
 

--- a/src/tui-render-utils.ts
+++ b/src/tui-render-utils.ts
@@ -127,3 +127,30 @@ export function wrapReadHashlinesForWidth(text: string, width: number | undefine
   }
   return output.join("\n");
 }
+
+export interface CollapsedPreview {
+  hint: string | null;
+  lines: string[];
+}
+
+export function buildCollapsedPreview(
+  body: string,
+  previewLines: number,
+  width: number | undefined,
+  options: { hashlines?: boolean } = {},
+): CollapsedPreview {
+  if (previewLines <= 0) return { hint: null, lines: [] };
+  const trimmed = body.replace(/\n+$/, "");
+  if (trimmed.length === 0) return { hint: null, lines: [] };
+  const rawLines = trimmed.split("\n");
+  const total = rawLines.length;
+  const tail = rawLines.slice(Math.max(0, total - previewLines));
+  const hiddenCount = total - tail.length;
+  const lines = options.hashlines
+    ? wrapReadHashlinesForWidth(tail.join("\n"), width).split("\n")
+    : clampLinesToWidth(tail, width);
+  const hint = hiddenCount > 0
+    ? `… (${hiddenCount} earlier ${hiddenCount === 1 ? "line" : "lines"}${EXPAND_HINT})`
+    : null;
+  return { hint, lines };
+}

--- a/tests/bash-preview-renderer.test.ts
+++ b/tests/bash-preview-renderer.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { registerBashRendererTool } from "../src/bash-renderer.js";
+
+const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
+function textOf(component: any, width = 120): string { return component?.text ?? component?.render?.(width)?.join("\n") ?? ""; }
+function bashTool(): any {
+  let registered: any;
+  registerBashRendererTool({ registerTool(def: any) { registered = def; } } as any, { createBuiltInBashTool: () => ({ execute: async () => ({ content: [] }), parameters: {} }) });
+  return registered;
+}
+
+describe("bash collapsed tail preview", () => {
+  const originalEnv = process.env.PI_HASHLINE_PREVIEW_LINES;
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.PI_HASHLINE_PREVIEW_LINES;
+    else process.env.PI_HASHLINE_PREVIEW_LINES = originalEnv;
+  });
+
+  it("shows the last 5 lines plus an earlier-lines hint when collapsed", () => {
+    delete process.env.PI_HASHLINE_PREVIEW_LINES;
+    const text = ["l1", "l2", "l3", "l4", "l5", "l6", "l7"].join("\n");
+    const rendered = textOf(bashTool().renderResult({ content: [{ type: "text", text }] }, {}, theme, {}));
+    expect(rendered).toContain("↳ 7 lines returned");
+    expect(rendered).toContain("… (2 earlier lines");
+    expect(rendered).toContain("l7");
+    expect(rendered).toContain("l3");
+    expect(rendered).not.toContain("\nl2");
+  });
+
+  it("shows all lines with no hint when within preview length", () => {
+    delete process.env.PI_HASHLINE_PREVIEW_LINES;
+    const rendered = textOf(bashTool().renderResult({ content: [{ type: "text", text: "only\ntwo" }] }, {}, theme, {}));
+    expect(rendered).toContain("only");
+    expect(rendered).toContain("two");
+    expect(rendered).not.toContain("earlier line");
+  });
+
+  it("restores content-free collapsed output when previewLines=0", () => {
+    process.env.PI_HASHLINE_PREVIEW_LINES = "0";
+    const text = ["a", "b", "c"].join("\n");
+    const rendered = textOf(bashTool().renderResult({ content: [{ type: "text", text }] }, {}, theme, {}));
+    expect(rendered).toBe("↳ 3 lines returned • Ctrl+O to expand");
+  });
+
+  it("keeps expanded output as the full body", () => {
+    process.env.PI_HASHLINE_PREVIEW_LINES = "0";
+    const text = ["a", "b", "c"].join("\n");
+    const rendered = textOf(bashTool().renderResult({ content: [{ type: "text", text }] }, { expanded: true }, theme, { expanded: true }));
+    expect(rendered).toContain("a");
+    expect(rendered).toContain("b");
+    expect(rendered).toContain("c");
+  });
+});

--- a/tests/bash-renderer-wrapper.test.ts
+++ b/tests/bash-renderer-wrapper.test.ts
@@ -16,7 +16,7 @@ describe("bash renderer wrapper", () => {
     await expect(registered.execute("call-1", { command: "npm test" }, undefined, undefined, { cwd: "/tmp/work" })).resolves.toMatchObject({ details: { delegated: true } });
     expect(createBuiltIn).toHaveBeenCalledWith("/tmp/work", { shellPath: undefined });
     expect(execute).toHaveBeenCalledWith("call-1", { command: "npm test" }, undefined, undefined);
-    expect(textOf(registered.renderResult({ content: [{ type: "text", text: "ok\n" }] }, {}, theme, {}))).toBe("↳ 1 line returned • Ctrl+O to expand");
+    expect(textOf(registered.renderResult({ content: [{ type: "text", text: "ok\n" }] }, {}, theme, {}))).toBe("↳ 1 line returned\nok");
     expect(textOf(registered.renderResult({ content: [{ type: "text", text: "" }] }, {}, theme, {}))).toBe("↳ command completed (no output)");
   });
 

--- a/tests/build-collapsed-preview.test.ts
+++ b/tests/build-collapsed-preview.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { EXPAND_HINT, buildCollapsedPreview } from "../src/tui-render-utils.js";
+
+describe("buildCollapsedPreview", () => {
+  it("returns the last N lines with an earlier-lines hint when content exceeds N", () => {
+    const body = ["one", "two", "three", "four", "five", "six", "seven"].join("\n");
+    const preview = buildCollapsedPreview(body, 5, 80);
+    expect(preview.lines).toEqual(["three", "four", "five", "six", "seven"]);
+    expect(preview.hint).toBe(`… (2 earlier lines${EXPAND_HINT})`);
+  });
+
+  it("shows all lines with no hint when content is within N", () => {
+    const preview = buildCollapsedPreview("a\nb", 5, 80);
+    expect(preview.lines).toEqual(["a", "b"]);
+    expect(preview.hint).toBeNull();
+  });
+
+  it("uses singular 'line' when exactly one earlier line is hidden", () => {
+    const body = ["1", "2", "3", "4", "5", "6"].join("\n");
+    const preview = buildCollapsedPreview(body, 5, 80);
+    expect(preview.hint).toBe(`… (1 earlier line${EXPAND_HINT})`);
+  });
+
+  it("returns nothing when previewLines is 0", () => {
+    const preview = buildCollapsedPreview("a\nb", 0, 80);
+    expect(preview.lines).toEqual([]);
+    expect(preview.hint).toBeNull();
+  });
+
+  it("returns nothing for blank bodies", () => {
+    const preview = buildCollapsedPreview("\n\n", 5, 80);
+    expect(preview.lines).toEqual([]);
+    expect(preview.hint).toBeNull();
+  });
+
+  it("width-clamps preview lines", () => {
+    const long = "x".repeat(200);
+    const preview = buildCollapsedPreview(long, 5, 20);
+    expect(preview.lines.every((l) => visibleWidth(l) <= 20)).toBe(true);
+  });
+
+  it("preserves hashline formatting when the hashlines option is set", () => {
+    const preview = buildCollapsedPreview("1:abc|hello", 5, 80, { hashlines: true });
+    expect(preview.lines[0]).toContain("1:abc|");
+  });
+});

--- a/tests/grep-preview-renderer.test.ts
+++ b/tests/grep-preview-renderer.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { registerGrepTool } from "../src/grep.js";
+
+const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
+function tool(): any { let registered: any; registerGrepTool({ registerTool(def: any) { registered = def; } } as any, {} as any); return registered; }
+function textOf(component: any, width = 120): string { return component?.text ?? component?.render?.(width)?.join("\n") ?? ""; }
+
+function makeResult(matchLines: string[]): any {
+  const cwd = process.cwd();
+  return {
+    content: [{ type: "text", text: matchLines.join("\n") }],
+    details: { ptcValue: { tool: "grep", summary: false, totalMatches: matchLines.length, records: [{ path: `${cwd}/src/a.ts`, kind: "match" }] } },
+  };
+}
+
+describe("grep collapsed tail preview", () => {
+  const originalEnv = process.env.PI_HASHLINE_PREVIEW_LINES;
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.PI_HASHLINE_PREVIEW_LINES;
+    else process.env.PI_HASHLINE_PREVIEW_LINES = originalEnv;
+  });
+
+  it("shows the last 5 match lines plus an earlier-lines hint when collapsed", () => {
+    delete process.env.PI_HASHLINE_PREVIEW_LINES;
+    const lines = Array.from({ length: 7 }, (_, i) => `src/a.ts:${i + 1}:abc|hit ${i + 1}`);
+    const rendered = textOf(tool().renderResult(makeResult(lines), {}, theme, { cwd: process.cwd() }));
+    expect(rendered).toContain("↳ 7 matches returned");
+    expect(rendered).toContain("… (2 earlier lines");
+    expect(rendered).toContain("hit 7");
+    expect(rendered).toContain("hit 3");
+    expect(rendered).not.toContain("hit 2");
+  });
+
+  it("restores content-free collapsed output when previewLines=0", () => {
+    process.env.PI_HASHLINE_PREVIEW_LINES = "0";
+    const rendered = textOf(tool().renderResult(makeResult(["src/a.ts:1:abc|hit"]), {}, theme, { cwd: process.cwd() }));
+    expect(rendered).toBe("↳ 1 match returned • Ctrl+O to expand");
+  });
+
+  it("keeps the expanded per-file count list unchanged", () => {
+    process.env.PI_HASHLINE_PREVIEW_LINES = "0";
+    const rendered = textOf(tool().renderResult(makeResult(["src/a.ts:1:abc|hit"]), { expanded: true }, theme, { expanded: true, cwd: process.cwd() }));
+    expect(rendered).toContain("src/a.ts (1)");
+  });
+});

--- a/tests/package-version.test.ts
+++ b/tests/package-version.test.ts
@@ -5,9 +5,9 @@ const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
 const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
 
 describe("package version", () => {
-  it("is bumped for the 0.9.2 release", () => {
-    expect(packageJson.version).toBe("0.9.2");
-    expect(packageLock.version).toBe("0.9.2");
-    expect(packageLock.packages[""].version).toBe("0.9.2");
+  it("is bumped for the 0.10.0 release", () => {
+    expect(packageJson.version).toBe("0.10.0");
+    expect(packageLock.version).toBe("0.10.0");
+    expect(packageLock.packages[""].version).toBe("0.10.0");
   });
 });

--- a/tests/preview-lines-settings.test.ts
+++ b/tests/preview-lines-settings.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import {
+  __resetHashlineSettingsPathsForTest,
+  __setHashlineSettingsPathsForTest,
+  resolveHashlineJsonSettings,
+} from "../src/hashline-settings.js";
+
+function tempRoot(prefix: string): string {
+  return join(tmpdir(), `${prefix}-${randomBytes(6).toString("hex")}`);
+}
+
+describe("display.previewLines settings validation", () => {
+  const cleanup: string[] = [];
+  afterEach(async () => {
+    __resetHashlineSettingsPathsForTest();
+    await Promise.all(cleanup.map((p) => rm(p, { recursive: true, force: true })));
+    cleanup.length = 0;
+  });
+
+  async function writeProject(root: string, value: unknown): Promise<string> {
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ display: { previewLines: value } }));
+    return projectSettingsPath;
+  }
+
+  it("accepts a positive integer display.previewLines without warnings", async () => {
+    const root = tempRoot("preview-lines-positive");
+    cleanup.push(root);
+    const projectSettingsPath = await writeProject(root, 8);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+    const result = resolveHashlineJsonSettings();
+    expect(result.settings.display?.previewLines).toBe(8);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("accepts display.previewLines = 0 (escape hatch) without warnings", async () => {
+    const root = tempRoot("preview-lines-zero");
+    cleanup.push(root);
+    const projectSettingsPath = await writeProject(root, 0);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+    const result = resolveHashlineJsonSettings();
+    expect(result.settings.display?.previewLines).toBe(0);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("warns and drops an invalid display.previewLines value", async () => {
+    const root = tempRoot("preview-lines-invalid");
+    cleanup.push(root);
+    const projectSettingsPath = await writeProject(root, -2);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+    const result = resolveHashlineJsonSettings();
+    expect(result.settings).toEqual({});
+    expect(result.warnings.map((w) => w.path)).toEqual(["display.previewLines"]);
+  });
+});

--- a/tests/preview-model-output-invariance.test.ts
+++ b/tests/preview-model-output-invariance.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import { registerBashRendererTool } from "../src/bash-renderer.js";
+import { registerGrepTool } from "../src/grep.js";
+
+const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
+function textOf(component: any, width = 120): string { return component?.text ?? component?.render?.(width)?.join("\n") ?? ""; }
+
+function bashTool(): any {
+  let registered: any;
+  registerBashRendererTool({ registerTool(def: any) { registered = def; } } as any, { createBuiltInBashTool: () => ({ execute: async () => ({ content: [] }), parameters: {} }) });
+  return registered;
+}
+function grepTool(): any { let registered: any; registerGrepTool({ registerTool(def: any) { registered = def; } } as any, {} as any); return registered; }
+
+describe("collapsed preview does not mutate model-facing output", () => {
+  const originalEnv = process.env.PI_HASHLINE_PREVIEW_LINES;
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.PI_HASHLINE_PREVIEW_LINES;
+    else process.env.PI_HASHLINE_PREVIEW_LINES = originalEnv;
+  });
+
+  it("leaves bash result content and details untouched", () => {
+    delete process.env.PI_HASHLINE_PREVIEW_LINES;
+    const text = ["l1", "l2", "l3", "l4", "l5", "l6", "l7"].join("\n");
+    const result: any = { content: [{ type: "text", text }], details: { bashOriginalOutput: { path: "/tmp/x" }, rtkCompaction: { applied: true } } };
+    const beforeContent = JSON.stringify(result.content);
+    const beforeDetails = JSON.stringify(result.details);
+    textOf(bashTool().renderResult(result, {}, theme, {}));
+    expect(JSON.stringify(result.content)).toBe(beforeContent);
+    expect(JSON.stringify(result.details)).toBe(beforeDetails);
+  });
+
+  it("leaves grep result content and details untouched", () => {
+    delete process.env.PI_HASHLINE_PREVIEW_LINES;
+    const cwd = process.cwd();
+    const lines = Array.from({ length: 7 }, (_, i) => `src/a.ts:${i + 1}:abc|hit ${i + 1}`);
+    const result: any = { content: [{ type: "text", text: lines.join("\n") }], details: { ptcValue: { tool: "grep", summary: false, totalMatches: 7, records: [{ path: `${cwd}/src/a.ts`, kind: "match" }] } } };
+    const beforeContent = JSON.stringify(result.content);
+    const beforeDetails = JSON.stringify(result.details);
+    textOf(grepTool().renderResult(result, {}, theme, { cwd }));
+    expect(JSON.stringify(result.content)).toBe(beforeContent);
+    expect(JSON.stringify(result.details)).toBe(beforeDetails);
+  });
+
+  it("keeps RTK compression and Bash context guard out of the renderResult paths", () => {
+    const bashSrc = readFileSync(new URL("../src/bash-renderer.ts", import.meta.url), "utf8");
+    const grepSrc = readFileSync(new URL("../src/grep.ts", import.meta.url), "utf8");
+    for (const src of [bashSrc, grepSrc]) {
+      expect(src).not.toContain("applyBashContextGuard");
+      expect(src).not.toContain("runRtk");
+    }
+  });
+});

--- a/tests/read-preview-renderer.test.ts
+++ b/tests/read-preview-renderer.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { registerReadTool } from "../src/read.js";
+
+const theme = { fg: (_: string, text: string) => text, bold: (text: string) => text };
+function tool(): any { let registered: any; registerReadTool({ registerTool(def: any) { registered = def; } } as any, {} as any); return registered; }
+function textOf(component: any, width = 80): string { return component?.text ?? component?.render?.(width)?.join("\n") ?? ""; }
+
+function makeResult(lineCount: number): any {
+  const lines = Array.from({ length: lineCount }, (_, i) => `${i + 1}:a${i}|line ${i + 1}`);
+  return {
+    content: [{ type: "text", text: lines.join("\n") }],
+    details: { ptcValue: { tool: "read", range: { startLine: 1, endLine: lineCount, totalLines: lineCount }, truncation: null, symbol: null, map: { requested: false, appended: false }, warnings: [] } },
+  };
+}
+
+describe("read collapsed tail preview", () => {
+  const originalEnv = process.env.PI_HASHLINE_PREVIEW_LINES;
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.PI_HASHLINE_PREVIEW_LINES;
+    else process.env.PI_HASHLINE_PREVIEW_LINES = originalEnv;
+  });
+
+  it("shows the last 5 hashlined lines plus an earlier-lines hint", () => {
+    delete process.env.PI_HASHLINE_PREVIEW_LINES;
+    const rendered = textOf(tool().renderResult(makeResult(7), {}, theme, {}));
+    expect(rendered).toContain("↳ loaded 7 lines");
+    expect(rendered).toContain("… (2 earlier lines");
+    expect(rendered).toContain("7:a6|line 7");
+    expect(rendered).toContain("3:a2|line 3");
+    expect(rendered).not.toContain("2:a1|line 2");
+  });
+
+  it("restores content-free collapsed output when previewLines=0", () => {
+    process.env.PI_HASHLINE_PREVIEW_LINES = "0";
+    const rendered = textOf(tool().renderResult(makeResult(3), {}, theme, {}));
+    expect(rendered).toBe("↳ loaded 3 lines • Ctrl+O to expand");
+  });
+
+  it("does not mutate model-facing text or ptcValue", () => {
+    delete process.env.PI_HASHLINE_PREVIEW_LINES;
+    const result = makeResult(7);
+    const beforeText = result.content[0].text;
+    const beforePtc = JSON.stringify(result.details.ptcValue);
+    tool().renderResult(result, {}, theme, {});
+    expect(result.content[0].text).toBe(beforeText);
+    expect(JSON.stringify(result.details.ptcValue)).toBe(beforePtc);
+  });
+});

--- a/tests/read-render-tui.test.ts
+++ b/tests/read-render-tui.test.ts
@@ -17,7 +17,7 @@ describe("read TUI renderer", () => {
   it("uses compact call and collapsed summary by default", () => {
     setCapabilities({ images: null, trueColor: true, hyperlinks: false });
     expect(textOf(tool().renderCall({ path: "src/edit.ts", offset: 120, limit: 61 }, theme))).toBe("read src/edit.ts:120-180");
-    expect(textOf(tool().renderResult(result, {}, theme, {}))).toBe("↳ loaded 1 line • Ctrl+O to expand");
+    expect(textOf(tool().renderResult(result, {}, theme, {}))).toBe("↳ loaded 1 line\n1:abc|export function veryLongName(argumentOne: string, argumentTwo: string): void {}");
   });
 
   it("wraps the read path title in an OSC 8 hyperlink when supported", () => {

--- a/tests/resolve-preview-lines.test.ts
+++ b/tests/resolve-preview-lines.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import {
+  __resetHashlineSettingsPathsForTest,
+  __setHashlineSettingsPathsForTest,
+  resolvePreviewLines,
+} from "../src/hashline-settings.js";
+
+function tempRoot(prefix: string): string {
+  return join(tmpdir(), `${prefix}-${randomBytes(6).toString("hex")}`);
+}
+
+describe("resolvePreviewLines", () => {
+  const cleanup: string[] = [];
+  const originalEnv = process.env.PI_HASHLINE_PREVIEW_LINES;
+  afterEach(async () => {
+    if (originalEnv === undefined) delete process.env.PI_HASHLINE_PREVIEW_LINES;
+    else process.env.PI_HASHLINE_PREVIEW_LINES = originalEnv;
+    __resetHashlineSettingsPathsForTest();
+    await Promise.all(cleanup.map((p) => rm(p, { recursive: true, force: true })));
+    cleanup.length = 0;
+  });
+
+  it("defaults to 5 when nothing is configured", () => {
+    delete process.env.PI_HASHLINE_PREVIEW_LINES;
+    const root = tempRoot("preview-default");
+    cleanup.push(root);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath: join(root, "repo/.pi/hashline-readmap/settings.json"),
+    });
+    expect(resolvePreviewLines()).toBe(5);
+  });
+
+  it("uses the JSON value when env is unset", async () => {
+    delete process.env.PI_HASHLINE_PREVIEW_LINES;
+    const root = tempRoot("preview-json");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ display: { previewLines: 3 } }));
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+    expect(resolvePreviewLines()).toBe(3);
+  });
+
+  it("lets PI_HASHLINE_PREVIEW_LINES override JSON, including 0", async () => {
+    process.env.PI_HASHLINE_PREVIEW_LINES = "0";
+    const root = tempRoot("preview-env-over-json");
+    cleanup.push(root);
+    const projectSettingsPath = join(root, "repo/.pi/hashline-readmap/settings.json");
+    await mkdir(join(projectSettingsPath, ".."), { recursive: true });
+    await writeFile(projectSettingsPath, JSON.stringify({ display: { previewLines: 9 } }));
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath,
+    });
+    expect(resolvePreviewLines()).toBe(0);
+  });
+
+  it("ignores an invalid env value and falls through to default", () => {
+    process.env.PI_HASHLINE_PREVIEW_LINES = "abc";
+    const root = tempRoot("preview-env-invalid");
+    cleanup.push(root);
+    __setHashlineSettingsPathsForTest({
+      globalSettingsPath: join(root, "home/.pi/agent/hashline-readmap/settings.json"),
+      projectSettingsPath: join(root, "repo/.pi/hashline-readmap/settings.json"),
+    });
+    expect(resolvePreviewLines()).toBe(5);
+  });
+});

--- a/tests/search-render-tui.test.ts
+++ b/tests/search-render-tui.test.ts
@@ -19,7 +19,7 @@ describe("search TUI renderers", () => {
     const grep = capture(registerGrepTool as any);
     expect(textOf(grep.renderCall({ pattern: "diffData", path: "src" }, theme))).toBe("grep /diffData/ in src");
     const result = { content: [{ type: "text", text: "src/a.ts:1:abc|diffData" }], details: { ptcValue: { tool: "grep", summary: false, totalMatches: 1, records: [{ path: `${process.cwd()}/src/a.ts`, kind: "match" }] } } };
-    expect(textOf(grep.renderResult(result, {}, theme, { cwd: process.cwd() }))).toBe("↳ 1 match returned • Ctrl+O to expand");
+    expect(textOf(grep.renderResult(result, {}, theme, { cwd: process.cwd() }))).toBe("↳ 1 match returned • Ctrl+O to expand\nsrc/a.ts:1:abc|diffData");
     expect(textOf(grep.renderResult(result, { expanded: true }, theme, { expanded: true, cwd: process.cwd() }))).toContain("src/a.ts (1)");
   });
 


### PR DESCRIPTION
## Summary

Collapsed `bash`, `read`, and `grep` TUI results were content-free — just a summary line plus a `• Ctrl+O to expand` affordance — so the operator had no glanceable signal about what a tool returned without expanding every call. This adds a configurable **tail preview**: a collapsed result now shows the existing summary/badge line followed by the last N visual lines of the output body (default 5), with a muted hint when earlier lines are hidden. This matches stock pi's collapsed-result behavior.

The change is **TUI-display-only**. Model-facing tool text, `details.ptcValue`, RTK bash compression, and the Bash context guard are untouched. Reversible to today's content-free behavior via `display.previewLines: 0`. Bumps the package to `0.10.0` so the result is publishable.

## What changed

### Shared preview helper (AC 5–7, 15, 16)
- **`src/tui-render-utils.ts`** — new theme-agnostic helper so all three renderers share one implementation:
  ```ts
  export interface CollapsedPreview { hint: string | null; lines: string[] }
  export function buildCollapsedPreview(
    body: string,
    previewLines: number,
    width: number | undefined,
    options: { hashlines?: boolean } = {},
  ): CollapsedPreview
  ```
  Slices the last `previewLines` raw body lines, then width-clamps via the existing `clampLinesToWidth` (or `wrapReadHashlinesForWidth` when `{ hashlines: true }`, used by `read`). Returns an empty result for `previewLines <= 0` or blank bodies. Builds the earlier-lines hint (`… (K earlier line(s) • Ctrl+O to expand)`) from the existing `EXPAND_HINT` constant.

### Settings + resolver (AC 8–12)
- **`src/hashline-settings.ts`** — new `display?: { previewLines?: number }` field on `HashlineJsonSettings`, plus `isStrictJsonNonNegativeInteger` / `readNonNegative` validators that — unlike the existing `readPositive` — accept `0`. New resolver alongside `resolveEditDiffDisplay`:
  ```ts
  export function resolvePreviewLines(env: NodeJS.ProcessEnv = process.env): number
  ```
  Precedence **env → JSON → default 5**; env is whitespace-trimmed and regex-guarded, invalid values fall through, invalid JSON emits a settings warning.

### Renderer wiring (AC 1–3, 13, 14, 17, 18)
- **`src/bash-renderer.ts`** — collapsed branch builds `[summary, ...hint, ...preview.lines]`; expanded branch isolated and byte-for-byte unchanged.
- **`src/read.ts`** — collapsed branch calls `buildCollapsedPreview(..., { hashlines: true })` so hashline formatting/width wrapping is preserved; expanded branch unchanged.
- **`src/grep.ts`** — collapsed branch appends the tail of the raw match body. `grep` is asymmetric: its *expanded* view renders a per-file count list (distinct content from the collapsed match preview), so the expand affordance is retained when that detail exists and the earlier-lines hint isn't already carrying it.

### Release
- **`package.json` / `package-lock.json`** — `0.9.2 → 0.10.0` (minor: new setting + changed default collapsed render).
- **`CHANGELOG.md`** — `[0.10.0]` release section.
- **`tests/package-version.test.ts`** — version pin updated to `0.10.0`.

### Docs
- **`README.md`** — `display.previewLines` row in the settings table + JSON example, a feature bullet in "Why use it?", and a reworded validation note (the field is the one budget-style knob that also accepts `0`).

## Acceptance criteria

- [x] AC 1–3: collapsed bash/read/grep show summary + last 5 lines (`tests/{bash,read,grep}-preview-renderer.test.ts`).
- [x] AC 4: default preview length 5 (`resolvePreviewLines`, `tests/resolve-preview-lines.test.ts`).
- [x] AC 5–7: tail not head; muted earlier-lines hint reusing `EXPAND_HINT`; no hint/padding when within N (`tests/build-collapsed-preview.test.ts`).
- [x] AC 8–9: `display.previewLines` validated with the strict + warning pattern; accepts `0`.
- [x] AC 10–12: `resolvePreviewLines` env→JSON→default precedence; invalid JSON warns; invalid/empty env ignored.
- [x] AC 13: `previewLines: 0` restores content-free summary only.
- [x] AC 14: expanded rendering byte-for-byte unchanged (bash/read full body, grep per-file count list).
- [x] AC 15–16: read preview via `wrapReadHashlinesForWidth`; all preview lines width-clamped.
- [x] AC 17–18: model-facing text + `details.ptcValue` unchanged; no RTK / Bash-context-guard calls in the renderResult paths (`tests/preview-model-output-invariance.test.ts`).

## Verification

- `npm run typecheck` → exit 0.
- `npm test` → **395 files / 1674 tests pass**.
- `symbol_graph(buildCollapsedPreview)` confirms the helper's only callers are the three renderers; each call site has a dedicated test and the shared helper has `tests/build-collapsed-preview.test.ts`.
- Codex review run against `main`: 2 findings — adopted both (grep expand-affordance discoverability for the per-file count list; a README self-contradiction on `display.previewLines` accepting `0`). The grep fix is pinned by `tests/search-render-tui.test.ts`.

## Behavior change

Collapsed `bash`/`read`/`grep` results gain a tail preview by default (last 5 lines). Expanded rendering and all model-facing output are unchanged. Set `display.previewLines: 0` (or `PI_HASHLINE_PREVIEW_LINES=0`) to restore the prior content-free collapsed summary.

## Follow-ups (out of scope)

- `edit`/`write` diff rendering does not honor `previewLines` (still governed by `edit.diffDisplay`).
- No head+tail preview mode; tail only this slice. The tail is sliced by **raw** lines then wrapped, so a single very long `read` line can wrap to more than N visual rows — intentional, matching stock pi.

Closes #214
