### PR TITLE
feat: atomic file writes with symlink/hard-link preservation (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-18
+
+### Changed
+- `write` and `edit` now write files atomically via a shared `src/fs-write.ts` helper (`resolveMutationTargetPath` + `writeFileAtomically`): content is written to a same-directory temp file (`open` with `wx`/`0o600`) and `rename`d over the target, so a target is never left partially written. Symlinked targets are written through to their real target and the symlink is preserved; hard-linked targets (`nlink > 1`) are updated in place so the inode and all links are kept. Existing files preserve their prior permission mode; newly created files keep the OS/umask default. The file-mutation queue is now keyed on the resolved target path so symlink/target aliases serialize. Atomic-write/rename failures (including `EXDEV`) surface through the existing `fs-error` envelope with `fsCode`/`fsMessage` — no new error codes (#215).
+- Behavior change: because edits/writes now land via a directory-level `rename`, editing or overwriting a read-only file (`0o444`) that lives in a writable directory now succeeds (previously this failed with `permission-denied`). A write is only refused when the **containing directory** is not writable (#215).
+
 ## [0.10.0] - 2026-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ write({ path: "src/new-module.ts", content: "export const demo = 1;\n" })
 
 `write` creates parent directories automatically and returns hashlined output for immediate refinement.
 
+Both `write` and `edit` write atomically (temp file in the same directory, then `rename` over the target), so a target file is never observed half-written. Symlinked targets are written through to their real target and the symlink is preserved. Hard-linked targets (`nlink > 1`) are the one exception: to keep the shared inode and all links, they are updated in place rather than via temp+rename, so that single case is not torn-write atomic. Existing files keep their permission mode; newly created files use the OS/umask default.
+
 ### Navigate a large file
 
 ```text

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {

--- a/prompts/edit.md
+++ b/prompts/edit.md
@@ -71,6 +71,7 @@ If `edit` auto-relocates an anchor, check the warning and verify the edit landed
 - `no-op` means the requested edit matched the current file already or produced identical content.
 - A whitespace-only warning means formatting changed but behavior probably did not.
 - A `replace`-only success may include a reminder to prefer anchored edits next time.
+- Edits are written atomically (temp file + rename); symlinks are written through to their real target and preserved, and hard links are updated in place.
 
 Syntax validation runs before writing when supported:
 - Supported: Rust, C++, C headers, Java.

--- a/prompts/write.md
+++ b/prompts/write.md
@@ -6,6 +6,8 @@ Use `write` to create a file or intentionally replace a whole file. For small ch
 
 Existing files are overwritten without confirmation. Binary-looking content is written, but hashlines are not generated, so there are no anchors to feed into `edit`.
 
+Writes are atomic: content is written to a temporary file in the same directory and renamed over the target, so the file is never left partially written. Symlinked targets are written through to their real target (the symlink is preserved). Hard-linked targets (`nlink > 1`) are the exception — they are updated in place to preserve the shared inode and all links, so that case is not temp+rename atomic. Existing files keep their permission mode; new files use the OS/umask default.
+
 ## Parameters
 
 - `path` — relative or absolute file path.

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -2,11 +2,12 @@ import { withFileMutationQueue, type ExtensionAPI, type EditToolDetails, type To
 import { Type } from "@sinclair/typebox";
 import type { Static } from "@sinclair/typebox";
 import { defineToolPromptMetadata } from "./tool-prompt-metadata.js";
-import { readFile as fsReadFile, writeFile as fsWriteFile } from "fs/promises";
+import { readFile as fsReadFile } from "fs/promises";
 import { createPatch } from "diff";
 import { detectLineEnding, generateCompactOrFullDiff, normalizeToLF, replaceText, restoreLineEndings, stripBom } from "./edit-diff.js";
 import { HashlineMismatchError, applyHashlineEdits, computeLineHash, ensureHashInit, parseLineRef, type HashlineEditItem, escapeControlCharsForDisplay } from "./hashline.js";
 import { resolveToCwd } from "./path-utils.js";
+import { resolveMutationTargetPath, writeFileAtomically } from "./fs-write.js";
 import { throwIfAborted } from "./runtime.js";
 import { buildEditOutput } from "./edit-output.js";
 import { classifyEdit, isDifftAvailable, runDifftastic } from "./edit-classify.js";
@@ -158,7 +159,8 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			const absolutePath = resolveToCwd(path, ctx.cwd);
 			throwIfAborted(signal);
 			try {
-				return await withFileMutationQueue(absolutePath, async () => {
+				const queueKey = await resolveMutationTargetPath(absolutePath);
+				return await withFileMutationQueue(queueKey, async () => {
 				throwIfAborted(signal);
 			if (options.wasReadInSession && !options.wasReadInSession(absolutePath)) {
 				const message = [
@@ -511,7 +513,7 @@ export function registerEditTool(pi: ExtensionAPI, options: EditToolOptions = {}
 			}
 			const writeContent = bom + restoreLineEndings(result, originalEnding);
 			try {
-				await fsWriteFile(absolutePath, writeContent, "utf-8");
+				await writeFileAtomically(absolutePath, writeContent);
 			} catch (err: any) {
 				const wrapped = wrapWriteError(err, path);
 				const code =

--- a/src/fs-write.ts
+++ b/src/fs-write.ts
@@ -1,0 +1,95 @@
+import { lstat, mkdir, open, readlink, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { dirname, join, parse, resolve, sep } from "node:path";
+
+export async function resolveMutationTargetPath(path: string): Promise<string> {
+  const absolutePath = resolve(path);
+  const { root } = parse(absolutePath);
+  const parts = absolutePath
+    .slice(root.length)
+    .split(sep)
+    .filter((part) => part.length > 0);
+  const visitedSymlinks = new Set<string>();
+
+  async function resolveFromParts(currentPath: string, remainingParts: string[]): Promise<string> {
+    if (remainingParts.length === 0) {
+      return currentPath;
+    }
+
+    const [nextPart, ...tail] = remainingParts;
+    const candidatePath = join(currentPath, nextPart);
+
+    try {
+      const candidateStats = await lstat(candidatePath);
+      if (!candidateStats.isSymbolicLink()) {
+        return resolveFromParts(candidatePath, tail);
+      }
+
+      if (visitedSymlinks.has(candidatePath)) {
+        const error = new Error(`Too many symbolic links while resolving ${path}`) as NodeJS.ErrnoException;
+        error.code = "ELOOP";
+        throw error;
+      }
+      visitedSymlinks.add(candidatePath);
+
+      const linkTargetPath = resolve(dirname(candidatePath), await readlink(candidatePath));
+      const targetParts = linkTargetPath
+        .slice(parse(linkTargetPath).root.length)
+        .split(sep)
+        .filter((part) => part.length > 0);
+      return resolveFromParts(parse(linkTargetPath).root, [...targetParts, ...tail]);
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+        return join(candidatePath, ...tail);
+      }
+      throw error;
+    }
+  }
+
+  return resolveFromParts(root, parts);
+}
+
+export async function writeFileAtomically(path: string, content: string): Promise<void> {
+  const targetPath = await resolveMutationTargetPath(path);
+
+  let existingStats: Awaited<ReturnType<typeof stat>> | null = null;
+  try {
+    existingStats = await stat(targetPath);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  // Hard links: update the inode in place so every link sees the new content.
+  if (existingStats && existingStats.nlink > 1) {
+    await writeFile(targetPath, content, "utf-8");
+    return;
+  }
+
+  const dir = dirname(targetPath);
+  await mkdir(dir, { recursive: true });
+  const tempPath = join(dir, `.tmp-${randomUUID()}`);
+  const tempHandle = await open(tempPath, "wx", 0o600);
+  try {
+    try {
+      await tempHandle.writeFile(content, "utf-8");
+      if (existingStats) {
+        // Overwrite: keep the target's prior permission bits (AC 7).
+        await tempHandle.chmod(existingStats.mode & 0o7777);
+      } else {
+        // New file: land at the OS/umask default (AC 8), not the temp's 0o600.
+        const umask = process.umask();
+        process.umask(umask); // restore immediately; we only wanted to read it
+        await tempHandle.chmod(0o666 & ~umask);
+      }
+    } finally {
+      await tempHandle.close();
+    }
+    await rename(tempPath, targetPath);
+  } catch (error: unknown) {
+    // Best-effort cleanup so write/chmod/rename failures leave no orphan temp (AC 12).
+    await unlink(tempPath).catch(() => {});
+    throw error;
+  }
+}

--- a/src/write.ts
+++ b/src/write.ts
@@ -1,9 +1,10 @@
 import { withFileMutationQueue, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, relative } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { relative } from "node:path";
 import { resolveToCwd } from "./path-utils.js";
+import { resolveMutationTargetPath, writeFileAtomically } from "./fs-write.js";
 import { ensureHashInit, formatHashlineDisplay } from "./hashline.js";
 import { buildPtcError, buildPtcLine, buildPtcWarning, type PtcLine, type PtcWarning } from "./ptc-value.js";
 import { looksLikeBinary } from "./binary-detect.js";
@@ -210,16 +211,9 @@ export async function executeWrite(opts: {
   const previousContent = readPreviousTextForDiff(filePath);
   const existedBeforeWrite = existsSync(filePath);
 
-  // Create parent directories
+  // Atomic write (handles parent-dir creation, symlinks, hard links)
   try {
-    mkdirSync(dirname(filePath), { recursive: true });
-  } catch (err: any) {
-    err.__phase = "mkdir";
-    throw err;
-  }
-  // Write file
-  try {
-    writeFileSync(filePath, content, "utf-8");
+    await writeFileAtomically(filePath, content);
   } catch (err: any) {
     err.__phase = "write";
     throw err;
@@ -337,7 +331,17 @@ export function registerWriteTool(pi: ExtensionAPI, options: WriteToolOptions = 
     async execute(_toolCallId: string, params: { path: string; content: string; map?: boolean }, _signal: AbortSignal | undefined, _onUpdate: any, ctx: any): Promise<any> {
       const cwd = ctx?.cwd ?? process.cwd();
       const absolutePath = resolveToCwd(params.path, cwd);
-      return withFileMutationQueue(absolutePath, async () => {
+      // Best-effort: resolve the symlink/hard-link target so aliases serialize on
+      // one queue key. If resolution itself fails (e.g. ELOOP), fall back to the
+      // literal path; writeFileAtomically re-resolves and surfaces the error
+      // through the structured fs-error envelope in the catch below.
+      let queueKey = absolutePath;
+      try {
+        queueKey = await resolveMutationTargetPath(absolutePath);
+      } catch {
+        // keep queueKey = absolutePath
+      }
+      return withFileMutationQueue(queueKey, async () => {
       let result: WriteResult;
       try {
         result = await executeWrite({

--- a/tests/edit-atomic-fs-errors.test.ts
+++ b/tests/edit-atomic-fs-errors.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+
+const fsMock = vi.hoisted(() => ({ readFile: vi.fn() }));
+const atomicMock = vi.hoisted(() => ({
+  writeFileAtomically: vi.fn(),
+  resolveMutationTargetPath: vi.fn(async (p: string) => p),
+}));
+
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  return { ...actual, readFile: fsMock.readFile };
+});
+
+vi.mock("../src/fs-write.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/fs-write.js")>();
+  return {
+    ...actual,
+    writeFileAtomically: atomicMock.writeFileAtomically,
+    resolveMutationTargetPath: atomicMock.resolveMutationTargetPath,
+  };
+});
+
+async function captureEditTool() {
+  const { registerEditTool } = await import("../src/edit.js");
+  let tool: any;
+  registerEditTool({ registerTool(def: any) { tool = def; } } as any);
+  return tool;
+}
+
+function err(code: string, msg: string): NodeJS.ErrnoException {
+  const e: any = new Error(msg);
+  e.code = code;
+  return e;
+}
+
+describe("edit atomic-write fs-error envelope", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    await ensureHashInit();
+    fsMock.readFile.mockReset();
+    atomicMock.writeFileAtomically.mockReset();
+    atomicMock.resolveMutationTargetPath.mockImplementation(async (p: string) => p);
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("EXDEV from writeFileAtomically -> fs-error with fsCode meta", async () => {
+    const tool = await captureEditTool();
+    fsMock.readFile.mockResolvedValue(Buffer.from("alpha\nbeta", "utf8"));
+    atomicMock.writeFileAtomically.mockRejectedValue(err("EXDEV", "EXDEV: cross-device link"));
+    const anchor = `1:${computeLineHash(1, "alpha")}`;
+    const result = await tool.execute(
+      "edit-call",
+      { path: "/virtual/x.txt", edits: [{ set_line: { anchor, new_text: "ALPHA" } }] },
+      new AbortController().signal, () => {}, { cwd: "/" },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.details.ptcValue.error.code).toBe("fs-error");
+    expect(result.details.ptcValue.error.details?.fsCode).toBe("EXDEV");
+  });
+
+  it("EACCES from writeFileAtomically -> permission-denied", async () => {
+    const tool = await captureEditTool();
+    fsMock.readFile.mockResolvedValue(Buffer.from("alpha\nbeta", "utf8"));
+    atomicMock.writeFileAtomically.mockRejectedValue(err("EACCES", "EACCES: denied"));
+    const anchor = `1:${computeLineHash(1, "alpha")}`;
+    const result = await tool.execute(
+      "edit-call",
+      { path: "/virtual/x.txt", edits: [{ set_line: { anchor, new_text: "ALPHA" } }] },
+      new AbortController().signal, () => {}, { cwd: "/" },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.details.ptcValue.error.code).toBe("permission-denied");
+  });
+
+  it("no new PTC error codes were introduced", async () => {
+    const { PTC_ERROR_CODES } = await import("../src/ptc-error-codes.js");
+    const codes = Object.keys(PTC_ERROR_CODES);
+    expect(codes).toContain("fs-error");
+    expect(codes).toContain("permission-denied");
+    // guard: atomic-write work must not add a bespoke code
+    expect(codes).not.toContain("atomic-write-failed");
+    expect(codes).not.toContain("rename-failed");
+  });
+});

--- a/tests/edit-post-verify-default.test.ts
+++ b/tests/edit-post-verify-default.test.ts
@@ -3,12 +3,25 @@ import { computeLineHash, ensureHashInit } from "../src/hashline.js";
 
 const fsMock = vi.hoisted(() => ({
   readFile: vi.fn(),
-  writeFile: vi.fn(),
+}));
+
+const atomicMock = vi.hoisted(() => ({
+  writeFileAtomically: vi.fn(),
+  resolveMutationTargetPath: vi.fn(async (p: string) => p),
 }));
 
 vi.mock("fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fs/promises")>();
-  return { ...actual, readFile: fsMock.readFile, writeFile: fsMock.writeFile };
+  return { ...actual, readFile: fsMock.readFile };
+});
+
+vi.mock("../src/fs-write.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/fs-write.js")>();
+  return {
+    ...actual,
+    writeFileAtomically: atomicMock.writeFileAtomically,
+    resolveMutationTargetPath: atomicMock.resolveMutationTargetPath,
+  };
 });
 
 import { registerEditTool } from "../src/edit.js";
@@ -24,7 +37,9 @@ describe("edit postEditVerify default", () => {
   beforeEach(async () => {
     await ensureHashInit();
     fsMock.readFile.mockReset();
-    fsMock.writeFile.mockReset();
+    atomicMock.writeFileAtomically.mockReset();
+    atomicMock.writeFileAtomically.mockResolvedValue(undefined);
+    atomicMock.resolveMutationTargetPath.mockImplementation(async (p: string) => p);
   });
 
   it("documents the explicit option and leaves verification off when absent", async () => {
@@ -33,7 +48,6 @@ describe("edit postEditVerify default", () => {
     expect(tool.parameters.properties.postEditVerify.type).toBe("boolean");
 
     fsMock.readFile.mockResolvedValue(Buffer.from("alpha\nbeta", "utf8"));
-    fsMock.writeFile.mockResolvedValue(undefined);
     const anchor = `1:${computeLineHash(1, "alpha")}`;
 
     const result = await tool.execute(
@@ -45,7 +59,7 @@ describe("edit postEditVerify default", () => {
     );
 
     expect(result.isError).toBeUndefined();
-    expect(fsMock.writeFile).toHaveBeenCalledWith("/tmp/post-edit-default.txt", "ALPHA\nbeta", "utf-8");
+    expect(atomicMock.writeFileAtomically).toHaveBeenCalledWith("/tmp/post-edit-default.txt", "ALPHA\nbeta");
     expect(fsMock.readFile).toHaveBeenCalledTimes(1);
     expect(result.content[0].text).toContain("Edited /tmp/post-edit-default.txt");
     expect(result.details.diff).toContain("alpha");

--- a/tests/edit-post-verify-mismatch.test.ts
+++ b/tests/edit-post-verify-mismatch.test.ts
@@ -3,12 +3,25 @@ import { computeLineHash, ensureHashInit } from "../src/hashline.js";
 
 const fsMock = vi.hoisted(() => ({
   readFile: vi.fn(),
-  writeFile: vi.fn(),
+}));
+
+const atomicMock = vi.hoisted(() => ({
+  writeFileAtomically: vi.fn(),
+  resolveMutationTargetPath: vi.fn(async (p: string) => p),
 }));
 
 vi.mock("fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fs/promises")>();
-  return { ...actual, readFile: fsMock.readFile, writeFile: fsMock.writeFile };
+  return { ...actual, readFile: fsMock.readFile };
+});
+
+vi.mock("../src/fs-write.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/fs-write.js")>();
+  return {
+    ...actual,
+    writeFileAtomically: atomicMock.writeFileAtomically,
+    resolveMutationTargetPath: atomicMock.resolveMutationTargetPath,
+  };
 });
 
 import { registerEditTool } from "../src/edit.js";
@@ -24,7 +37,9 @@ describe("edit postEditVerify mismatch", () => {
   beforeEach(async () => {
     await ensureHashInit();
     fsMock.readFile.mockReset();
-    fsMock.writeFile.mockReset();
+    atomicMock.writeFileAtomically.mockReset();
+    atomicMock.writeFileAtomically.mockResolvedValue(undefined);
+    atomicMock.resolveMutationTargetPath.mockImplementation(async (p: string) => p);
   });
 
   it("returns a structured error when persisted content differs after the write completed", async () => {
@@ -32,7 +47,6 @@ describe("edit postEditVerify mismatch", () => {
     fsMock.readFile
       .mockResolvedValueOnce(Buffer.from("alpha\nbeta", "utf8"))
       .mockResolvedValueOnce("tampered\nbeta");
-    fsMock.writeFile.mockResolvedValue(undefined);
     const anchor = `1:${computeLineHash(1, "alpha")}`;
 
     const result = await tool.execute(
@@ -43,7 +57,7 @@ describe("edit postEditVerify mismatch", () => {
       { cwd: process.cwd() },
     );
 
-    expect(fsMock.writeFile).toHaveBeenCalledTimes(1);
+    expect(atomicMock.writeFileAtomically).toHaveBeenCalledTimes(1);
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("write completed but post-edit verification did not confirm the intended content");
     expect(result.details.ptcValue.ok).toBe(false);

--- a/tests/edit-post-verify-prewrite-guards.test.ts
+++ b/tests/edit-post-verify-prewrite-guards.test.ts
@@ -3,12 +3,25 @@ import { computeLineHash, ensureHashInit } from "../src/hashline.js";
 
 const fsMock = vi.hoisted(() => ({
   readFile: vi.fn(),
-  writeFile: vi.fn(),
+}));
+
+const atomicMock = vi.hoisted(() => ({
+  writeFileAtomically: vi.fn(),
+  resolveMutationTargetPath: vi.fn(async (p: string) => p),
 }));
 
 vi.mock("fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fs/promises")>();
-  return { ...actual, readFile: fsMock.readFile, writeFile: fsMock.writeFile };
+  return { ...actual, readFile: fsMock.readFile };
+});
+
+vi.mock("../src/fs-write.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/fs-write.js")>();
+  return {
+    ...actual,
+    writeFileAtomically: atomicMock.writeFileAtomically,
+    resolveMutationTargetPath: atomicMock.resolveMutationTargetPath,
+  };
 });
 
 import { registerEditTool } from "../src/edit.js";
@@ -24,13 +37,14 @@ describe("edit postEditVerify pre-write guards", () => {
   beforeEach(async () => {
     await ensureHashInit();
     fsMock.readFile.mockReset();
-    fsMock.writeFile.mockReset();
+    atomicMock.writeFileAtomically.mockReset();
+    atomicMock.writeFileAtomically.mockResolvedValue(undefined);
+    atomicMock.resolveMutationTargetPath.mockImplementation(async (p: string) => p);
   });
 
   it("does not write or read back when a pre-write no-op guard rejects the edit", async () => {
     const tool = captureEditTool();
     fsMock.readFile.mockResolvedValue(Buffer.from("alpha\nbeta", "utf8"));
-    fsMock.writeFile.mockResolvedValue(undefined);
     const anchor = `1:${computeLineHash(1, "alpha")}`;
 
     const result = await tool.execute(
@@ -43,7 +57,22 @@ describe("edit postEditVerify pre-write guards", () => {
 
     expect(result.isError).toBe(true);
     expect(result.details.ptcValue.error.code).toBe("no-op");
-    expect(fsMock.writeFile).not.toHaveBeenCalled();
+    expect(atomicMock.writeFileAtomically).not.toHaveBeenCalled();
     expect(fsMock.readFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes a real edit through writeFileAtomically", async () => {
+    const tool = captureEditTool();
+    fsMock.readFile.mockResolvedValue(Buffer.from("alpha\nbeta", "utf8"));
+    const anchor = `1:${computeLineHash(1, "alpha")}`;
+    const result = await tool.execute(
+      "edit-call",
+      { path: "/virtual/x.txt", edits: [{ set_line: { anchor, new_text: "ALPHA" } }] },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/" },
+    );
+    expect(result.isError).toBeFalsy();
+    expect(atomicMock.writeFileAtomically).toHaveBeenCalledWith("/virtual/x.txt", expect.stringContaining("ALPHA"));
   });
 });

--- a/tests/edit-post-verify-read-failure.test.ts
+++ b/tests/edit-post-verify-read-failure.test.ts
@@ -3,12 +3,25 @@ import { computeLineHash, ensureHashInit } from "../src/hashline.js";
 
 const fsMock = vi.hoisted(() => ({
   readFile: vi.fn(),
-  writeFile: vi.fn(),
+}));
+
+const atomicMock = vi.hoisted(() => ({
+  writeFileAtomically: vi.fn(),
+  resolveMutationTargetPath: vi.fn(async (p: string) => p),
 }));
 
 vi.mock("fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fs/promises")>();
-  return { ...actual, readFile: fsMock.readFile, writeFile: fsMock.writeFile };
+  return { ...actual, readFile: fsMock.readFile };
+});
+
+vi.mock("../src/fs-write.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/fs-write.js")>();
+  return {
+    ...actual,
+    writeFileAtomically: atomicMock.writeFileAtomically,
+    resolveMutationTargetPath: atomicMock.resolveMutationTargetPath,
+  };
 });
 
 import { registerEditTool } from "../src/edit.js";
@@ -24,7 +37,9 @@ describe("edit postEditVerify read failure", () => {
   beforeEach(async () => {
     await ensureHashInit();
     fsMock.readFile.mockReset();
-    fsMock.writeFile.mockReset();
+    atomicMock.writeFileAtomically.mockReset();
+    atomicMock.writeFileAtomically.mockResolvedValue(undefined);
+    atomicMock.resolveMutationTargetPath.mockImplementation(async (p: string) => p);
   });
 
   it("returns a structured error when read-back fails after the write completed", async () => {
@@ -33,7 +48,6 @@ describe("edit postEditVerify read failure", () => {
     fsMock.readFile
       .mockResolvedValueOnce(Buffer.from("alpha\nbeta", "utf8"))
       .mockRejectedValueOnce(readError);
-    fsMock.writeFile.mockResolvedValue(undefined);
     const anchor = `1:${computeLineHash(1, "alpha")}`;
 
     const result = await tool.execute(
@@ -44,7 +58,7 @@ describe("edit postEditVerify read failure", () => {
       { cwd: process.cwd() },
     );
 
-    expect(fsMock.writeFile).toHaveBeenCalledTimes(1);
+    expect(atomicMock.writeFileAtomically).toHaveBeenCalledTimes(1);
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("write completed but post-edit verification failed");
     expect(result.details.ptcValue.ok).toBe(false);

--- a/tests/edit-post-verify-success.test.ts
+++ b/tests/edit-post-verify-success.test.ts
@@ -3,12 +3,25 @@ import { computeLineHash, ensureHashInit } from "../src/hashline.js";
 
 const fsMock = vi.hoisted(() => ({
   readFile: vi.fn(),
-  writeFile: vi.fn(),
+}));
+
+const atomicMock = vi.hoisted(() => ({
+  writeFileAtomically: vi.fn(),
+  resolveMutationTargetPath: vi.fn(async (p: string) => p),
 }));
 
 vi.mock("fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fs/promises")>();
-  return { ...actual, readFile: fsMock.readFile, writeFile: fsMock.writeFile };
+  return { ...actual, readFile: fsMock.readFile };
+});
+
+vi.mock("../src/fs-write.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/fs-write.js")>();
+  return {
+    ...actual,
+    writeFileAtomically: atomicMock.writeFileAtomically,
+    resolveMutationTargetPath: atomicMock.resolveMutationTargetPath,
+  };
 });
 
 import { registerEditTool } from "../src/edit.js";
@@ -24,7 +37,8 @@ describe("edit postEditVerify success", () => {
   beforeEach(async () => {
     await ensureHashInit();
     fsMock.readFile.mockReset();
-    fsMock.writeFile.mockReset();
+    atomicMock.writeFileAtomically.mockReset();
+    atomicMock.resolveMutationTargetPath.mockImplementation(async (p: string) => p);
   });
 
   it("reads back after a successful opt-in write and preserves the normal success details", async () => {
@@ -33,7 +47,7 @@ describe("edit postEditVerify success", () => {
     fsMock.readFile
       .mockResolvedValueOnce(Buffer.from("alpha\nbeta", "utf8"))
       .mockImplementationOnce(async () => persisted);
-    fsMock.writeFile.mockImplementation(async (_path: string, content: string) => { persisted = content; });
+    atomicMock.writeFileAtomically.mockImplementation(async (_path: string, content: string) => { persisted = content; });
     const anchor = `1:${computeLineHash(1, "alpha")}`;
 
     const result = await tool.execute(
@@ -45,9 +59,9 @@ describe("edit postEditVerify success", () => {
     );
 
     expect(result.isError).toBeUndefined();
-    expect(fsMock.writeFile).toHaveBeenCalledWith("/tmp/post-edit-success.txt", "ALPHA\nbeta", "utf-8");
+    expect(atomicMock.writeFileAtomically).toHaveBeenCalledWith("/tmp/post-edit-success.txt", "ALPHA\nbeta");
     expect(fsMock.readFile).toHaveBeenCalledTimes(2);
-    expect(fsMock.readFile.mock.invocationCallOrder[1]).toBeGreaterThan(fsMock.writeFile.mock.invocationCallOrder[0]);
+    expect(fsMock.readFile.mock.invocationCallOrder[1]).toBeGreaterThan(atomicMock.writeFileAtomically.mock.invocationCallOrder[0]);
     expect(result.content[0].text).toContain("Edited /tmp/post-edit-success.txt");
     expect(result.details.diff).toContain("alpha");
     expect(result.details.diffData).toEqual(result.details.ptcValue.diffData);

--- a/tests/fs-write-atomic.test.ts
+++ b/tests/fs-write-atomic.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  chmod, link, lstat, readFile, readdir, readlink,
+  stat, symlink, writeFile,
+} from "node:fs/promises";
+import { mkdtempSync as mkdtempSyncRoot, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeFileAtomically } from "../src/fs-write.js";
+
+let dir: string;
+
+beforeEach(() => {
+  // realpathSync canonicalizes the temp dir so the symlink/dangling/hard-link
+  // path-equality assertions below match the helper's resolved output. On macOS
+  // tmpdir() is /var/folders/... and /var is a symlink to /private/var, which
+  // resolveMutationTargetPath would otherwise canonicalize.
+  dir = realpathSync(mkdtempSyncRoot(join(tmpdir(), "fs-write-atomic-")));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("writeFileAtomically", () => {
+  it("creates a new file with the given content", async () => {
+    const p = join(dir, "created.txt");
+    await writeFileAtomically(p, "hello\n");
+    expect(await readFile(p, "utf-8")).toBe("hello\n");
+  });
+
+  it("creates parent directories that do not yet exist", async () => {
+    const p = join(dir, "nested", "deep", "file.txt");
+    await writeFileAtomically(p, "deep\n");
+    expect(await readFile(p, "utf-8")).toBe("deep\n");
+  });
+
+  it("overwrites an existing file and leaves no temp files behind", async () => {
+    const p = join(dir, "over.txt");
+    await writeFile(p, "before\n", "utf-8");
+    await writeFileAtomically(p, "after\n");
+    expect(await readFile(p, "utf-8")).toBe("after\n");
+    const entries = await readdir(dir);
+    expect(entries.filter((e) => e.startsWith(".tmp-"))).toEqual([]);
+  });
+
+  it("preserves the target mode when overwriting (0o755 stays 0o755)", async () => {
+    const p = join(dir, "script.sh");
+    await writeFile(p, "echo before\n", "utf-8");
+    await chmod(p, 0o755);
+    await writeFileAtomically(p, "echo after\n");
+    expect((await stat(p)).mode & 0o777).toBe(0o755);
+  });
+
+  it("preserves the target mode under a restrictive umask", async () => {
+    const p = join(dir, "public.txt");
+    await writeFile(p, "before\n", "utf-8");
+    await chmod(p, 0o644);
+    const prev = process.umask(0o077);
+    try {
+      await writeFileAtomically(p, "after\n");
+    } finally {
+      process.umask(prev);
+    }
+    expect((await stat(p)).mode & 0o777).toBe(0o644);
+  });
+
+  it("creates a new file at the umask default mode, not 0o600 (AC 8)", async () => {
+    const p = join(dir, "fresh.txt");
+    const prev = process.umask(0o022);
+    try {
+      await writeFileAtomically(p, "new\n");
+    } finally {
+      process.umask(prev);
+    }
+    expect((await stat(p)).mode & 0o777).toBe(0o644);
+  });
+
+  it("updates a symlink's target without replacing the symlink", async () => {
+    const target = join(dir, "target.txt");
+    const linkPath = join(dir, "linked.txt");
+    await writeFile(target, "before\n", "utf-8");
+    await symlink("target.txt", linkPath);
+    await writeFileAtomically(linkPath, "after\n");
+    expect(await readFile(target, "utf-8")).toBe("after\n");
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);
+    expect(await readlink(linkPath)).toBe("target.txt");
+  });
+
+  it("writes through a dangling symlink chain to the terminal target", async () => {
+    const intermediate = join(dir, "level-2.txt");
+    const top = join(dir, "level-1.txt");
+    const missing = join(dir, "missing.txt");
+    await symlink("missing.txt", intermediate);
+    await symlink("level-2.txt", top);
+    await writeFileAtomically(top, "after\n");
+    expect((await lstat(top)).isSymbolicLink()).toBe(true);
+    expect((await lstat(intermediate)).isSymbolicLink()).toBe(true);
+    expect(await readFile(missing, "utf-8")).toBe("after\n");
+  });
+
+  it("preserves hard links by updating the inode in place", async () => {
+    const primary = join(dir, "primary.txt");
+    const sibling = join(dir, "sibling.txt");
+    await writeFile(primary, "before\n", "utf-8");
+    await link(primary, sibling);
+    const inode = (await stat(primary)).ino;
+    await writeFileAtomically(primary, "after\n");
+    expect(await readFile(primary, "utf-8")).toBe("after\n");
+    expect(await readFile(sibling, "utf-8")).toBe("after\n");
+    expect((await stat(primary)).ino).toBe(inode);
+    expect((await stat(sibling)).ino).toBe(inode);
+  });
+});

--- a/tests/fs-write-permissions.test.ts
+++ b/tests/fs-write-permissions.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const writeFileMock = vi.fn(async () => undefined);
+const handleWriteFileMock = vi.fn(async () => undefined);
+const handleChmodMock = vi.fn(async () => undefined);
+const handleCloseMock = vi.fn(async () => undefined);
+const openMock = vi.fn(async () => ({
+  writeFile: handleWriteFileMock,
+  chmod: handleChmodMock,
+  close: handleCloseMock,
+}));
+const renameMock = vi.fn(async () => undefined);
+const mkdirMock = vi.fn(async () => undefined);
+const unlinkMock = vi.fn(async () => undefined);
+const statMock = vi.fn(async () => ({ mode: 0o100600, nlink: 1 }));
+const lstatMock = vi.fn(async () => ({ isSymbolicLink: () => false }));
+const readlinkMock = vi.fn(async () => "");
+
+vi.mock("node:fs/promises", () => ({
+  lstat: lstatMock,
+  open: openMock,
+  mkdir: mkdirMock,
+  readlink: readlinkMock,
+  rename: renameMock,
+  stat: statMock,
+  unlink: unlinkMock,
+  writeFile: writeFileMock,
+}));
+
+describe("writeFileAtomically permissions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    openMock.mockResolvedValue({
+      writeFile: handleWriteFileMock,
+      chmod: handleChmodMock,
+      close: handleCloseMock,
+    });
+    statMock.mockResolvedValue({ mode: 0o100600, nlink: 1 });
+    lstatMock.mockResolvedValue({ isSymbolicLink: () => false });
+  });
+
+  it("opens a secure temp file (wx, 0o600), writes, chmods to target mode, renames", async () => {
+    const { writeFileAtomically } = await import("../src/fs-write.js");
+    await writeFileAtomically("/tmp/secret.txt", "secret\n");
+    expect(openMock).toHaveBeenCalledWith(expect.stringMatching(/\.tmp-/), "wx", 0o600);
+    expect(handleWriteFileMock).toHaveBeenCalledWith("secret\n", "utf-8");
+    expect(handleChmodMock).toHaveBeenCalledWith(0o600);
+    expect(handleCloseMock).toHaveBeenCalled();
+    expect(renameMock).toHaveBeenCalled();
+    // hard-link in-place path must NOT be taken for nlink === 1
+    expect(writeFileMock).not.toHaveBeenCalled();
+  });
+
+  it("best-effort unlinks the temp file when rename fails", async () => {
+    renameMock.mockRejectedValueOnce(Object.assign(new Error("EXDEV"), { code: "EXDEV" }));
+    const { writeFileAtomically } = await import("../src/fs-write.js");
+    await expect(writeFileAtomically("/tmp/secret.txt", "secret\n")).rejects.toMatchObject({ code: "EXDEV" });
+    expect(unlinkMock).toHaveBeenCalledWith(expect.stringMatching(/\.tmp-/));
+  });
+});

--- a/tests/fs-write-resolve.test.ts
+++ b/tests/fs-write-resolve.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveMutationTargetPath } from "../src/fs-write.js";
+
+let dir: string;
+
+beforeEach(() => {
+  // realpathSync canonicalizes the temp dir so expected paths match the
+  // helper's symlink-resolved output. On macOS tmpdir() is /var/folders/...
+  // and /var is itself a symlink to /private/var, so resolveMutationTargetPath
+  // would otherwise return /private/var/... and every path-equality check below
+  // would FAIL.
+  dir = realpathSync(mkdtempSync(join(tmpdir(), "fs-write-resolve-")));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("resolveMutationTargetPath", () => {
+  it("returns a plain (non-symlink) path unchanged", async () => {
+    const p = join(dir, "plain.txt");
+    expect(await resolveMutationTargetPath(p)).toBe(p);
+  });
+
+  it("resolves a symlink through to its real terminal target", async () => {
+    const target = join(dir, "target.txt");
+    const link = join(dir, "linked.txt");
+    // relative link so it is resolved against the link's own directory
+    symlinkSync("target.txt", link);
+    expect(await resolveMutationTargetPath(link)).toBe(target);
+  });
+
+  it("returns the missing terminal target for a dangling symlink chain", async () => {
+    const intermediate = join(dir, "level-2.txt");
+    const top = join(dir, "level-1.txt");
+    const missing = join(dir, "missing.txt");
+    symlinkSync("missing.txt", intermediate);
+    symlinkSync("level-2.txt", top);
+    expect(await resolveMutationTargetPath(top)).toBe(missing);
+  });
+
+  it("throws ELOOP on a symlink cycle", async () => {
+    const a = join(dir, "a.txt");
+    const b = join(dir, "b.txt");
+    symlinkSync("b.txt", a);
+    symlinkSync("a.txt", b);
+    await expect(resolveMutationTargetPath(a)).rejects.toMatchObject({ code: "ELOOP" });
+  });
+});

--- a/tests/package-version.test.ts
+++ b/tests/package-version.test.ts
@@ -5,9 +5,9 @@ const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
 const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
 
 describe("package version", () => {
-  it("is bumped for the 0.10.0 release", () => {
-    expect(packageJson.version).toBe("0.10.0");
-    expect(packageLock.version).toBe("0.10.0");
-    expect(packageLock.packages[""].version).toBe("0.10.0");
+  it("is bumped for the 0.11.0 release", () => {
+    expect(packageJson.version).toBe("0.11.0");
+    expect(packageLock.version).toBe("0.11.0");
+    expect(packageLock.packages[""].version).toBe("0.11.0");
   });
 });

--- a/tests/repro-023-edit-readonly.test.ts
+++ b/tests/repro-023-edit-readonly.test.ts
@@ -38,32 +38,35 @@ describe("Bug #023: edit readonly file -> permission denied", () => {
 		expect(wrapWriteError(eio, "baz.txt").message).toBe("Failed to write file: baz.txt");
 	});
 
-	it("edit tool execute on chmod 444 file returns 'Permission denied: <path>'", async () => {
-		const { registerEditTool } = await import("../src/edit.js");
-		const { ensureHashInit, computeLineHash } = await import("../src/hashline.js");
-		await ensureHashInit();
-		let capturedTool: any = null;
-		const mockPi = {
-			registerTool(def: any) {
-				capturedTool = def;
-			},
-		};
-		registerEditTool(mockPi as any);
-		if (!capturedTool) throw new Error("edit tool was not registered");
+	it("edit tool execute in a read-only directory returns 'Permission denied: <path>'", async () => {
+		// Atomic writes rename a temp over the target, so blocking the write now
+		// requires removing write permission on the *directory*, not the file (#215).
+		const roDir = join(tmpDir, "ro-dir");
+		const roFile = join(roDir, "target.txt");
+		mkdirSync(roDir, { recursive: true });
+		writeFileSync(roFile, "line1\nline2\nline3\n", "utf-8");
+		chmodSync(roDir, 0o555);
+		try {
+			const { registerEditTool } = await import("../src/edit.js");
+			const { ensureHashInit, computeLineHash } = await import("../src/hashline.js");
+			await ensureHashInit();
+			let capturedTool: any = null;
+			registerEditTool({ registerTool(def: any) { capturedTool = def; } } as any);
+			if (!capturedTool) throw new Error("edit tool was not registered");
 
-		const hash1 = computeLineHash(1, "line1");
-		const result = await capturedTool.execute(
-			"test-call",
-			{
-				path: readonlyFile,
-				edits: [{ set_line: { anchor: `1:${hash1}`, new_text: "modified" } }],
-			},
-			new AbortController().signal,
-			() => {},
-			{ cwd: process.cwd() },
-		);
-		expect(result.isError).toBe(true);
-		const text = result.content.find((c: any) => c.type === "text")?.text ?? "";
-		expect(text).toMatch(/Permission denied/);
+			const hash1 = computeLineHash(1, "line1");
+			const result = await capturedTool.execute(
+				"test-call",
+				{ path: roFile, edits: [{ set_line: { anchor: `1:${hash1}`, new_text: "modified" } }] },
+				new AbortController().signal,
+				() => {},
+				{ cwd: process.cwd() },
+			);
+			expect(result.isError).toBe(true);
+			const text = result.content.find((c: any) => c.type === "text")?.text ?? "";
+			expect(text).toMatch(/Permission denied/);
+		} finally {
+			chmodSync(roDir, 0o755);
+		}
 	});
 });

--- a/tests/repro-160-mutation-queue.test.ts
+++ b/tests/repro-160-mutation-queue.test.ts
@@ -7,6 +7,7 @@ function tick(): Promise<void> {
 describe("repro 160 — Pi file mutation queue integration", () => {
   afterEach(() => {
     vi.doUnmock("fs/promises");
+    vi.doUnmock("../src/fs-write.js");
     vi.resetModules();
   });
 
@@ -21,11 +22,19 @@ describe("repro 160 — Pi file mutation queue integration", () => {
         await tick();
         return Buffer.from(fileContent, "utf-8");
       }),
-      writeFile: vi.fn(async (_path: string, content: string | Buffer) => {
-        await tick();
-        fileContent = content.toString();
-      }),
     }));
+
+    vi.doMock("../src/fs-write.js", async () => {
+      const actual = await vi.importActual<any>("../src/fs-write.js");
+      return {
+        ...actual,
+        resolveMutationTargetPath: vi.fn(async (p: string) => p),
+        writeFileAtomically: vi.fn(async (_path: string, content: string | Buffer) => {
+          await tick();
+          fileContent = content.toString();
+        }),
+      };
+    });
 
     const { registerEditTool } = await import("../src/edit.js");
     let tool: any;

--- a/tests/write-fs-errors.test.ts
+++ b/tests/write-fs-errors.test.ts
@@ -1,16 +1,19 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 
-async function getWriteTool(fsOverrides?: Partial<typeof import("node:fs")>) {
+async function getWriteTool(behavior?: { throwOnWrite?: NodeJS.ErrnoException }) {
   vi.resetModules();
-  if (fsOverrides) {
-    vi.doMock("node:fs", async (importOriginal) => {
-      const actual = await importOriginal<typeof import("node:fs")>();
-      return { ...actual, ...fsOverrides };
+  if (behavior?.throwOnWrite) {
+    vi.doMock("../src/fs-write.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("../src/fs-write.js")>();
+      return {
+        ...actual,
+        resolveMutationTargetPath: async (p: string) => p,
+        writeFileAtomically: async () => { throw behavior.throwOnWrite; },
+      };
     });
   } else {
-    vi.doUnmock("node:fs");
+    vi.doUnmock("../src/fs-write.js");
   }
-
   const { registerWriteTool } = await import("../src/write.js");
   let captured: any = null;
   registerWriteTool({ registerTool(def: any) { captured = def; } } as any);
@@ -30,18 +33,13 @@ function fsErr(code: string, msg: string): NodeJS.ErrnoException {
 
 describe("write fs-error mapping", () => {
   afterEach(() => {
-    vi.doUnmock("node:fs");
+    vi.doUnmock("../src/fs-write.js");
     vi.resetModules();
     vi.restoreAllMocks();
   });
 
-  it("EACCES on writeFile -> 'Permission denied — cannot write: <path>'", async () => {
-    const tool = await getWriteTool({
-      mkdirSync: (() => undefined) as any,
-      writeFileSync: (() => {
-        throw fsErr("EACCES", "EACCES: permission denied, open '/root/locked.txt'");
-      }) as any,
-    });
+  it("EACCES on write -> 'Permission denied — cannot write: <path>'", async () => {
+    const tool = await getWriteTool({ throwOnWrite: fsErr("EACCES", "EACCES: permission denied") });
     const result = await tool.execute(
       "tc", { path: "/root/locked.txt", content: "hi" },
       new AbortController().signal, undefined, { cwd: process.cwd() },
@@ -51,13 +49,8 @@ describe("write fs-error mapping", () => {
     expect(result.details?.ptcValue?.error?.code).toBe("permission-denied");
   });
 
-  it("EPERM on writeFile -> same permission-denied mapping", async () => {
-    const tool = await getWriteTool({
-      mkdirSync: (() => undefined) as any,
-      writeFileSync: (() => {
-        throw fsErr("EPERM", "EPERM: operation not permitted");
-      }) as any,
-    });
+  it("EPERM on write -> same permission-denied mapping", async () => {
+    const tool = await getWriteTool({ throwOnWrite: fsErr("EPERM", "EPERM: operation not permitted") });
     const result = await tool.execute(
       "tc", { path: "/root/locked2.txt", content: "hi" },
       new AbortController().signal, undefined, { cwd: process.cwd() },
@@ -66,13 +59,8 @@ describe("write fs-error mapping", () => {
     expect(result.details?.ptcValue?.error?.code).toBe("permission-denied");
   });
 
-  it("EISDIR on writeFile -> 'Path is a directory — cannot overwrite: <path>'", async () => {
-    const tool = await getWriteTool({
-      mkdirSync: (() => undefined) as any,
-      writeFileSync: (() => {
-        throw fsErr("EISDIR", "EISDIR: illegal operation on a directory");
-      }) as any,
-    });
+  it("EISDIR on write -> 'Path is a directory — cannot overwrite: <path>'", async () => {
+    const tool = await getWriteTool({ throwOnWrite: fsErr("EISDIR", "EISDIR: illegal operation on a directory") });
     const result = await tool.execute(
       "tc", { path: "/tmp/somedir", content: "hi" },
       new AbortController().signal, undefined, { cwd: process.cwd() },
@@ -81,28 +69,8 @@ describe("write fs-error mapping", () => {
     expect(result.details?.ptcValue?.error?.code).toBe("path-is-directory");
   });
 
-  it("ENOENT on mkdirSync -> 'Cannot create parent directories for <path>: <reason>'", async () => {
-    const tool = await getWriteTool({
-      mkdirSync: (() => {
-        throw fsErr("ENOENT", "ENOENT: parent does not exist");
-      }) as any,
-    });
-    const result = await tool.execute(
-      "tc", { path: "/no/such/parent/file.txt", content: "hi" },
-      new AbortController().signal, undefined, { cwd: process.cwd() },
-    );
-    expect(text(result)).toContain("Cannot create parent directories for /no/such/parent/file.txt");
-    expect(text(result)).toContain("ENOENT: parent does not exist");
-    expect(result.details?.ptcValue?.error?.code).toBe("fs-error");
-  });
-
-  it("ENOSPC on writeFile -> 'No space left on device — cannot write: <path>'", async () => {
-    const tool = await getWriteTool({
-      mkdirSync: (() => undefined) as any,
-      writeFileSync: (() => {
-        throw fsErr("ENOSPC", "ENOSPC: no space left");
-      }) as any,
-    });
+  it("ENOSPC on write -> fs-error with No space message", async () => {
+    const tool = await getWriteTool({ throwOnWrite: fsErr("ENOSPC", "ENOSPC: no space left") });
     const result = await tool.execute(
       "tc", { path: "/tmp/full.txt", content: "hi" },
       new AbortController().signal, undefined, { cwd: process.cwd() },
@@ -111,19 +79,24 @@ describe("write fs-error mapping", () => {
     expect(result.details?.ptcValue?.error?.code).toBe("fs-error");
   });
 
-  it("EROFS on writeFile -> 'Read-only filesystem — cannot write: <path>'", async () => {
-    const tool = await getWriteTool({
-      mkdirSync: (() => undefined) as any,
-      writeFileSync: (() => {
-        throw fsErr("EROFS", "EROFS: read-only file system");
-      }) as any,
-    });
+  it("EROFS on write -> 'Read-only filesystem — cannot write: <path>'", async () => {
+    const tool = await getWriteTool({ throwOnWrite: fsErr("EROFS", "EROFS: read-only file system") });
     const result = await tool.execute(
       "tc", { path: "/readonly/file.txt", content: "hi" },
       new AbortController().signal, undefined, { cwd: process.cwd() },
     );
     expect(text(result)).toBe("Read-only filesystem — cannot write: /readonly/file.txt");
     expect(result.details?.ptcValue?.error?.code).toBe("fs-error");
+  });
+
+  it("EXDEV on write -> fs-error with fsCode meta", async () => {
+    const tool = await getWriteTool({ throwOnWrite: fsErr("EXDEV", "EXDEV: cross-device link") });
+    const result = await tool.execute(
+      "tc", { path: "/tmp/x.txt", content: "hi" },
+      new AbortController().signal, undefined, { cwd: process.cwd() },
+    );
+    expect(result.details?.ptcValue?.error?.code).toBe("fs-error");
+    expect(result.details?.ptcValue?.error?.details?.fsCode).toBe("EXDEV");
   });
 
   it("regression: successful write still returns hashlined output", async () => {

--- a/tests/write-mutation-queue.test.ts
+++ b/tests/write-mutation-queue.test.ts
@@ -3,11 +3,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 describe("write Pi file mutation queue integration", () => {
   afterEach(() => {
     vi.doUnmock("@earendil-works/pi-coding-agent");
-    vi.doUnmock("node:fs");
+    vi.doUnmock("../src/fs-write.js");
     vi.resetModules();
   });
 
-  it("wraps write's full mutation window in Pi's file mutation queue", async () => {
+  it("wraps write's window in Pi's queue, keyed on the resolved target path", async () => {
     vi.resetModules();
     const events: string[] = [];
     const filePath = "/virtual/write-queue.txt";
@@ -25,15 +25,13 @@ describe("write Pi file mutation queue integration", () => {
       };
     });
 
-    vi.doMock("node:fs", async () => {
-      const actual = await vi.importActual<any>("node:fs");
+    vi.doMock("../src/fs-write.js", async () => {
+      const actual = await vi.importActual<any>("../src/fs-write.js");
       return {
         ...actual,
-        mkdirSync: vi.fn((dirPath: string) => {
-          events.push(`mkdir:${dirPath}`);
-        }),
-        writeFileSync: vi.fn((targetPath: string, content: string) => {
-          events.push(`write:${targetPath}:${content}`);
+        resolveMutationTargetPath: vi.fn(async (p: string) => p),
+        writeFileAtomically: vi.fn(async (targetPath: string, content: string) => {
+          events.push(`atomic-write:${targetPath}:${content}`);
         }),
       };
     });
@@ -52,11 +50,7 @@ describe("write Pi file mutation queue integration", () => {
 
     expect(result.isError).not.toBe(true);
     expect(events[0]).toBe(`queue-enter:${filePath}`);
-    expect(events).toEqual([
-      `queue-enter:${filePath}`,
-      "mkdir:/virtual",
-      `write:${filePath}:queued content`,
-      `queue-exit:${filePath}`,
-    ]);
+    expect(events).toContain(`atomic-write:${filePath}:queued content`);
+    expect(events[events.length - 1]).toBe(`queue-exit:${filePath}`);
   });
 });


### PR DESCRIPTION
## Summary

`write` and `edit` mutated files non-atomically — `writeFileSync` in `src/write.ts` and `fsWriteFile` in `src/edit.ts` wrote directly to the target. A crash, full disk, or concurrent reader mid-write could observe a torn/partial file, and writing to a symlinked path replaced the link with a regular file instead of updating its target.

This replaces both paths with a single shared atomic-write helper that writes to a same-directory temp file and `rename()`s it over the target (atomic *visibility* — the target is never observed half-written), writes through symlinks to their real target (link preserved), and updates hard-linked inodes in place (all links preserved). Follows the proven `YuGiMob/pi-hashline-edit-pro` design. Bumps the package to `0.11.0`.

## What changed

### Shared atomic-write helper (AC 1–12)
- **`src/fs-write.ts`** (new) — `node:fs/promises` only, no new deps:
  ```ts
  export async function resolveMutationTargetPath(path: string): Promise<string>
  export async function writeFileAtomically(path: string, content: string): Promise<void>
  ```
  - `resolveMutationTargetPath` walks the absolute path component-by-component, reading each symlink relative to its own directory and continuing from the link target. Detects cycles and throws with `code === \"ELOOP\"`; treats `ENOENT` on a component as \"stop here\" so a dangling chain (`level-1 → level-2 → missing`) resolves to the path of `missing`.
  - `writeFileAtomically` resolves the target, then: for a hard-linked target (`nlink > 1`) writes in place to keep the shared inode; otherwise `mkdir`s the parent, creates a temp via `open(tempPath, \"wx\", 0o600)`, writes, `chmod`s to the target's prior mode (`mode & 0o7777`) on overwrite or the OS/umask default on a new file, then `rename`s over the target. Any failure after temp creation best-effort `unlink`s the temp and rethrows the original error.

### Tool wiring (AC 13–17)
- **`src/write.ts`** — drops `writeFileSync`/`mkdirSync`; writes via `writeFileAtomically`. `withFileMutationQueue` is keyed on `resolveMutationTargetPath(absolutePath)` so symlink/target aliases serialize on one key. Resolution is best-effort with a literal-path fallback so a resolution failure still surfaces through `mapFsWriteError` → `fs-error` (symmetry with `edit`).
- **`src/edit.ts`** — drops `fsWriteFile`; writes via `writeFileAtomically` while preserving BOM/line-ending restoration and post-edit-verification. Queue keyed on the resolved target. `EXDEV`/rename failures surface through the existing `fs-error` envelope (`{ fsCode, fsMessage }`); `EACCES`/`EPERM` → `permission-denied`. No new keys in `src/ptc-error-codes.ts`.

### Release + docs (AC 18–19)
- **`package.json` / `package-lock.json`** — `0.10.0 → 0.11.0`.
- **`CHANGELOG.md`** — `[0.11.0]` section documenting the atomic-write contract and the read-only-file behavior change.
- **`README.md`**, **`prompts/write.md`**, **`prompts/edit.md`** — document atomic write + symlink/hard-link semantics, including the hard-link in-place exception.
- **`tests/package-version.test.ts`** — pin updated to `0.11.0`.

### Tests (AC 20)
- **`tests/fs-write-resolve.test.ts`** (new) — symlink resolution, ELOOP cycle, dangling-chain terminal target.
- **`tests/fs-write-atomic.test.ts`** (new) — real-filesystem coverage: new file, nested parent creation, overwrite + no orphan temp, mode preservation (incl. `umask 0o077`), new-file umask default, symlink write-through, dangling-chain write-through, hard-link in-place inode preservation.
- **`tests/fs-write-permissions.test.ts`** (new) — `open(\"wx\", 0o600)` + chmod-to-target-mode + rename ordering; best-effort temp unlink on rename failure.
- **`tests/edit-atomic-fs-errors.test.ts`** (new) — `EXDEV` → `fs-error` with `fsCode`; `EACCES` → `permission-denied`; guard that no bespoke codes were added.
- **Rewired** existing `write-fs-errors`, `write-mutation-queue`, `repro-160-mutation-queue`, `repro-023-edit-readonly`, `edit-post-verify-*` to mock the new `fs-write` seam; assertions preserved.

## Verification

- `npm run typecheck` → exit 0.
- `npm test` → **399 files / 1693 tests pass**.
- Codex review run against `main`: 2 findings adopted — (1) `write.ts` resolution error now flows through the `fs-error` envelope (parity with `edit`); (2) docs clarified that hard-link writes are the documented non-temp+rename exception. A Low finding (xattr/ACL non-preservation across rename) was dispositioned won't-fix — inherent to atomic rename, out of scope, matches the reference design.

## Behavior change

Editing/overwriting a read-only file (`0o444`) that lives in a **writable** directory now succeeds (atomic rename operates at the directory level), where it previously failed with `permission-denied`. A write is now refused only when the **containing directory** is not writable. Documented in `CHANGELOG.md` and reflected in `tests/repro-023-edit-readonly.test.ts`.

## Out of scope (deferred)

- Opt-in `0o600`-final mode for new files (default keeps umask-default).
- `fsync` crash durability (atomic *visibility* is the property in scope, not power-failure durability).
- Windows-specific atomic-rename hardening (retry on AV/locking `EPERM`/`EEXIST`).
- Configurable temp-dir location (temp is always same-dir-as-target to keep rename intra-filesystem).

Closes #215