### PR TITLE
fix: dedent-to-col0, read long-line guard, stale-read wording (#219)

### DIFF
--- a/docs/context-hygiene.md
+++ b/docs/context-hygiene.md
@@ -47,9 +47,9 @@ Maskable stale tools are:
 Rendered placeholders include:
 
 ```text
-[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]
-[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Run grep again for current matches.]
-[Stale ast_search result — this earlier ast_search was superseded by a later file change; nothing is wrong with ast_search. Run ast_search again for current matches.]
+[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run read for fresh anchors.]
+[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run grep for current matches.]
+[Stale ast_search result — this earlier ast_search was superseded by a later file change; nothing is wrong with ast_search. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run ast_search for current matches.]
 [Stale bash context: mutation-after-read. Re-run the Bash command to refresh. Command: npm test]
 ```
 

--- a/prompts/edit.md
+++ b/prompts/edit.md
@@ -70,6 +70,7 @@ If `edit` auto-relocates an anchor, check the warning and verify the edit landed
 - Anchored edits are applied bottom-up so line numbers stay stable.
 - `no-op` means the requested edit matched the current file already or produced identical content.
 - A whitespace-only warning means formatting changed but behavior probably did not.
+- Anchored edits honor your `new_text` indentation. If your replacement adds its own leading whitespace, that is used verbatim. As a convenience for replacements that collapse a wrapped/split line back to one line, the original line's indentation is restored only when no indentation was supplied; a plain 1:1 single-line replacement (`set_line`, or `replace_lines` with one target line) that starts at column 0 is honored as-is, so you can dedent a line to the left margin by setting `new_text` to column-0 content.
 - A `replace`-only success may include a reminder to prefer anchored edits next time.
 - Edits are written atomically (temp file + rename); symlinks are written through to their real target and preserved, and hard links are updated in place.
 

--- a/prompts/read.md
+++ b/prompts/read.md
@@ -9,6 +9,8 @@ Read text files with `LINE:HASH|content` anchors usable by `edit`. Default cap: 
 
 When a full-file read is truncated, a structural map is appended automatically when available. Use that map's line ranges for follow-up `read({ offset, limit })`. Structural maps support many common code/data formats and may fall back to ctags/heuristics.
 
+Very long single lines are truncated in the displayed output at 500 characters, the same threshold `grep` uses, with a `... [truncated, N chars total]` marker showing the original length. Truncation is display-only: the `LINE:HASH` anchor is computed from the full line, so `edit` still operates on the complete content and the hash is unchanged.
+
 ## Symbol examples
 
 | Query | Reads |

--- a/src/context-hygiene.ts
+++ b/src/context-hygiene.ts
@@ -207,15 +207,15 @@ export function buildStaleContextRecord(input: BuildStaleContextRecordInput): Co
 }
 
 export function renderStaleReadPlaceholder(): string {
-  return "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]";
+  return "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run read for fresh anchors.]";
 }
 
 export function renderStaleGrepPlaceholder(): string {
-  return "[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Run grep again for current matches.]";
+  return "[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run grep for current matches.]";
 }
 
 export function renderStaleAstSearchPlaceholder(): string {
-  return "[Stale ast_search result — this earlier ast_search was superseded by a later file change; nothing is wrong with ast_search. Run ast_search again for current matches.]";
+  return "[Stale ast_search result — this earlier ast_search was superseded by a later file change; nothing is wrong with ast_search. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run ast_search for current matches.]";
 }
 
 export function renderStaleBashPlaceholder(record: ContextHygieneStaleRecord): string {

--- a/src/hashline.ts
+++ b/src/hashline.ts
@@ -686,8 +686,12 @@ export function applyHashlineEdits(
 
 			const orig = origLines.slice(spec.ref.line - 1, spec.ref.line);
 			let stripped = stripRangeBoundaryEcho(origLines, spec.ref.line, spec.ref.line, dstLines);
+			const beforeWrap = stripped;
 			stripped = restoreOldWrappedLines(orig, stripped);
-			let newL = restoreIndentPaired(orig, stripped);
+			// Only auto-restore indentation when a wrapped/split span was actually collapsed
+			// back to one line. For a genuine 1:1 anchored replacement, honor the requested
+			// column (e.g. an intentional dedent to column 0). See issue #216.
+			let newL = stripped !== beforeWrap ? restoreIndentPaired(orig, stripped) : stripped;
 			if (orig.join("\n") === newL.join("\n") && orig.some((line) => CONFUSABLE_HYPHENS_RE.test(line))) {
 				newL = normalizeConfusableHyphensInLines(newL);
 			}
@@ -701,8 +705,10 @@ export function applyHashlineEdits(
 			const count = spec.end.line - spec.start.line + 1;
 			const orig = origLines.slice(spec.start.line - 1, spec.start.line - 1 + count);
 			let stripped = stripRangeBoundaryEcho(origLines, spec.start.line, spec.end.line, dstLines);
+			const beforeWrap = stripped;
 			stripped = restoreOldWrappedLines(orig, stripped);
-			let newL = restoreIndentPaired(orig, stripped);
+			// See issue #216 — only restore indent after a real wrap collapse.
+			let newL = stripped !== beforeWrap ? restoreIndentPaired(orig, stripped) : stripped;
 			if (orig.join("\n") === newL.join("\n") && orig.some((line) => CONFUSABLE_HYPHENS_RE.test(line))) {
 				newL = normalizeConfusableHyphensInLines(newL);
 			}

--- a/src/ptc-value.ts
+++ b/src/ptc-value.ts
@@ -1,5 +1,6 @@
 import { computeLineHash, escapeControlCharsForDisplay } from "./hashline.js";
 import type { DiffData } from "./diff-data.js";
+import { truncateLine } from "@earendil-works/pi-coding-agent";
 
 export interface PtcLine {
   line: number;
@@ -76,8 +77,24 @@ export function buildPtcLines(startLine: number, rawLines: string[]): PtcLine[] 
   return rawLines.map((raw, index) => buildPtcLine(startLine + index, raw));
 }
 
+/**
+ * Cap an already-rendered display string at grep's per-line threshold (500 chars),
+ * appending a marker that includes the original character count. Display-only:
+ * callers must keep the untruncated content for hashing/editing, so anchors and
+ * edits still operate on full content. Threshold matches grep's `truncateLine`
+ * (500). See issue #217.
+ */
+export function truncateDisplayLine(display: string): string {
+  const { text, wasTruncated } = truncateLine(display);
+  if (!wasTruncated) return display;
+  // truncateLine returns `<first 500 chars>... [truncated]`; replace grep's bare
+  // marker with one that also reports the original length for read's contract.
+  const sliced = text.slice(0, text.length - "... [truncated]".length);
+  return `${sliced}... [truncated, ${display.length} chars total]`;
+}
+
 export function renderPtcLine(line: PtcLine): string {
-  return `${line.anchor}|${line.display}`;
+  return `${line.anchor}|${truncateDisplayLine(line.display)}`;
 }
 
 export function renderPtcLines(lines: PtcLine[]): string {

--- a/tests/bash-filter.test.ts
+++ b/tests/bash-filter.test.ts
@@ -45,6 +45,15 @@ describe("command detection", () => {
     expect(isBuildCommand("npx tsc")).toBe(true);
     expect(isBuildCommand("./node_modules/.bin/tsc")).toBe(true);
   });
+
+  it("#219 reconcile: .tscn false-positive stays fixed for the reporter's exact command (GH PR #148)", () => {
+    // Reporter scenario from GH PR #148 / issue #211: a Godot scene diff must not
+    // be swallowed by the build-output filter, while real tsc invocations still are.
+    expect(isBuildCommand("git diff scenes/player/player.tscn")).toBe(false);
+    expect(isBuildCommand("cat ui/main_menu.tscn")).toBe(false);
+    expect(isBuildCommand("tsc")).toBe(true);
+    expect(isBuildCommand("npx tsc --noEmit")).toBe(true);
+  });
 });
 
 

--- a/tests/context-hygiene-context-application.test.ts
+++ b/tests/context-hygiene-context-application.test.ts
@@ -40,7 +40,7 @@ describe("context hygiene context application", () => {
     expect(applied).not.toBe(messages);
     expect(applied[0]).not.toBe(staleRead);
     expect(applied[0].content).toEqual([
-      { type: "text", text: "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]" },
+      { type: "text", text: "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run read for fresh anchors.]" },
     ]);
     expect(applied[0].details).toMatchObject({
       ptcValue: { tool: "read" },
@@ -82,7 +82,7 @@ describe("context hygiene context application", () => {
     );
 
     expect(applied[0].content).toEqual([
-      { type: "text", text: "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]" },
+      { type: "text", text: "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run read for fresh anchors.]" },
     ]);
     expect(applied[1]).toBe(liveWrite);
     expect(applied[2]).toBe(freshRead);
@@ -105,7 +105,7 @@ describe("context hygiene context application", () => {
     const applied = applyContextHygieneStaleContext([staleGrep, liveEdit], tracker.generateReport());
 
     expect(applied[0].content).toEqual([
-      { type: "text", text: "[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Run grep again for current matches.]" },
+      { type: "text", text: "[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run grep for current matches.]" },
     ]);
     expect(applied[0].details).toMatchObject({
       contextHygieneStale: {
@@ -136,7 +136,7 @@ describe("context hygiene context application", () => {
     const applied = applyContextHygieneStaleContext([staleGrep, liveWrite], tracker.generateReport());
 
     expect(applied[0].content).toEqual([
-      { type: "text", text: "[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Run grep again for current matches.]" },
+      { type: "text", text: "[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run grep for current matches.]" },
     ]);
     expect(applied[1]).toBe(liveWrite);
   });
@@ -164,10 +164,10 @@ describe("context hygiene context application", () => {
     ], tracker.generateReport());
 
     expect(applied[0].content).toEqual([
-      { type: "text", text: "[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Run grep again for current matches.]" },
+      { type: "text", text: "[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run grep for current matches.]" },
     ]);
     expect(applied[1].content).toEqual([
-      { type: "text", text: "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]" },
+      { type: "text", text: "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run read for fresh anchors.]" },
     ]);
     expect(applied[2].content).toEqual([{ type: "text", text: "chain edit output" }]);
   });
@@ -189,7 +189,7 @@ describe("context hygiene context application", () => {
     const applied = applyContextHygieneStaleContext([staleAst, liveEdit], tracker.generateReport());
 
     expect(applied[0].content).toEqual([
-      { type: "text", text: "[Stale ast_search result — this earlier ast_search was superseded by a later file change; nothing is wrong with ast_search. Run ast_search again for current matches.]" },
+      { type: "text", text: "[Stale ast_search result — this earlier ast_search was superseded by a later file change; nothing is wrong with ast_search. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run ast_search for current matches.]" },
     ]);
     expect(applied[0].details).toMatchObject({
       contextHygieneStale: {
@@ -220,7 +220,7 @@ describe("context hygiene context application", () => {
     const applied = applyContextHygieneStaleContext([staleAst, liveWrite], tracker.generateReport());
 
     expect(applied[0].content).toEqual([
-      { type: "text", text: "[Stale ast_search result — this earlier ast_search was superseded by a later file change; nothing is wrong with ast_search. Run ast_search again for current matches.]" },
+      { type: "text", text: "[Stale ast_search result — this earlier ast_search was superseded by a later file change; nothing is wrong with ast_search. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run ast_search for current matches.]" },
     ]);
     expect(applied[1]).toBe(liveWrite);
   });
@@ -248,7 +248,7 @@ describe("context hygiene context application", () => {
     const staleRead = toolResult("read-before-edit", "read", "old read output");
     const staleApplied = applyContextHygieneStaleContext([staleRead], tracker.generateReport());
     expect(staleApplied[0].content).toEqual([
-      { type: "text", text: "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]" },
+      { type: "text", text: "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run read for fresh anchors.]" },
     ]);
     expect(staleApplied[0].content[0].text.toLowerCase()).toContain("stale");
     expect(staleApplied[0].content[0].text.toLowerCase()).not.toContain("retired");

--- a/tests/context-hygiene-context-handler.test.ts
+++ b/tests/context-hygiene-context-handler.test.ts
@@ -75,7 +75,7 @@ describe("context hygiene provider context handler", () => {
     const result = handlers.context({ type: "context", messages: providerContextCopy }, {});
 
     expect(result.messages[0].content).toEqual([
-      { type: "text", text: "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]" },
+      { type: "text", text: "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run read for fresh anchors.]" },
     ]);
     expect(result.messages[0].details).toMatchObject({
       ptcValue: { tool: "read" },

--- a/tests/context-hygiene-stale-placeholders.test.ts
+++ b/tests/context-hygiene-stale-placeholders.test.ts
@@ -30,9 +30,9 @@ describe("context hygiene stale placeholders", () => {
     const secondRender = records.map(renderStaleContextPlaceholder);
 
     expect(firstRender).toEqual([
-      "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]",
-      "[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Run grep again for current matches.]",
-      "[Stale ast_search result — this earlier ast_search was superseded by a later file change; nothing is wrong with ast_search. Run ast_search again for current matches.]",
+      "[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run read for fresh anchors.]",
+      "[Stale grep result — this earlier grep was superseded by a later file change; nothing is wrong with grep. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run grep for current matches.]",
+      "[Stale ast_search result — this earlier ast_search was superseded by a later file change; nothing is wrong with ast_search. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run ast_search for current matches.]",
     ]);
     expect(secondRender).toEqual(firstRender);
 

--- a/tests/repro-144-stale-read-edit-guard.test.ts
+++ b/tests/repro-144-stale-read-edit-guard.test.ts
@@ -85,7 +85,7 @@ describe("issue 144 — stale-masked read must not satisfy edit's must-read guar
       ],
     }, {});
     expect(ctxResult.messages[0].content[0].text)
-      .toContain("[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Run read again for current content.]");
+      .toContain("[Stale read result — this earlier read was superseded by a later file change; nothing is wrong with read. Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies. Re-run read for fresh anchors.]");
 
     // 4. Edit with a structurally-valid LINE:HASH whose hash matches a *different*
     //    line — adaptive relocation would silently land it. The fix must intercept

--- a/tests/repro-216-edit-dedent-col0.test.ts
+++ b/tests/repro-216-edit-dedent-col0.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { applyHashlineEdits, computeLineHash, ensureHashInit } from "../src/hashline.js";
+
+describe("issue 216 — dedent a line to column 0 via anchored edits", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("set_line dedents a tab-indented line to column 0", () => {
+    const origContent = ["function foo() {", "\t\tnested();", "}"].join("\n");
+    const anchor = `2:${computeLineHash(2, "\t\tnested();")}`;
+    const result = applyHashlineEdits(origContent, [
+      { set_line: { anchor, new_text: "dedented();" } },
+    ]);
+    expect(result.content.split("\n")[1]).toBe("dedented();");
+  });
+
+  it("set_line dedents a space-indented line to column 0", () => {
+    const origContent = ["function foo() {", "    nested();", "}"].join("\n");
+    const anchor = `2:${computeLineHash(2, "    nested();")}`;
+    const result = applyHashlineEdits(origContent, [
+      { set_line: { anchor, new_text: "dedented();" } },
+    ]);
+    expect(result.content.split("\n")[1]).toBe("dedented();");
+  });
+
+  it("replace_lines (single-target) dedents a tab-indented line to column 0", () => {
+    const origContent = ["class C {", "\tmethod() {}", "}"].join("\n");
+    const anchor = `2:${computeLineHash(2, "\tmethod() {}")}`;
+    const result = applyHashlineEdits(origContent, [
+      { replace_lines: { start_anchor: anchor, end_anchor: anchor, new_text: "topLevel();" } },
+    ]);
+    expect(result.content.split("\n")[1]).toBe("topLevel();");
+  });
+
+  it("still restores indentation when a wrapped (multi-line) new_text collapses back to one line", () => {
+    // Wrap/split case: original is one indented line; model emits it across 2 lines with no indent.
+    // restoreOldWrappedLines collapses them, and restoreIndentPaired must keep the original indent.
+    const origContent = ["function f() {", "\tconst summary = alpha + beta + gamma;", "}"].join("\n");
+    const anchor = `2:${computeLineHash(2, "\tconst summary = alpha + beta + gamma;")}`;
+    const newText = ["const summary = alpha + beta +", "gamma;"].join("\n");
+    const result = applyHashlineEdits(origContent, [
+      { set_line: { anchor, new_text: newText } },
+    ]);
+    // The wrap is restored to the original single indented line (no-op).
+    expect(result.content.split("\n")[1]).toBe("\tconst summary = alpha + beta + gamma;");
+  });
+});

--- a/tests/repro-217-read-long-line-guard.test.ts
+++ b/tests/repro-217-read-long-line-guard.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+import init from "../index.js";
+
+function getText(result: any): string {
+  return result.content?.find((c: any) => c.type === "text")?.text ?? "";
+}
+
+function createHarness() {
+  const tools: Record<string, any> = {};
+  const handlers: Record<string, Function> = {};
+  init({
+    registerTool(def: any) { tools[def.name] = def; },
+    on(event: string, handler: Function) { handlers[event] = handler; },
+    events: { emit() {}, on() {} },
+  } as any);
+  return { tools, handlers };
+}
+
+describe("issue 217 — read long-line guard + edit on full content", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("truncates a 20k-char single line in read output with a marker + original length", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-issue-217-"));
+    const filePath = resolve(dir, "long.txt");
+    const longLine = "needle " + "x".repeat(20000);
+    writeFileSync(filePath, longLine, "utf-8");
+
+    const { tools } = createHarness();
+    const result = await tools.read.execute("read-1", { path: filePath }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+    const text = getText(result);
+
+    const row = text.split("\n").find((l) => /^\d+:[0-9a-f]{3}\|/.test(l)) ?? "";
+    const displayed = row.replace(/^\d+:[0-9a-f]{3}\|/, "");
+    expect(displayed.length).toBeLessThan(600);
+    expect(displayed.endsWith(`... [truncated, ${longLine.length} chars total]`)).toBe(true);
+  });
+
+  it("editing the truncated line still applies against full content (hash unchanged)", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-issue-217-edit-"));
+    const filePath = resolve(dir, "long.txt");
+    const longLine = "needle " + "x".repeat(20000);
+    writeFileSync(filePath, longLine, "utf-8");
+
+    const { tools } = createHarness();
+    // read first so the read-before-edit guard is satisfied
+    await tools.read.execute("read-1", { path: filePath }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+
+    // The anchor hash is derived from the FULL line content (display truncation is cosmetic).
+    const anchor = `1:${computeLineHash(1, longLine)}`;
+    const editResult = await tools.edit.execute(
+      "edit-1",
+      { path: filePath, edits: [{ set_line: { anchor, new_text: "replaced();" } }] },
+      new AbortController().signal,
+      () => {},
+      { cwd: process.cwd() },
+    );
+    expect(editResult.isError).not.toBe(true);
+    expect(readFileSync(filePath, "utf-8")).toBe("replaced();");
+  });
+});

--- a/tests/repro-217-render-ptc-line-truncation.test.ts
+++ b/tests/repro-217-render-ptc-line-truncation.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { ensureHashInit } from "../src/hashline.js";
+import { buildPtcLine, renderPtcLine, renderPtcLines } from "../src/ptc-value.js";
+
+describe("issue 217 — renderPtcLine caps long display lines", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("renders short lines unchanged with full anchor + content", () => {
+    const line = buildPtcLine(3, "const x = 1;");
+    expect(renderPtcLine(line)).toBe(`${line.anchor}|const x = 1;`);
+  });
+
+  it("truncates the displayed content of a >500-char line but keeps the full anchor", () => {
+    const longRaw = "needle " + "x".repeat(20000);
+    const line = buildPtcLine(1, longRaw);
+    const rendered = renderPtcLine(line);
+    // Anchor (line:hash) is preserved and derived from the FULL raw content.
+    expect(rendered.startsWith(`${line.anchor}|`)).toBe(true);
+    // Displayed content is capped, not the full 20k chars.
+    const displayed = rendered.slice(`${line.anchor}|`.length);
+    expect(displayed.length).toBeLessThan(600);
+    expect(displayed.endsWith(`... [truncated, ${longRaw.length} chars total]`)).toBe(true);
+    // The stored raw is untouched — edits still operate on full content.
+    expect(line.raw).toBe(longRaw);
+  });
+
+  it("renderPtcLines applies the cap per line", () => {
+    const a = buildPtcLine(1, "short");
+    const b = buildPtcLine(2, "z".repeat(700));
+    const out = renderPtcLines([a, b]).split("\n");
+    expect(out[0]).toBe(`${a.anchor}|short`);
+    expect(out[1].endsWith("... [truncated, 700 chars total]")).toBe(true);
+  });
+});

--- a/tests/repro-217-truncate-display-line.test.ts
+++ b/tests/repro-217-truncate-display-line.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { truncateDisplayLine } from "../src/ptc-value.js";
+
+describe("issue 217 — truncateDisplayLine (display-only long-line guard)", () => {
+  it("returns short display strings unchanged", () => {
+    expect(truncateDisplayLine("short line")).toBe("short line");
+  });
+
+  it("returns a 500-char string unchanged (at the boundary)", () => {
+    const exactly500 = "x".repeat(500);
+    expect(truncateDisplayLine(exactly500)).toBe(exactly500);
+  });
+
+  it("truncates a >500-char string to 500 chars + marker with original length", () => {
+    const long = "x".repeat(600);
+    const out = truncateDisplayLine(long);
+    expect(out).toBe("x".repeat(500) + "... [truncated, 600 chars total]");
+  });
+
+  it("reports the true original length in the marker for very long lines", () => {
+    const long = "y".repeat(20000);
+    const out = truncateDisplayLine(long);
+    expect(out.startsWith("y".repeat(500))).toBe(true);
+    expect(out.endsWith("... [truncated, 20000 chars total]")).toBe(true);
+    expect(out.length).toBeLessThan(600);
+  });
+});

--- a/tests/repro-218-stale-read-wording.test.ts
+++ b/tests/repro-218-stale-read-wording.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import {
+  renderStaleReadPlaceholder,
+  renderStaleGrepPlaceholder,
+  renderStaleAstSearchPlaceholder,
+} from "../src/context-hygiene.js";
+
+describe("issue 218 — stale placeholders clarify that content-hash edits still validate", () => {
+  it("read placeholder explains hash-validated edits are not blocked", () => {
+    const msg = renderStaleReadPlaceholder();
+    expect(msg.toLowerCase()).toContain("content-derived");
+    expect(msg.toLowerCase()).toContain("hash");
+    expect(msg.toLowerCase()).toContain("still applies");
+    // Keep the existing reassurance + rehydration guidance.
+    expect(msg).toContain("Stale read result");
+    expect(msg.toLowerCase()).toContain("nothing is wrong with read");
+  });
+
+  it("grep placeholder explains hash-validated edits are not blocked", () => {
+    const msg = renderStaleGrepPlaceholder();
+    expect(msg.toLowerCase()).toContain("content-derived");
+    expect(msg.toLowerCase()).toContain("still applies");
+    expect(msg).toContain("Stale grep result");
+  });
+
+  it("ast_search placeholder explains hash-validated edits are not blocked", () => {
+    const msg = renderStaleAstSearchPlaceholder();
+    expect(msg.toLowerCase()).toContain("content-derived");
+    expect(msg.toLowerCase()).toContain("still applies");
+    expect(msg).toContain("Stale ast_search result");
+  });
+});

--- a/tests/repro-218-stale-scope-guard.test.ts
+++ b/tests/repro-218-stale-scope-guard.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { ensureHashInit, computeLineHash } from "../src/hashline.js";
+import init from "../index.js";
+
+function createHarness() {
+  const tools: Record<string, any> = {};
+  const handlers: Record<string, Function> = {};
+  init({
+    registerTool(def: any) { tools[def.name] = def; },
+    on(event: string, handler: Function) { handlers[event] = handler; },
+    events: { emit() {}, on() {} },
+  } as any);
+  return { tools, handlers };
+}
+
+describe("issue 218 — stale masking stays file-scoped", () => {
+  beforeAll(async () => {
+    await ensureHashInit();
+  });
+
+  it("masks the edited file's own read but NOT a prior read of unrelated file B", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-issue-218-scope-"));
+    const fileA = resolve(dir, "a.ts");
+    const fileB = resolve(dir, "b.ts");
+    writeFileSync(fileA, ["a1", "uniqueA", "a3"].join("\n") + "\n", "utf-8");
+    writeFileSync(fileB, ["b1", "b2", "b3"].join("\n") + "\n", "utf-8");
+
+    const { tools, handlers } = createHarness();
+
+    // Read BOTH files so each edit-before-read guard is satisfied and edit-A records a
+    // real mutation event (a failed/unread edit emits no contextHygiene, so it would mask
+    // nothing and the test would pass vacuously).
+    const readA = await tools.read.execute("read-A", { path: fileA }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+    await handlers.tool_result({ toolName: "read", toolCallId: "read-A", input: { path: fileA }, content: readA.content, isError: false, details: readA.details }, {});
+
+    const readB = await tools.read.execute("read-B", { path: fileB }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+    await handlers.tool_result({ toolName: "read", toolCallId: "read-B", input: { path: fileB }, content: readB.content, isError: false, details: readB.details }, {});
+
+    const anchorA = `2:${computeLineHash(2, "uniqueA")}`;
+    const editA = await tools.edit.execute("edit-A", { path: fileA, edits: [{ set_line: { anchor: anchorA, new_text: "uniqueAv2" } }] }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+    // The edit must actually apply — this is what records the mutation event for file A.
+    expect(editA.isError).not.toBe(true);
+    await handlers.tool_result({ toolName: "edit", toolCallId: "edit-A", input: { path: fileA }, content: editA.content, isError: false, details: editA.details }, {});
+
+    const ctx = handlers.context!({
+      type: "context",
+      messages: [
+        { role: "toolResult", toolCallId: "read-A", toolName: "read", content: [{ type: "text", text: "A read output" }], details: { ptcValue: { tool: "read" } }, isError: false, timestamp: 1 },
+        { role: "toolResult", toolCallId: "read-B", toolName: "read", content: [{ type: "text", text: "B read output" }], details: { ptcValue: { tool: "read" } }, isError: false, timestamp: 2 },
+        { role: "toolResult", toolCallId: "edit-A", toolName: "edit", content: [{ type: "text", text: "edit succeeded" }], details: { ptcValue: { tool: "edit" } }, isError: false, timestamp: 3 },
+      ],
+    }, {});
+
+    // read-A (same resource as the edit) IS masked — proving a mutation was recorded …
+    const maskedA = ctx?.messages?.[0]?.content?.[0]?.text ?? "";
+    expect(maskedA).toContain("Stale read result");
+    expect(maskedA.toLowerCase()).toContain("content-derived");
+    // … while the unrelated read-B is left untouched — proving file-scoped keying holds.
+    // If a future change broke the resource-keying (e.g. masked all reads), this fails.
+    expect(ctx?.messages?.[1]?.content?.[0]?.text).toBe("B read output");
+  });
+
+  it("editing the same file B DOES mask the prior read of B with the clarified wording", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "pi-issue-218-same-"));
+    const fileB = resolve(dir, "b.ts");
+    writeFileSync(fileB, ["b1", "uniqueB", "b3"].join("\n") + "\n", "utf-8");
+
+    const { tools, handlers } = createHarness();
+
+    const readB = await tools.read.execute("read-B", { path: fileB }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+    await handlers.tool_result({ toolName: "read", toolCallId: "read-B", input: { path: fileB }, content: readB.content, isError: false, details: readB.details }, {});
+
+    const anchorB = `2:${computeLineHash(2, "uniqueB")}`;
+    const editB = await tools.edit.execute("edit-B", { path: fileB, edits: [{ set_line: { anchor: anchorB, new_text: "uniqueBv2" } }] }, new AbortController().signal, () => {}, { cwd: process.cwd() });
+    await handlers.tool_result({ toolName: "edit", toolCallId: "edit-B", input: { path: fileB }, content: editB.content, isError: false, details: editB.details }, {});
+
+    const ctx = handlers.context!({
+      type: "context",
+      messages: [
+        { role: "toolResult", toolCallId: "read-B", toolName: "read", content: [{ type: "text", text: "B read output" }], details: { ptcValue: { tool: "read" } }, isError: false, timestamp: 1 },
+        { role: "toolResult", toolCallId: "edit-B", toolName: "edit", content: [{ type: "text", text: "edit succeeded" }], details: { ptcValue: { tool: "edit" } }, isError: false, timestamp: 2 },
+      ],
+    }, {});
+    const masked = ctx?.messages?.[0]?.content?.[0]?.text ?? "";
+    expect(masked).toContain("Stale read result");
+    expect(masked.toLowerCase()).toContain("content-derived");
+  });
+});


### PR DESCRIPTION
## Summary

Batch issue #219 rolls up four independently-traced edge-case findings: two real bugs, one feature gap, and two verify-only confirmations. Each was diagnosed to a confirmed root cause before any change.

- **#216 (bug)** — `edit` could not dedent a line to column 0. `applyHashlineEdits` ran `restoreIndentPaired` unconditionally after `restoreOldWrappedLines` in the single-line and range branches, so a genuine 1:1 replacement starting at column 0 had the original indent silently re-prepended — the edit reported success while the on-disk content differed from the request.
- **#217 (feature gap)** — `read` emitted very long single lines uncompressed, while `grep` already caps display at 500 chars. Minified/generated single-line files blew context with no guard.
- **#218 (messaging)** — the stale read/grep/ast_search placeholders said the result was "superseded … run read again" but never stated that edits still validate against current on-disk content via content-derived hashes, so a caller could read "stale" as "edit blocked."
- **#218 (scope)** and **#212/#211 (`.tscn`)** — confirmed already-correct; no source change, locked with guard/reconcile tests.

The behavior changes are narrow and display/messaging-focused; the core edit engine change is gated to the exact 1:1 case.

## What changed

### #216 — dedent to column 0 honored (`src/hashline.ts`)
- Gate `restoreIndentPaired` on whether a wrap was actually collapsed. `restoreOldWrappedLines` returns the *same array reference* on a no-op and a *new array* only when it collapses a span, so a strict reference comparison is a precise signal in both the single-line and range branches:
  ```ts
  const beforeWrap = stripped;
  stripped = restoreOldWrappedLines(orig, stripped);
  // Only auto-restore indent when a wrapped/split span was actually collapsed back
  // to one line. For a genuine 1:1 anchored replacement, honor the requested column.
  let newL = stripped !== beforeWrap ? restoreIndentPaired(orig, stripped) : stripped;
  ```
  The merge branch (`maybeExpandSingleLineMerge`) is untouched — merges remain a legitimate wrap-collapse and keep restoring indent.
- **`prompts/edit.md`** — documents the anchored-edit auto-indent behavior and the supported column-0 dedent path.

### #217 — `read` long-line display guard (`src/ptc-value.ts`)
- New pure helper, reusing pi's exported `truncateLine` (500-char threshold, same as `grep`):
  ```ts
  export function truncateDisplayLine(display: string): string
  ```
  It appends `... [truncated, N chars total]` (grep's marker plus the original length). Wired into `renderPtcLine`, which is the live `read` render surface (`buildReadOutput` → `renderPtcLines` → `renderPtcLine`). Display-only: `PtcLine.raw`/`hash`/`anchor` are untouched, so `LINE:HASH` anchors derive from the full line and `edit` still operates on complete content.
- **`prompts/read.md`** — documents the 500-char threshold, the marker, and that editing a truncated line still works against full content.

### #218 — clarified stale-read messaging (`src/context-hygiene.ts`)
- `renderStaleReadPlaceholder` / `renderStaleGrepPlaceholder` / `renderStaleAstSearchPlaceholder` now state: *"Edits still validate against current on-disk content via content-derived LINE:HASH anchors, so a matching hash still applies."* Messaging-only — the file-scoped masking mechanism was already correct.
- **`docs/context-hygiene.md`** — example placeholder strings updated to match.
- Lockstep assertion updates: `tests/context-hygiene-stale-placeholders.test.ts`, `tests/context-hygiene-context-application.test.ts`, `tests/context-hygiene-context-handler.test.ts`, `tests/repro-144-stale-read-edit-guard.test.ts`.

### #212/#211 — `.tscn` reconcile (no source change)
- Both build-command gates already use `/\btsc\b/` (`src/rtk/bash-filter.ts`, `src/rtk/build.ts`). Added a reconciliation assertion in **`tests/bash-filter.test.ts`** for the reporter's exact GH PR #148 command.

### Tests (new)
- `tests/repro-216-edit-dedent-col0.test.ts` — tab/space dedent to column 0 + wrap-restore regression.
- `tests/repro-217-truncate-display-line.test.ts` — helper boundary cases (≤500 unchanged, 600→500+marker, 20000→correct count).
- `tests/repro-217-render-ptc-line-truncation.test.ts` — `renderPtcLine` caps display, keeps anchor/`raw`.
- `tests/repro-217-read-long-line-guard.test.ts` — end-to-end via the real `read`/`edit` tools.
- `tests/repro-218-stale-read-wording.test.ts` — the three placeholders carry the clarified wording.
- `tests/repro-218-stale-scope-guard.test.ts` — editing file A does not mask a prior read of unrelated file B; same-file control masks.

## Verification

- `npm run typecheck` → exit 0 (validates the new `truncateLine` import).
- `npm test` → **405 files / 1712 tests, 0 failures**.
- Original symptoms reproduced through the real `read`/`edit` tool entry points and confirmed gone: tab/space dedents land at column 0; a 20007-char line renders at 534 chars with `... [truncated, 20007 chars total]` and still edits against full content; the three stale placeholders carry the clarified wording.

## Behavior change

A genuine 1:1 `set_line`/`replace_lines` whose `new_text` starts at column 0 now lands at column 0 instead of having the original indent re-added. Wrap/split/blank-collapse auto-indent and the merge path are unchanged. `read` now truncates single display lines longer than 500 chars (display-only; anchors and edits are unaffected).

Closes #219 (rolls up #216, #217, #218; reconciles the #212/#211 `.tscn` slice).
