### PR TITLE
fix(find): hint about basename matching for slash-containing globs (#220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-06-19
+
+### Fixed
+- `find` no longer fails silently for slash-containing globs. `find` matches basenames, not paths, so a pattern like `src/*.ts` or `src/**/*.ts` never matched and returned a bare "No files found" with no explanation. When the pattern contains a `/` and produces no results, the output now appends a hint: `find matches basenames, not paths — drop the directory segment or pass it via path: (e.g. find("*.ts", path: "src/readmap")).` The hint covers both the `fd` and node-fallback backends; matching behavior is unchanged (#220).
 ## [0.11.0] - 2026-06-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ find({ pattern: "*.ts", path: "src", maxDepth: 2 })
 nu({ command: "open package.json | get scripts" })
 ```
 
-`ls` shows one directory with directories first and dotfiles included. `find` performs recursive discovery, respects `.gitignore`, includes hidden files, and supports depth, regex, sort, mtime, and size filters. `nu` registers only when Nushell is installed and is useful for structured JSON, CSV, TOML, YAML, and filesystem inspection.
+`ls` shows one directory with directories first and dotfiles included. `find` performs recursive discovery, respects `.gitignore`, includes hidden files, and supports depth, regex, sort, mtime, and size filters. `find` matches basenames, not paths — pass directories via `path:` (e.g. `find({ pattern: "*.ts", path: "src" })`) rather than embedding them in the glob; a slash-containing glob that matches nothing returns a hint explaining this. `nu` registers only when Nushell is installed and is useful for structured JSON, CSV, TOML, YAML, and filesystem inspection.
 
 ### Handle noisy command output
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hashline-readmap",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hashline-readmap",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Unified pi extension: hash-anchored read/edit/grep, structural code maps, AST-grep, file exploration (ls/find), and bash output compression",
   "type": "module",
   "exports": {

--- a/prompts/find.md
+++ b/prompts/find.md
@@ -16,4 +16,4 @@ Find files recursively by name. Uses glob patterns by default, respects nested `
 One relative path per line. Directories end with `/`. If results exceed `limit` or 50 KB, output says it was truncated.
 Filtering and sorting happen before `limit`, so queries like largest/newest files work as expected.
 
-Use `find` for recursive file-name discovery, `ls` for one directory, and `grep` for file contents. Remember: `pattern` matches basenames, not full paths.
+Use `find` for recursive file-name discovery, `ls` for one directory, and `grep` for file contents. Remember: `pattern` matches basenames, not full paths. A pattern containing `/` (e.g. `src/*.ts`) will not match — scope the directory via `path:` instead (e.g. `find("*.ts", path: "src/readmap")`). When a slash-containing glob returns nothing, the result includes a hint to this effect.

--- a/src/find.ts
+++ b/src/find.ts
@@ -269,8 +269,14 @@ function formatOutput(
   showFdHint: boolean,
 ): string {
   if (entries.length === 0 && !truncated) {
-    const text = `No files found matching pattern: ${pattern}`;
-    return showFdHint ? text + "\nHint: Install fd for faster file discovery: brew install fd" : text;
+    let text = `No files found matching pattern: ${pattern}`;
+    if (pattern.includes("/")) {
+      text += `\nHint: find matches basenames, not paths \u2014 drop the directory segment or pass it via path: (e.g. find("*.ts", path: "src/readmap")).`;
+    }
+    if (showFdHint) {
+      text += "\nHint: Install fd for faster file discovery: brew install fd";
+    }
+    return text;
   }
 
   const lines: string[] = [];

--- a/tests/find.test.ts
+++ b/tests/find.test.ts
@@ -551,3 +551,69 @@ describe("find path resolution", () => {
   });
 });
 
+describe("find slash-glob hint", () => {
+  afterEach(() => { vi.restoreAllMocks(); _testable.isFdAvailable = _originalIsFdAvailable; });
+
+  const SLASH_HINT = "find matches basenames";
+
+  it("hints about basename matching for slash globs (node fallback)", async () => {
+    _testable.isFdAvailable = () => false;
+    const tool = await getFindTool();
+    const result = await tool.execute(
+      "tc",
+      { pattern: "src/*.ts" },
+      new AbortController().signal,
+      undefined,
+      { cwd: fixturesDir },
+    );
+    const output = text(result);
+    expect(output).toContain("No files found matching pattern: src/*.ts");
+    expect(output).toContain(SLASH_HINT);
+  });
+
+  it("hints about basename matching for slash globs (fd path)", async () => {
+    if (!_originalIsFdAvailable()) return; // skip when fd is unavailable
+    _testable.isFdAvailable = _originalIsFdAvailable;
+    const tool = await getFindTool();
+    const result = await tool.execute(
+      "tc",
+      { pattern: "src/*.ts" },
+      new AbortController().signal,
+      undefined,
+      { cwd: fixturesDir },
+    );
+    const output = text(result);
+    expect(output).toContain(SLASH_HINT);
+  });
+
+  it("does NOT hint for a normal basename glob with no matches", async () => {
+    _testable.isFdAvailable = () => false;
+    const tool = await getFindTool();
+    const result = await tool.execute(
+      "tc",
+      { pattern: "nope-*.xyz" },
+      new AbortController().signal,
+      undefined,
+      { cwd: fixturesDir },
+    );
+    const output = text(result);
+    expect(output).toContain("No files found matching pattern: nope-*.xyz");
+    expect(output).not.toContain(SLASH_HINT);
+  });
+
+  it("does NOT hint when the path-scoped equivalent returns results", async () => {
+    _testable.isFdAvailable = () => false;
+    const tool = await getFindTool();
+    const result = await tool.execute(
+      "tc",
+      { pattern: "*.ts", path: "src" },
+      new AbortController().signal,
+      undefined,
+      { cwd: fixturesDir },
+    );
+    const output = text(result);
+    expect(output).toContain("app.ts");
+    expect(output).not.toContain(SLASH_HINT);
+  });
+});
+

--- a/tests/package-version.test.ts
+++ b/tests/package-version.test.ts
@@ -5,9 +5,9 @@ const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
 const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
 
 describe("package version", () => {
-  it("is bumped for the 0.11.0 release", () => {
-    expect(packageJson.version).toBe("0.11.0");
-    expect(packageLock.version).toBe("0.11.0");
-    expect(packageLock.packages[""].version).toBe("0.11.0");
+  it("is bumped for the 0.11.1 release", () => {
+    expect(packageJson.version).toBe("0.11.1");
+    expect(packageLock.version).toBe("0.11.1");
+    expect(packageLock.packages[""].version).toBe("0.11.1");
   });
 });


### PR DESCRIPTION
## Summary

`find` matches basenames only, so any glob containing a `/` (e.g. `src/*.ts`, `src/**/*.ts`) silently returned `No files found` with no explanation — a real footgun, since an agent reasonably expects `src/**/*.ts` to work and may wrongly conclude the files are absent.

This implements **Option 1** from the issue (the low-risk hint): when `pattern` contains `/` and the result is empty, `formatOutput` now appends:

> `Hint: find matches basenames, not paths — drop the directory segment or pass it via path: (e.g. find("*.ts", path: "src/readmap")).`

The hint covers **both** backends (fd and node-fallback) since they share `formatOutput`. Matching behavior is unchanged, so there is no regression risk to existing glob/regex/filter/sort tests.

### Why not Option 2 (full-path matching)?
Diagnosis surfaced a real divergence hazard: the natural fd transform (`**/` prefix) is *unanchored* (matches a dir at any depth) while picomatch without `basename` is *root-anchored*, so the two backends would return different result sets for the same input. Too risky for a p3 bugfix.

## Changes
- `src/find.ts` — append slash hint in the empty/non-truncated branch of `formatOutput`; existing fd-install hint preserved.
- `tests/find.test.ts` — +4 focused tests (fd path, node fallback, no-hint negative, path-scoped works).
- `prompts/find.md`, `README.md` — document basename matching, path scoping, and the hint.
- `package.json` / `package-lock.json` / `tests/package-version.test.ts` — 0.11.0 → 0.11.1.
- `CHANGELOG.md` — 0.11.1 Fixed entry.

## Verification
- `npm test` → 1716 passed (405 files)
- `npm run typecheck` → clean
- `npm pack --dry-run` → `pi-hashline-readmap-0.11.1.tgz`
- Live end-to-end against the real repo confirmed the hint appears for `src/*.ts` / `src/**/*.ts`, is absent for non-slash patterns, and path-scoped queries still return results.

Closes #220